### PR TITLE
Fixes #1715: When registering custom function to access via, it instead registers at

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProcedures.java
+++ b/full/src/main/java/apoc/custom/CypherProcedures.java
@@ -101,7 +101,7 @@ public class CypherProcedures {
                 ProcedureSignature signature = procedureDescriptor.getSignature();
                 return new CustomProcedureInfo(
                         PROCEDURE,
-                        signature.name().toString().replace(PREFIX + ".", ""),
+                        signature.name().toString().substring(PREFIX.length() + 1),
                         signature.description().orElse(null),
                         signature.mode().toString().toLowerCase(),
                         procedureDescriptor.getStatement(),
@@ -113,7 +113,7 @@ public class CypherProcedures {
                 UserFunctionSignature signature = userFunctionDescriptor.getSignature();
                 return new CustomProcedureInfo(
                         FUNCTION,
-                        signature.name().toString().replace(PREFIX + ".", ""),
+                        signature.name().toString().substring(PREFIX.length() + 1),
                         signature.description().orElse(null),
                         null,
                         userFunctionDescriptor.getStatement(),

--- a/full/src/main/java/apoc/custom/CypherProcedures.java
+++ b/full/src/main/java/apoc/custom/CypherProcedures.java
@@ -101,7 +101,7 @@ public class CypherProcedures {
                 ProcedureSignature signature = procedureDescriptor.getSignature();
                 return new CustomProcedureInfo(
                         PROCEDURE,
-                        getFullStatement(signature.name()),
+                        signature.name().toString().replace(PREFIX + ".", ""),
                         signature.description().orElse(null),
                         signature.mode().toString().toLowerCase(),
                         procedureDescriptor.getStatement(),
@@ -113,7 +113,7 @@ public class CypherProcedures {
                 UserFunctionSignature signature = userFunctionDescriptor.getSignature();
                 return new CustomProcedureInfo(
                         FUNCTION,
-                        getFullStatement(signature.name()),
+                        signature.name().toString().replace(PREFIX + ".", ""),
                         signature.description().orElse(null),
                         null,
                         userFunctionDescriptor.getStatement(),
@@ -155,15 +155,6 @@ public class CypherProcedures {
             s = s.substring(0, s.length()-1);
         }
         return s;
-    }
-
-    private String getFullStatement(QualifiedName qualifiedName) {
-        String[] nameSpace = qualifiedName.namespace();
-        String name = nameSpace.length > 1
-                ? String.join(".", Arrays.copyOfRange(nameSpace, 1, nameSpace.length)) + "."
-                : "";
-
-        return name + qualifiedName.name();
     }
 
     public static class CustomProcedureInfo {

--- a/full/src/main/java/apoc/custom/CypherProcedures.java
+++ b/full/src/main/java/apoc/custom/CypherProcedures.java
@@ -3,10 +3,7 @@ package apoc.custom;
 import apoc.Extended;
 import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
-import org.neo4j.internal.kernel.api.procs.FieldSignature;
-import org.neo4j.internal.kernel.api.procs.Neo4jTypes;
-import org.neo4j.internal.kernel.api.procs.ProcedureSignature;
-import org.neo4j.internal.kernel.api.procs.UserFunctionSignature;
+import org.neo4j.internal.kernel.api.procs.*;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
@@ -104,7 +101,7 @@ public class CypherProcedures {
                 ProcedureSignature signature = procedureDescriptor.getSignature();
                 return new CustomProcedureInfo(
                         PROCEDURE,
-                        signature.name().name(),
+                        getFullStatement(signature.name()),
                         signature.description().orElse(null),
                         signature.mode().toString().toLowerCase(),
                         procedureDescriptor.getStatement(),
@@ -116,7 +113,7 @@ public class CypherProcedures {
                 UserFunctionSignature signature = userFunctionDescriptor.getSignature();
                 return new CustomProcedureInfo(
                         FUNCTION,
-                        signature.name().name(),
+                        getFullStatement(signature.name()),
                         signature.description().orElse(null),
                         null,
                         userFunctionDescriptor.getStatement(),
@@ -158,6 +155,15 @@ public class CypherProcedures {
             s = s.substring(0, s.length()-1);
         }
         return s;
+    }
+
+    private String getFullStatement(QualifiedName qualifiedName) {
+        String[] nameSpace = qualifiedName.namespace();
+        String name = nameSpace.length > 1
+                ? String.join(".", Arrays.copyOfRange(nameSpace, 1, nameSpace.length)) + "."
+                : "";
+
+        return name + qualifiedName.name();
     }
 
     public static class CustomProcedureInfo {

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
-import org.neo4j.procedure.impl.GlobalProceduresRegistry;
 import org.neo4j.scheduler.Group;
 import org.neo4j.scheduler.JobHandle;
 import org.neo4j.scheduler.JobScheduler;
@@ -419,11 +418,8 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     }
 
     public static QualifiedName qualifiedName(@Name("name") String name) {
-        String[] names = name.split("\\.");
-        List<String> namespace = new ArrayList<>(names.length);
-        namespace.add(PREFIX);
-        namespace.addAll(Arrays.asList(names));
-        return new QualifiedName(namespace.subList(0, namespace.size() - 1), names[names.length - 1]);
+        Map<String, Object> fullName = getFullName(name);
+        return new QualifiedName((List<String>) fullName.get("prefix"), (String) fullName.get("name"));
     }
 
     public List<FieldSignature> inputSignatures(@Name(value = "inputs", defaultValue = "null") List<List<String>> inputs) {
@@ -605,9 +601,11 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     public void removeProcedure(String name) {
         withSystemDb(tx -> {
+            Map<String, Object> fullName = getFullName(name);
             tx.findNodes(SystemLabels.ApocCypherProcedures,
                     SystemPropertyKeys.database.name(), api.databaseName(),
-                    SystemPropertyKeys.name.name(), name
+                    SystemPropertyKeys.name.name(), fullName.get("name"),
+                    SystemPropertyKeys.prefix.name(), ((List<String>) fullName.get("prefix")).toArray(String[]::new)
             ).stream().filter(n -> n.hasLabel(SystemLabels.Procedure)).forEach(node -> {
                 ProcedureDescriptor descriptor = procedureDescriptor(node);
                 registerProcedure(descriptor.getSignature(), null);
@@ -621,9 +619,11 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     public void removeFunction(String name) {
         withSystemDb(tx -> {
+            Map<String, Object> fullName = getFullName(name);
             tx.findNodes(SystemLabels.ApocCypherProcedures,
                     SystemPropertyKeys.database.name(), api.databaseName(),
-                    SystemPropertyKeys.name.name(), name
+                    SystemPropertyKeys.name.name(), fullName.get("name"),
+                    SystemPropertyKeys.prefix.name(), ((List<String>) fullName.get("prefix")).toArray(String[]::new)
             ).stream().filter(n -> n.hasLabel(SystemLabels.Function)).forEach(node -> {
                 UserFunctionDescriptor descriptor = userFunctionDescriptor(node);
                 registerFunction(descriptor.getSignature(), null, false);
@@ -634,6 +634,18 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             return null;
         });
 
+    }
+
+    private static Map<String, Object> getFullName(String name) {
+        String[] names = name.split("\\.");
+        List<String> namespace = new ArrayList<>(names.length);
+        namespace.add(PREFIX);
+        namespace.addAll(Arrays.asList(names));
+        return Map.of("prefix",
+                namespace.subList(0, namespace.size() - 1),
+                "name",
+                names[names.length - 1]
+        );
     }
 
     public abstract class ProcedureOrFunctionDescriptor {

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -55,6 +55,22 @@ public class CypherProceduresStorageTest {
     }
 
     @Test
+    public void registerSimpleFunctionWithDotInName() throws Exception {
+        db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("foo.bar.baz", row.get("name"));
+            assertEquals("function", row.get("type"));
+        });
+        restartDb();
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("foo.bar.baz", row.get("name"));
+            assertEquals("function", row.get("type"));
+        });
+    }
+
+    @Test
     public void registerSimpleStatementWithDotInName() throws Exception {
         db.executeTransactionally("call apoc.custom.asProcedure('foo.bar.baz','RETURN 42 as answer')");
         TestUtil.testCall(db, "call custom.foo.bar.baz()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -41,20 +41,33 @@ public class CypherProceduresStorageTest {
         databaseManagementService = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot()).build();
         db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         assertTrue(db.isAvailable(1000));
+        TestUtil.registerProcedure(db, CypherProcedures.class);
     }
     @Test
     public void registerSimpleStatement() throws Exception {
         db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
         restartDb();
         TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("answer", row.get("name"));
+            assertEquals("procedure", row.get("type"));
+        });
     }
 
     @Test
     public void registerSimpleStatementWithDotInName() throws Exception {
-        db.executeTransactionally("call apoc.custom.asProcedure('foo.bar','RETURN 42 as answer')");
-        TestUtil.testCall(db, "call custom.foo.bar()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        db.executeTransactionally("call apoc.custom.asProcedure('foo.bar.baz','RETURN 42 as answer')");
+        TestUtil.testCall(db, "call custom.foo.bar.baz()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("foo.bar.baz", row.get("name"));
+            assertEquals("procedure", row.get("type"));
+        });
         restartDb();
-        TestUtil.testCall(db, "call custom.foo.bar()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        TestUtil.testCall(db, "call custom.foo.bar.baz()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("foo.bar.baz", row.get("name"));
+            assertEquals("procedure", row.get("type"));
+        });
     }
 
     @Test
@@ -99,14 +112,26 @@ public class CypherProceduresStorageTest {
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         restartDb();
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("answer", row.get("name"));
+            assertEquals("function", row.get("type"));
+        });
     }
 
     @Test
     public void registerSimpleStatementFunctionWithDotInName() throws Exception {
-        db.executeTransactionally("call apoc.custom.asFunction('foo.bar','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.foo.bar() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("foo.bar.baz", row.get("name"));
+            assertEquals("function", row.get("type"));
+        });
         restartDb();
-        TestUtil.testCall(db, "return custom.foo.bar() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "call apoc.custom.list()", row -> {
+            assertEquals("foo.bar.baz", row.get("name"));
+            assertEquals("function", row.get("type"));
+        });
     }
 
     @Test

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -330,4 +330,14 @@ public class CypherProceduresTest  {
         // when
         TestUtil.singleResultFirstColumn(db, "return custom.answer()");
     }
+
+    @Test
+    public void testIssue1715() {
+        db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c', 'RETURN 42')");
+        TestUtil.testCall(db, "RETURN custom.a.b.c() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("42")));
+        TestUtil.testCall(db, "CALL apoc.custom.list()", row -> {
+            assertEquals("a.b.c", row.get("name"));
+            assertEquals("function", row.get("type"));
+        });
+    }
 }

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -445,5 +445,4 @@ public class CypherProceduresTest  {
         // when
         TestUtil.singleResultFirstColumn(db, "return custom.answer()");
     }
-
 }


### PR DESCRIPTION
Fixes #1715 

- Improved logic of `apoc.custom.removeFunction()`, `apoc.custom.removeProcedure()` and `apoc.custom.list()`to work with names containing dots.