### PR TITLE
Fixes #1568: apoc.custom.list displays procedure name but execution errors out with `There is no procedure with the name`

### DIFF
--- a/docs/asciidoc/cypher-execution/custom.adoc
+++ b/docs/asciidoc/cypher-execution/custom.adoc
@@ -171,6 +171,16 @@ Fields:
 |===
 
 
+=== Refresh a procedure `apoc.custom.refresh`
+
+The procedure `apoc.custom.refresh` refresh immediately all procedures/functions
+
+[source,cypher]
+----
+CALL apoc.custom.removeFunction(<name>)
+----
+
+
 === How to manage procedure/function replication in a Causal Cluster
 
 In order to replicate the procedure/function in a cluster environment you can tune the following parameters:

--- a/docs/asciidoc/cypher-execution/custom.adoc
+++ b/docs/asciidoc/cypher-execution/custom.adoc
@@ -177,7 +177,7 @@ The procedure `apoc.custom.refresh` refresh immediately all procedures/functions
 
 [source,cypher]
 ----
-CALL apoc.custom.removeFunction(<name>)
+CALL apoc.custom.refresh
 ----
 
 

--- a/docs/asciidoc/cypher-execution/custom.adoc
+++ b/docs/asciidoc/cypher-execution/custom.adoc
@@ -171,7 +171,7 @@ Fields:
 |===
 
 
-=== Refresh a procedure `apoc.custom.refresh`
+=== Refresh all procedures/functions `apoc.custom.refresh`
 
 The procedure `apoc.custom.refresh` refresh immediately all procedures/functions
 

