### PR TITLE
Fixes #1491: apoc.meta.subgraph returns java.lang.NullPointerException

### DIFF
--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -414,10 +414,10 @@ public class    Meta {
 
     private Map<String, Integer> labelsInUse(TokenRead ops, Collection<String> labelNames) {
         final Iterable<Label> allLabelsInUse = tx.getAllLabelsInUse();
-        final Set<Label> allLabelsAsList = Iterables.asSet(allLabelsInUse);
+        final Set<Label> allLabelsAsSet = Iterables.asSet(allLabelsInUse);
         Stream<String> labels = (labelNames == null || labelNames.isEmpty()) ?
                 Iterables.stream(allLabelsInUse).map(Label::name) :
-                labelNames.stream().filter(labelName -> allLabelsAsList.contains(Label.label(labelName)));
+                labelNames.stream().filter(labelName -> allLabelsAsSet.contains(Label.label(labelName)));
         return labels.collect(toMap(t -> t, ops::nodeLabel));
     }
 
@@ -697,10 +697,10 @@ public class    Meta {
         Map<String, Object> relationships = new LinkedHashMap<>();
         for(String entityName : metaData.keySet()) {
             Map<String, MetaResult> entityData = metaData.get(entityName);
-            Map<String, Object> entityProperties = new LinkedHashMap<>();
             if (entityData.isEmpty()) {
                 continue;
             }
+            Map<String, Object> entityProperties = new LinkedHashMap<>();
             boolean isRelationship = true;
             for (String entityDataKey : entityData.keySet()) {
                 MetaResult metaResult = entityData.get(entityDataKey);

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -1,5 +1,6 @@
 package apoc.meta;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.neo4j.logging.Log;
 import apoc.result.GraphResult;
 import apoc.result.MapResult;
@@ -413,12 +414,13 @@ public class    Meta {
     }
 
     private Map<String, Integer> labelsInUse(TokenRead ops, Collection<String> labelNames) {
-        final Iterable<Label> allLabelsInUse = tx.getAllLabelsInUse();
-        final Set<Label> allLabelsAsSet = Iterables.asSet(allLabelsInUse);
-        Stream<String> labels = (labelNames == null || labelNames.isEmpty()) ?
-                Iterables.stream(allLabelsInUse).map(Label::name) :
-                labelNames.stream().filter(labelName -> allLabelsAsSet.contains(Label.label(labelName)));
-        return labels.collect(toMap(t -> t, ops::nodeLabel));
+        Stream<Label> stream = Iterables.stream(tx.getAllLabelsInUse());
+        if (CollectionUtils.isNotEmpty(labelNames)) {
+            stream = stream.filter(rel -> labelNames.contains(rel.name()));
+        }
+        return stream
+                .map(Label::name)
+                .collect(toMap(t -> t, ops::nodeLabel));
     }
 
     // todo ask index for distinct values if index size < 10 or so

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -1,6 +1,5 @@
 package apoc.meta;
 
-import org.apache.commons.collections4.IterableUtils;
 import org.neo4j.logging.Log;
 import apoc.result.GraphResult;
 import apoc.result.MapResult;
@@ -524,7 +523,6 @@ public class    Meta {
                 for (ConstraintDefinition cd : schema.getConstraints(label)) { profile.noteConstraint(label, cd); }
                 for (IndexDefinition index : schema.getIndexes(label)) { profile.noteIndex(label, index); }
 
-                // todo - e qui?
                 long labelCount = countStore.get(labelName);
                 long sample = getSampleForLabelCount(labelCount, config.getSample());
 
@@ -581,7 +579,6 @@ public class    Meta {
                     indexed.add(prop);
                 }
             }
-            // todo - e qui?
             long labelCount = countStore.get(labelName);
             long sample = getSampleForLabelCount(labelCount, config.getSample());
             try (ResourceIterator<Node> nodes = tx.findNodes(label)) {

--- a/src/test/java/apoc/meta/MetaTest.java
+++ b/src/test/java/apoc/meta/MetaTest.java
@@ -28,6 +28,7 @@ import static apoc.util.TestUtil.testCall;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.Comparator.comparing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.neo4j.driver.Values.isoDuration;
@@ -371,6 +372,53 @@ public class MetaTest {
                     assertEquals(false, actedInRoleProperty.get("existence"));
                 });
     }
+    
+    @Test
+    public void testMetaSchemaWithNodesAndRelsWithoutProps() {
+        db.executeTransactionally("CREATE (:Other), (:Other)-[:REL_1]->(:Movie)<-[:REL_2 {baz: 'baa'}]-(:Director), (:Director {alpha: 'beta'}), (:Actor {foo:'bar'}), (:Person)");
+        testCall(db, "CALL apoc.meta.schema()",
+                (row) -> {
+                    Map<String, Object> value = (Map<String, Object>) row.get("value");
+                    assertEquals(7, value.size());
+
+                    Map<String, Object>  other = (Map<String, Object>) value.get("Other");
+                    Map<String, Object>  otherProperties = (Map<String, Object>) other.get("properties");
+                    assertEquals(0, otherProperties.size());
+                    assertEquals("node", other.get("type"));
+                    assertEquals(2L, other.get("count"));
+                    Map<String, Object>  Movie = (Map<String, Object>) value.get("Movie");
+                    Map<String, Object>  movieProperties = (Map<String, Object>) Movie.get("properties");
+                    assertEquals(0, movieProperties.size());
+                    assertEquals("node", Movie.get("type"));
+                    assertEquals(1L, Movie.get("count"));
+                    Map<String, Object>  director = (Map<String, Object>) value.get("Director");
+                    Map<String, Object>  directorProperties = (Map<String, Object>) director.get("properties");
+                    assertEquals(1, directorProperties.size());
+                    assertEquals("node", director.get("type"));
+                    assertEquals(2L, director.get("count"));
+                    Map<String, Object>  person = (Map<String, Object>) value.get("Person");
+                    Map<String, Object>  personProperties = (Map<String, Object>) person.get("properties");
+                    assertEquals(0, personProperties.size());
+                    assertEquals("node", person.get("type"));
+                    assertEquals(1L, person.get("count"));
+                    Map<String, Object>  actor = (Map<String, Object>) value.get("Actor");
+                    Map<String, Object>  actorProperties = (Map<String, Object>) actor.get("properties");
+                    assertEquals(1, actorProperties.size());
+                    assertEquals("node", actor.get("type"));
+                    assertEquals(1L, actor.get("count"));
+
+                    Map<String, Object>  rel1 = (Map<String, Object>) value.get("REL_1");
+                    Map<String, Object>  rel1Properties = (Map<String, Object>) rel1.get("properties");
+                    assertEquals(0, rel1Properties.size());
+                    assertEquals("relationship", rel1.get("type"));
+                    assertEquals(1L, rel1.get("count"));
+                    Map<String, Object>  rel2 = (Map<String, Object>) value.get("REL_2");
+                    Map<String, Object>  rel2Properties = (Map<String, Object>) rel2.get("properties");
+                    assertEquals(1, rel2Properties.size());
+                    assertEquals("relationship", rel2.get("type"));
+                    assertEquals(1L, rel2.get("count"));
+                });
+    }
 
     @Test
     public void testSubGraphNoLimits() throws Exception {
@@ -417,6 +465,32 @@ public class MetaTest {
             assertEquals(2, nodes.size());
             assertEquals(true, nodes.stream().map(n -> Iterables.first(n.getLabels()).name()).allMatch(n -> n.equals("A") || n.equals("C")));
             assertEquals(0, rels.size());
+        });
+    }
+    
+    @Test
+    public void testSubGraphLNotMatchingLabels() {
+        db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
+        testCall(db,"CALL apoc.meta.subGraph({labels:['A', 'B', 'NotMatching'], includeRels: ['X', 'NotMatchingRel']})", (row) -> {
+            List<Node> nodes = ((List<Node>) row.get("nodes")).stream().sorted(comparing(i -> (String) i.getProperty("name"))).collect(Collectors.toList());
+            List<Relationship> rels = (List<Relationship>) row.get("relationships");
+            assertEquals(2, nodes.size());
+            final Node nodeA = nodes.get(0);
+            assertEquals(1L, nodeA.getProperty("count"));
+            assertEquals("A", nodeA.getProperty("name"));
+            assertEquals("A", Iterables.first(nodeA.getLabels()).name());
+            final Node nodeB = nodes.get(1);
+            assertEquals(1L, nodeB.getProperty("count"));
+            assertEquals("B", nodeB.getProperty("name"));
+            assertEquals("B", Iterables.first(nodeB.getLabels()).name());
+
+            assertEquals(1, rels.size());
+            final Relationship relationship = rels.get(0);
+            assertEquals(1L, relationship.getProperty("count"));
+            assertEquals(1L, relationship.getProperty("in"));
+            assertEquals(1L, relationship.getProperty("out"));
+            assertEquals("X", relationship.getProperty("type"));
+            assertEquals("X", relationship.getType().name());
         });
     }
 

--- a/src/test/java/apoc/meta/MetaTest.java
+++ b/src/test/java/apoc/meta/MetaTest.java
@@ -472,7 +472,7 @@ public class MetaTest {
     public void testSubGraphLNotMatchingLabels() {
         db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
         testCall(db,"CALL apoc.meta.subGraph({labels:['A', 'B', 'NotMatching'], includeRels: ['X', 'NotMatchingRel']})", (row) -> {
-            List<Node> nodes = ((List<Node>) row.get("nodes")).stream().sorted(comparing(i -> (String) i.getProperty("name"))).collect(Collectors.toList());
+            List<Node> nodes = ((List<Node>) row.get("nodes")).stream().sorted(comparing(node -> (String) node.getProperty("name"))).collect(Collectors.toList());
             List<Relationship> rels = (List<Relationship>) row.get("relationships");
             assertEquals(2, nodes.size());
             final Node nodeA = nodes.get(0);

--- a/src/test/java/apoc/meta/MetaTest.java
+++ b/src/test/java/apoc/meta/MetaTest.java
@@ -417,7 +417,7 @@ public class MetaTest {
                     assertEquals(1, rel2Properties.size());
                     assertEquals("relationship", rel2.get("type"));
                     assertEquals(1L, rel2.get("count"));
-                });
+        });
     }
 
     @Test

--- a/src/test/java/apoc/meta/MetaTest.java
+++ b/src/test/java/apoc/meta/MetaTest.java
@@ -471,6 +471,7 @@ public class MetaTest {
     @Test
     public void testSubGraphLNotMatchingLabels() {
         db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
+        
         testCall(db,"CALL apoc.meta.subGraph({labels:['A', 'B', 'NotMatching'], includeRels: ['X', 'NotMatchingRel']})", (row) -> {
             List<Node> nodes = ((List<Node>) row.get("nodes")).stream().sorted(comparing(node -> (String) node.getProperty("name"))).collect(Collectors.toList());
             List<Relationship> rels = (List<Relationship>) row.get("relationships");


### PR DESCRIPTION
TODO: Blocked because specific of 4.0 only


Fixes #1491 
Fixes #1906

Fixes #1810 (Still present in `4.0` branch)