### PR TITLE
Fixes #1901: apoc.uuid.install addToExistingNodes does not work

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.uuid.install.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.uuid.install.adoc
@@ -63,6 +63,15 @@ RETURN p;
 | (:Person {name: "Tom Hanks", uuid: "cec34337-9709-46af-bbb7-9e0742d8aaa7"})
 |===
 
+The `uuid` property will be created also with a label `SET`. For example:
+
+[source,cypher]
+----
+CREATE (:AnotherLabel {name: "Tom Hanks"});
+// ...
+MATCH (n:AnotherLabel) SET n:Person;
+----
+
 If we want to use a different property key for our UUID value, we can pass in the `uuidProperty` key, not forgetting to first setup a constraint:
 
 [source,cypher]

--- a/full/src/main/java/apoc/uuid/Uuid.java
+++ b/full/src/main/java/apoc/uuid/Uuid.java
@@ -26,7 +26,7 @@ public class Uuid {
     @Context
     public Transaction tx;
 
-    @Procedure(mode = Mode.DBMS)
+    @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.uuid.install(label, {addToExistingNodes: true/false, uuidProperty: 'uuid'}) yield label, installed, properties, batchComputationResult | it will add the uuid transaction handler\n" +
             "for the provided `label` and `uuidProperty`, in case the UUID handler is already present it will be replaced by the new one")
     public Stream<UuidInstallInfo> install(@Name("label") String label, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {


### PR DESCRIPTION
Fixes #1901

- Fixed `addToExistingNodes` bug
- Added uuid handling with `SET n:LabelName`