--- a/src/main/java/apoc/custom/CypherProcedures.java
+++ b/src/main/java/apoc/custom/CypherProcedures.java
@@ -532,6 +532,7 @@ public class CypherProcedures {
             CustomStatementRegistry registry = new CustomStatementRegistry(api, log);
             Map<String, Map<String, Map<String, Object>>> stored = readData(properties);
             Signatures sigs = new Signatures("custom");
+            Map<String, Map<String, Object>> removed = stored.getOrDefault(REMOVED, emptyMap());
             stored.get(FUNCTIONS).forEach((name, data) -> {
                 String description = parseStoredDescription(data.get("description"));
                 if (data.containsKey("signature")) {
@@ -541,6 +542,7 @@ public class CypherProcedures {
                     registry.registerFunction(name, (String) data.get("statement"), (String) data.get("output"),
                             (List<List<String>>) data.get("inputs"), (Boolean) data.get("forceSingle"), description);
                 }
+                removed.getOrDefault(FUNCTIONS, emptyMap()).remove(name);
             });
             stored.get(PROCEDURES).forEach((name, data) -> {
                 String description = parseStoredDescription(data.get("description"));
@@ -551,9 +553,9 @@ public class CypherProcedures {
                     registry.registerProcedure(name, (String) data.get("statement"), (String) data.get("mode"),
                             (List<List<String>>) data.get("outputs"), (List<List<String>>) data.get("inputs"), description);
                 }
+                removed.getOrDefault(PROCEDURES, emptyMap()).remove(name);
             });
-            stored.getOrDefault(REMOVED, emptyMap())
-                    .forEach((type, data) -> data.forEach((name, metadata) -> {
+            removed.forEach((type, data) -> data.forEach((name, metadata) -> {
                         switch (type) {
                             case PROCEDURES:
                                 registry.removeProcedure(name, (Map<String, Object>) metadata);

--- a/src/main/java/apoc/custom/CypherProcedures.java
+++ b/src/main/java/apoc/custom/CypherProcedures.java
@@ -40,8 +40,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.util.Util.map;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.*;
 
 /**
@@ -58,7 +58,6 @@ public class CypherProcedures {
     public static final List<FieldSignature> DEFAULT_MAP_OUTPUT = singletonList(FieldSignature.inputField("row", NTMap));
     public static final List<FieldSignature> DEFAULT_INPUTS = singletonList(FieldSignature.inputField("params", NTMap, DefaultParameterValue.ntMap(Collections.emptyMap())));
     public static final String REMOVED = "removed";
-
     @Context
     public GraphDatabaseAPI api;
     @Context

--- a/src/main/java/apoc/custom/CypherProcedures.java
+++ b/src/main/java/apoc/custom/CypherProcedures.java
@@ -85,18 +85,6 @@ public class CypherProcedures {
         CustomProcedureStorage.storeProcedure(api, name, statement, mode, outputs, inputs, description);
     }
 
-    @Procedure(value = "apoc.custom.asProcedureSync",mode = Mode.WRITE)
-    @Description("apoc.custom.asProcedureSync(name, statement, mode, outputs, inputs, description) - register a custom cypher procedure and refresh procedures and functions")
-    public void asProcedureSync(@Name("name") String name, @Name("statement") String statement,
-                            @Name(value = "mode",defaultValue = "read") String mode,
-                            @Name(value= "outputs", defaultValue = "null") List<List<String>> outputs,
-                            @Name(value= "inputs", defaultValue = "null") List<List<String>> inputs,
-                            @Name(value= "description", defaultValue = "null") String description
-    ) {
-        asProcedure(name, statement, mode, outputs, inputs, description);
-        restoreProceduresAndFunctionsSync();
-    }
-
     @Procedure(value = "apoc.custom.declareProcedure", mode = Mode.WRITE)
     @Description("apoc.custom.declareProcedure(signature, statement, mode, description) - register a custom cypher procedure")
     public void declareProcedure(@Name("signature") String signature, @Name("statement") String statement,
@@ -110,16 +98,6 @@ public class CypherProcedures {
             throw new IllegalStateException("Error registering procedure " + procedureSignature.name() + ", see log.");
         }
         CustomProcedureStorage.storeProcedure(api, procedureSignature, statement);
-    }
-
-    @Procedure(value = "apoc.custom.declareProcedureSync", mode = Mode.WRITE)
-    @Description("apoc.custom.declareProcedureSync(signature, statement, mode, description) - register a custom cypher procedure and refresh procedures and functions")
-    public void declareProcedureSync(@Name("signature") String signature, @Name("statement") String statement,
-                                 @Name(value = "mode", defaultValue = "read") String mode,
-                                 @Name(value = "description", defaultValue = "null") String description
-    ) {
-        declareProcedure(signature, statement, mode, description);
-        restoreProceduresAndFunctionsSync();
     }
 
     @Procedure(value = "apoc.custom.asFunction",mode = Mode.WRITE)
@@ -136,17 +114,6 @@ public class CypherProcedures {
         CustomProcedureStorage.storeFunction(api, name, statement, output, inputs, forceSingle, description);
     }
 
-    @Procedure(value = "apoc.custom.asFunctionSync",mode = Mode.WRITE)
-    @Description("apoc.custom.asFunctionSync(name, statement, outputs, inputs, forceSingle, description) - register a custom cypher function and refresh procedures and functions")
-    public void asFunctionSync(@Name("name") String name, @Name("statement") String statement,
-                            @Name(value= "outputs", defaultValue = "") String output,
-                            @Name(value= "inputs", defaultValue = "null") List<List<String>> inputs,
-                            @Name(value = "forceSingle", defaultValue = "false") boolean forceSingle,
-                            @Name(value = "description", defaultValue = "null") String description) throws ProcedureException {
-        asFunction(name, statement, output, inputs, forceSingle, description);
-        restoreProceduresAndFunctionsSync();
-    }
-
     @Procedure(value = "apoc.custom.declareFunction", mode = Mode.WRITE)
     @Description("apoc.custom.declareFunction(signature, statement, forceSingle, description) - register a custom cypher function")
     public void declareFunction(@Name("signature") String signature, @Name("statement") String statement,
@@ -158,15 +125,6 @@ public class CypherProcedures {
             throw new IllegalStateException("Error registering function " + signature + ", see log.");
         }
         CustomProcedureStorage.storeFunction(api, userFunctionSignature, statement, forceSingle);
-    }
-
-    @Procedure(value = "apoc.custom.declareFunctionSync", mode = Mode.WRITE)
-    @Description("apoc.custom.declareFunctionSync(signature, statement, forceSingle, description) - register a custom cypher function and refresh procedures and functions")
-    public void declareFunctionSync(@Name("signature") String signature, @Name("statement") String statement,
-                           @Name(value = "forceSingle", defaultValue = "false") boolean forceSingle,
-                           @Name(value = "description", defaultValue = "null") String description) throws ProcedureException {
-        declareFunction(signature, statement, forceSingle, description);
-        restoreProceduresAndFunctionsSync();
     }
 
     @Procedure(value = "apoc.custom.list", mode = Mode.READ)
@@ -189,13 +147,6 @@ public class CypherProcedures {
         }
     }
 
-    @Procedure(value = "apoc.custom.removeProcedureSync", mode = Mode.WRITE)
-    @Description("apoc.custom.removeProcedureSync(name) - remove the targeted custom procedure and refresh procedures and functions")
-    public void removeProcedureSync(@Name("name") String name) {
-        removeProcedure(name);
-        restoreProceduresAndFunctionsSync();
-    }
-
     @Procedure(value = "apoc.custom.removeFunction", mode = Mode.WRITE)
     @Description("apoc.custom.removeFunction(name, type) - remove the targeted custom function")
     public void removeFunction(@Name("name") String name) {
@@ -209,14 +160,9 @@ public class CypherProcedures {
         }
     }
 
-    @Procedure(value = "apoc.custom.removeFunctionSync", mode = Mode.WRITE)
-    @Description("apoc.custom.removeFunctionSync(name) - remove the targeted custom function and refresh procedures and functions")
-    public void removeFunctionSync(@Name("name") String name) {
-        removeFunction(name);
-        restoreProceduresAndFunctionsSync();
-    }
-
-    private void restoreProceduresAndFunctionsSync() {
+    @Procedure(value = "apoc.custom.restore")
+    @Description("apoc.custom.restore - refresh procedures and functions")
+    public void restore() {
         new CustomProcedureStorage(Pools.NEO4J_SCHEDULER, api, log).restoreProceduresSync();
     }
 

--- a/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -19,6 +19,7 @@ import org.neo4j.kernel.impl.core.GraphPropertiesProxy;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 import org.neo4j.scheduler.JobScheduler;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static apoc.util.Util.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 

--- a/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -63,13 +63,6 @@ public class CypherProceduresStorageTest {
     }
 
     @Test
-    public void registerSimpleStatementSync() throws Exception {
-        db.execute("call apoc.custom.asProcedureSync('answer','RETURN 42 as answer')");
-        restartDb();
-        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
-    }
-
-    @Test
     public void registerSimpleStatementConcreteResults() throws Exception {
         db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer','read',[['answer','long']])");
         restartDb();
@@ -108,13 +101,6 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunction() throws Exception {
         db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        restartDb();
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
-    }
-
-    @Test
-    public void registerSimpleStatementFunctionSync() throws Exception {
-        db.execute("call apoc.custom.asFunctionSync('answer','RETURN 42 as answer')");
         restartDb();
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
     }

--- a/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -19,7 +19,6 @@ import org.neo4j.kernel.impl.core.GraphPropertiesProxy;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 import org.neo4j.scheduler.JobScheduler;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static apoc.util.Util.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -60,6 +58,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatement() throws Exception {
         db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
+        restartDb();
+        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+    }
+
+    @Test
+    public void registerSimpleStatementSync() throws Exception {
+        db.execute("call apoc.custom.asProcedureSync('answer','RETURN 42 as answer')");
         restartDb();
         TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
     }
@@ -103,6 +108,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunction() throws Exception {
         db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
+        restartDb();
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+    }
+
+    @Test
+    public void registerSimpleStatementFunctionSync() throws Exception {
+        db.execute("call apoc.custom.asFunctionSync('answer','RETURN 42 as answer')");
         restartDb();
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
     }

--- a/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -53,7 +53,7 @@ public class CypherProceduresTest {
     public void overrideSingleCallStatement() throws Exception {
         db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
         TestUtil.testCall(db, "call custom.answer() yield row return row", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
-        db.execute("call apoc.custom.restore");
+        db.execute("call apoc.custom.refresh");
 
         db.execute("call apoc.custom.asProcedure('answer','RETURN 43 as answer')");
         TestUtil.testCall(db, "call custom.answer() yield row return row", (row) -> assertEquals(43L, ((Map)row.get("row")).get("answer")));
@@ -63,7 +63,7 @@ public class CypherProceduresTest {
     public void overrideCypherCallStatement() throws Exception {
         db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
         TestUtil.testCall(db, "with 1 as foo call custom.answer() yield row return row", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
-        db.execute("call apoc.custom.restore");
+        db.execute("call apoc.custom.refresh");
 
         db.execute("call apoc.custom.asProcedure('answer','RETURN 43 as answer')");
         TestUtil.testCall(db, "with 1 as foo call custom.answer() yield row return row", (row) -> assertEquals(43L, ((Map)row.get("row")).get("answer")));
@@ -222,7 +222,7 @@ public class CypherProceduresTest {
 
         // when
         db.execute("call apoc.custom.removeProcedure('answer')").close();
-        db.execute("call apoc.custom.restore");
+        db.execute("call apoc.custom.refresh");
 
         // then
         try {
@@ -244,7 +244,7 @@ public class CypherProceduresTest {
 
         // when
         db.execute("call apoc.custom.removeFunction('answer')").close();
-        db.execute("call apoc.custom.restore");
+        db.execute("call apoc.custom.refresh");
 
         // then
         try {
@@ -257,14 +257,14 @@ public class CypherProceduresTest {
         }
     }
 
-    @Test()
+    @Test
     public void shouldRefreshCorrectlyAFunction() throws InterruptedException {
 
         db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
 
         db.execute("call apoc.custom.removeFunction('answer')").close();
-        db.execute("call apoc.custom.restore");
+        db.execute("call apoc.custom.refresh");
 
         try {
             TestUtil.testCall(db, "return custom.answer() as row", (row) -> {});
@@ -280,14 +280,14 @@ public class CypherProceduresTest {
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
     }
 
-    @Test()
+    @Test
     public void shouldRefreshCorrectlyAProcedure() throws InterruptedException {
 
         db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
         TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
 
         db.execute("call apoc.custom.removeProcedure('answer')").close();
-        db.execute("call apoc.custom.restore");
+        db.execute("call apoc.custom.refresh");
 
         try {
             TestUtil.testCall(db, "call custom.answer()", (row) -> {});

--- a/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -1,8 +1,10 @@
 package apoc.custom;
 
+import apoc.ApocConfiguration;
 import apoc.Pools;
 import apoc.util.TestUtil;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -16,6 +18,7 @@ import java.util.Map;
 
 import static apoc.custom.CypherProcedures.FUNCTION;
 import static apoc.custom.CypherProcedures.PROCEDURE;
+import static apoc.util.MapUtil.map;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 
@@ -29,13 +32,64 @@ public class CypherProceduresTest {
 
     @Before
     public void setUp() throws Exception {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        db = TestUtil.apocGraphDatabaseBuilder().newGraphDatabase();
         TestUtil.registerProcedure(db, CypherProcedures.class);
     }
 
     @After
     public void tearDown() {
         db.shutdown();
+    }
+
+    @Test()
+    public void shouldRefreshCorrectlyAFunction() {
+
+        db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+
+        db.execute("call apoc.custom.removeFunction('answer')").close();
+        db.execute("call dbms.clearQueryCaches()").close();
+
+        try {
+            TestUtil.testCall(db, "return custom.answer() as row", (row) -> {});
+            Assert.fail();
+        } catch (QueryExecutionException e) {
+            String expected = "Unknown function 'custom.answer'";
+            assertEquals(expected, e.getMessage());
+            assertEquals("Neo.ClientError.Statement.SyntaxError", e.getStatusCode());
+        }
+
+        db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')").close();
+
+        db.execute("call dbms.clearQueryCaches()").close(); // clear cache or waiting for refresh procedure (default 60s)
+
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+    }
+
+    @Test()
+    public void shouldRefreshCorrectlyAProcedure() {
+
+        db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
+        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+
+        db.execute("call apoc.custom.removeProcedure('answer')").close();
+        db.execute("call dbms.clearQueryCaches()").close();
+
+        try {
+            TestUtil.testCall(db, "call custom.answer()", (row) -> {});
+            Assert.fail();
+        } catch (QueryExecutionException e) {
+            String expected = "There is no procedure with the name `custom.answer` registered for this database instance. " +
+                               "Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.";
+            assertEquals(expected, e.getMessage());
+            assertEquals("Neo.ClientError.Procedure.ProcedureNotFound", e.getStatusCode());
+        }
+
+        db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')").close();
+
+        db.execute("call dbms.clearQueryCaches()").close(); // clear cache or waiting for refresh procedure (default 60s)
+
+        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
     }
 
     @Test

--- a/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -1,10 +1,8 @@
 package apoc.custom;
 
-import apoc.ApocConfiguration;
 import apoc.Pools;
 import apoc.util.TestUtil;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -18,7 +16,6 @@ import java.util.Map;
 
 import static apoc.custom.CypherProcedures.FUNCTION;
 import static apoc.custom.CypherProcedures.PROCEDURE;
-import static apoc.util.MapUtil.map;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 
@@ -32,64 +29,13 @@ public class CypherProceduresTest {
 
     @Before
     public void setUp() throws Exception {
-        db = TestUtil.apocGraphDatabaseBuilder().newGraphDatabase();
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
         TestUtil.registerProcedure(db, CypherProcedures.class);
     }
 
     @After
     public void tearDown() {
         db.shutdown();
-    }
-
-    @Test()
-    public void shouldRefreshCorrectlyAFunction() {
-
-        db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
-
-        db.execute("call apoc.custom.removeFunction('answer')").close();
-        db.execute("call dbms.clearQueryCaches()").close();
-
-        try {
-            TestUtil.testCall(db, "return custom.answer() as row", (row) -> {});
-            Assert.fail();
-        } catch (QueryExecutionException e) {
-            String expected = "Unknown function 'custom.answer'";
-            assertEquals(expected, e.getMessage());
-            assertEquals("Neo.ClientError.Statement.SyntaxError", e.getStatusCode());
-        }
-
-        db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')").close();
-
-        db.execute("call dbms.clearQueryCaches()").close(); // clear cache or waiting for refresh procedure (default 60s)
-
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
-    }
-
-    @Test()
-    public void shouldRefreshCorrectlyAProcedure() {
-
-        db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
-
-        db.execute("call apoc.custom.removeProcedure('answer')").close();
-        db.execute("call dbms.clearQueryCaches()").close();
-
-        try {
-            TestUtil.testCall(db, "call custom.answer()", (row) -> {});
-            Assert.fail();
-        } catch (QueryExecutionException e) {
-            String expected = "There is no procedure with the name `custom.answer` registered for this database instance. " +
-                               "Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.";
-            assertEquals(expected, e.getMessage());
-            assertEquals("Neo.ClientError.Procedure.ProcedureNotFound", e.getStatusCode());
-        }
-
-        db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')").close();
-
-        db.execute("call dbms.clearQueryCaches()").close(); // clear cache or waiting for refresh procedure (default 60s)
-
-        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
     }
 
     @Test
@@ -309,4 +255,56 @@ public class CypherProceduresTest {
             throw e;
         }
     }
+
+    @Test()
+    public void shouldRefreshCorrectlyAFunction() {
+
+        db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+
+        db.execute("call apoc.custom.removeFunction('answer')").close();
+        db.execute("call dbms.clearQueryCaches()").close();
+
+        try {
+            TestUtil.testCall(db, "return custom.answer() as row", (row) -> {});
+            fail();
+        } catch (QueryExecutionException e) {
+            String expected = "Unknown function 'custom.answer'";
+            assertEquals(expected, e.getMessage());
+            assertEquals("Neo.ClientError.Statement.SyntaxError", e.getStatusCode());
+        }
+
+        db.execute("call apoc.custom.asFunction('answer','RETURN 42 as answer')").close();
+
+        db.execute("call dbms.clearQueryCaches()").close(); // clear cache or waiting for refresh procedure (default 60s)
+
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+    }
+
+    @Test()
+    public void shouldRefreshCorrectlyAProcedure() {
+
+        db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
+        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+
+        db.execute("call apoc.custom.removeProcedure('answer')").close();
+        db.execute("call dbms.clearQueryCaches()").close();
+
+        try {
+            TestUtil.testCall(db, "call custom.answer()", (row) -> {});
+            fail();
+        } catch (QueryExecutionException e) {
+            String expected = "There is no procedure with the name `custom.answer` registered for this database instance. " +
+                    "Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.";
+            assertEquals(expected, e.getMessage());
+            assertEquals("Neo.ClientError.Procedure.ProcedureNotFound", e.getStatusCode());
+        }
+
+        db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')").close();
+
+        db.execute("call dbms.clearQueryCaches()").close(); // clear cache or waiting for refresh procedure (default 60s)
+
+        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+    }
+
 }


### PR DESCRIPTION
Fixes neo4j-contrib#1568
