### PR TITLE
Fixes #1325: Add apoc.jdbc.<key>.password and apoc.jdbc.<key>.user to config

### DIFF
--- a/core/src/main/java/apoc/load/util/LoadJdbcConfig.java
+++ b/core/src/main/java/apoc/load/util/LoadJdbcConfig.java
@@ -17,6 +17,7 @@ public class LoadJdbcConfig {
     private ZoneId zoneId = null;
 
     private Credentials credentials;
+    private String authKey;
 
     private final Long fetchSize;
 
@@ -31,12 +32,17 @@ public class LoadJdbcConfig {
             throw new IllegalArgumentException(String.format("The timezone field contains an error: %s", e.getMessage()));
         }
         this.credentials = config.containsKey("credentials") ? createCredentials((Map<String, String>) config.get("credentials")) : null;
+        this.authKey = (String) config.get("authKey");
         this.fetchSize = Util.toLong(config.getOrDefault("fetchSize", 5000L));
         this.autoCommit = Util.toBoolean(config.getOrDefault("autoCommit", false));
     }
 
     public ZoneId getZoneId(){
         return this.zoneId;
+    }
+
+    public String getAuthKey() {
+        return authKey;
     }
 
     public Credentials getCredentials() {

--- a/docs/asciidoc/modules/ROOT/pages/config/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/config/index.adoc
@@ -44,7 +44,7 @@ procedures
 | apoc.import.file.use_neo4j_config=true/false (default `true`) | the procedures check whether file system access is allowed and possibly constrained to a specific directory by reading the two configuration parameters `dbms.security.allow_csv_import_from_file_urls` and `dbms.directories.import` respectively
 | apoc.initializer.cypher | a cypher statment to be executed once the database is started
 | apoc.initializer.cypher.<key> | multiple cypher statements to be executed once the database is started
-| apoc.jdbc.<key>.uri=jdbc-url-with-credentials | store jdbc-urls under a key to be used by apoc.load.jdbc
+| apoc.jdbc.<key>.url=jdbc-url-with-credentials | store jdbc-urls under a key to be used by apoc.load.jdbc
 | apoc.jobs.scheduled.num_threads=number-of-threads (default: number of CPU cores / 4) | Many periodic procedures rely on a scheduled executor that has
 a pool of threads with a default fixed size. You can configure the pool size using this configuration property
 | apoc.jobs.pool.num_threads=number-of-threads (default: number of CPU cores * 2) | Number of threads in the default APOC thread pool used for background executions.

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
@@ -395,11 +395,24 @@ Credentials can be passed in two ways:
 CALL apoc.load.jdbc('jdbc:derby:derbyDB;user=apoc;password=Ap0c!#Db;create=true', 'PERSON')
 ----
 
-* by config parameter.
+* by `credentials` config parameter.
 
 [source,cypher]
 ----
 CALL apoc.load.jdbc('jdbc:derby:derbyDB', 'PERSON',[],{credentials:{user:'apoc',password:'Ap0c!#Db'}})
+----
+
+* in `apoc.conf`, through the `authKey` config parameter.
+
+.apoc.conf
+----
+apoc.jdbc.myKey.user=myUsername
+apoc.jdbc.myKey.password=myPassword
+----
+
+[source,cypher]
+----
+CALL apoc.load.jdbc('jdbc:postgresql://localhost:55120/test', 'PERSON',[],{authKey: 'myKey'});
 ----
 
 Google BigQuery using Simba drivers requires an additional parameter 'autoCommit' to be used e.g.

--- a/full/src/main/java/apoc/load/Jdbc.java
+++ b/full/src/main/java/apoc/load/Jdbc.java
@@ -79,7 +79,7 @@ public class Jdbc {
         String url = getUrlOrKey(urlOrKey);
         String query = getSqlOrKey(tableOrSelect);
         try {
-            Connection connection = getConnection(url,loadJdbcConfig);
+            Connection connection = getConnection(url,loadJdbcConfig,log);
             // see https://jdbc.postgresql.org/documentation/91/query.html#query-with-cursors
             connection.setAutoCommit(loadJdbcConfig.isAutoCommit());
             try {
@@ -120,7 +120,7 @@ public class Jdbc {
         String url = getUrlOrKey(urlOrKey);
         LoadJdbcConfig jdbcConfig = new LoadJdbcConfig(config);
         try {
-            Connection connection = getConnection(url,jdbcConfig);
+            Connection connection = getConnection(url,jdbcConfig,log);
             try {
                 PreparedStatement stmt = connection.prepareStatement(query,ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 stmt.setFetchSize(5000);

--- a/full/src/main/java/apoc/model/Model.java
+++ b/full/src/main/java/apoc/model/Model.java
@@ -4,6 +4,7 @@ import apoc.Extended;
 import apoc.load.util.LoadJdbcConfig;
 import apoc.result.VirtualNode;
 import org.neo4j.graphdb.*;
+import org.neo4j.logging.Log;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.*;
 import schemacrawler.schema.*;
@@ -27,6 +28,9 @@ public class Model {
 
     @Context
     public Transaction tx;
+
+    @Context
+    public Log log;
 
     private Node createNode(String label, String name, boolean virtual) {
         if (virtual) {
@@ -63,7 +67,7 @@ public class Model {
                 .withSchemaInfoLevel(SchemaInfoLevelBuilder.standard());
         SchemaCrawlerOptions options = optionsBuilder.toOptions();
 
-        Catalog catalog = SchemaCrawlerUtility.getCatalog(getConnection(url, new LoadJdbcConfig(config)),
+        Catalog catalog = SchemaCrawlerUtility.getCatalog(getConnection(url, new LoadJdbcConfig(config), log),
                 options);
 
         DatabaseModel databaseModel = new DatabaseModel();

--- a/full/src/test/java/apoc/load/JdbcTest.java
+++ b/full/src/test/java/apoc/load/JdbcTest.java
@@ -194,6 +194,12 @@ public class JdbcTest extends AbstractJdbcTest {
     public void testLoadJdbcUpdateParamsUrlWithSpecialCharWithAuthentication() throws Exception {
         testCall(db, "CALL apoc.load.jdbcUpdate('jdbc:derby:derbyDB','UPDATE PERSON SET NAME = ? WHERE NAME = ?',['John','John'],{credentials:{user:'apoc',password:'Ap0c!#Db'}})",
                 (row) -> assertEquals(Util.map("count", 1 ), row.get("row")));
+        
+        // with authKey
+        apocConfig().setProperty("apoc.jdbc.myKey.user", "apoc");
+        apocConfig().setProperty("apoc.jdbc.myKey.password", "Ap0c!#Db");
+        testCall(db, "CALL apoc.load.jdbcUpdate('jdbc:derby:derbyDB','UPDATE PERSON SET NAME = ? WHERE NAME = ?',['John','John'],{authKey: 'myKey'})",
+                (row) -> assertEquals(Util.map("count", 1 ), row.get("row")));
     }
 
     @Test
@@ -202,7 +208,7 @@ public class JdbcTest extends AbstractJdbcTest {
         thrown.expectMessage("In config param credentials must be passed both user and password.");
         TestUtil.singleResultFirstColumn(db,"CALL apoc.load.jdbc($url, 'PERSON',[],{credentials:{user:'',password:'Ap0c!#Db'}})", Util.map("url","jdbc:derby:derbyDB"));
     }
-
+    
     @Test
     public void testLoadJdbcUrlWithSpecialCharWithoutUserWithAuthentication() throws Exception {
         thrown.expect(QueryExecutionException.class);
@@ -248,7 +254,7 @@ public class JdbcTest extends AbstractJdbcTest {
         thrown.expectMessage("In config param credentials must be passed both user and password.");
         TestUtil.singleResultFirstColumn(db, "CALL apoc.load.jdbc($url, 'PERSON',[],{credentials:{user:'apoc',password:''}})", Util.map("url","jdbc:derby:derbyDB"));
     }
-
+    
     @Test
     public void testLoadJdbcUrlWithSpecialCharWithoutPasswordWithAuthentication() throws Exception {
         thrown.expect(QueryExecutionException.class);


### PR DESCRIPTION
Fixes #1325

TODO - `CALL apoc.load.jdbc('jdbc:oracle:thin:@HOST:PORT/SERVICE_NAME',
'select * from dual',
[],
{credentials:{user:apoc.static.get("apoc.static.jdbc.<key>.user"), password: apoc.static.get("apoc.static.jdbc.<key>.password")}}) 
YIELD row 
RETURN row`

TODO - Test with non-testing db