### PR TITLE
Fixes #1949: The procedure apoc.export.xls.graph fails with 100+ nodes

### DIFF
--- a/full/src/main/java/apoc/export/xls/ExportXls.java
+++ b/full/src/main/java/apoc/export/xls/ExportXls.java
@@ -26,6 +26,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -120,7 +121,6 @@ public class ExportXls {
 
         for (String header: result.columns()) {
             Cell cell = headerRow.createCell(columnNum);
-            sheet.autoSizeColumn(columnNum);
             cell.setCellValue(header);
             columnNum++;
         }
@@ -133,6 +133,8 @@ public class ExportXls {
                 columnNum = amendCell(row, columnNum, map.get(header), config, styles);
             }
         }
+        // autoSize when all sizes are kwnown
+        IntStream.range(0, columnNum).forEach(sheet::autoSizeColumn);
     }
 
     private void dumpSubGraph(SubGraph subgraph, XlsExportConfig config, ProgressReporter reporter, SXSSFWorkbook wb, Map<Class, CellStyle> styles) {
@@ -169,7 +171,7 @@ public class ExportXls {
 
             List<String> magicKeys = triple.getMiddle();
             List<String> keys = triple.getRight();
-            Row row = sheet.getRow(0);
+            Row row = sheet.rowIterator().next();
             int cellNum = 0;
             for (String key: ListUtils.union(magicKeys,keys)) {
                 sheet.autoSizeColumn(cellNum);

--- a/full/src/test/java/apoc/export/csv/ExportXlsTest.java
+++ b/full/src/test/java/apoc/export/csv/ExportXlsTest.java
@@ -5,6 +5,7 @@ import apoc.export.xls.ExportXls;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
@@ -13,6 +14,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.internal.helpers.collection.Iterators;
@@ -23,7 +25,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertEquals;
@@ -80,8 +86,27 @@ public class ExportXlsTest {
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *",
                 map("file", fileName),
-                (r) -> assertResults(fileName, r, "graph", true));
+                (r) -> assertResults(fileName, r, "graph", 108L, 2L, 106));
         assertExcelFileForGraph(fileName);
+        db.executeTransactionally("MATCH (n:Test) DETACH DELETE n");
+    }
+
+    @Test
+    public void testExportGraphXlsWithCustomHeader() {
+        String nodeId = "customNode";
+        String relId = "customRel";
+        String startNodeId = "customStart";
+        String endNodeId = "customEnd";
+        db.executeTransactionally("UNWIND range(1,100) as range CREATE (n:Test)");
+        String fileName = "graph.xlsx";
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.xls.graph(graph, $file, $conf) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("file", fileName, "conf", map("headerNodeId", nodeId, 
+                        "headerRelationshipId", relId, "headerStartNodeId", startNodeId, "headerEndNodeId", endNodeId)),
+                (r) -> assertResults(fileName, r, "graph", 108L, 2L, 106));
+        assertExcelFileForGraph(fileName, nodeId, List.of(relId, startNodeId, endNodeId));
         db.executeTransactionally("MATCH (n:Test) DETACH DELETE n");
     }
 
@@ -138,21 +163,25 @@ public class ExportXlsTest {
         db.executeTransactionally("MATCH p = (u:User{name: 'Andrea'})-[r:COMPANY]->(c:Company{name: 'Larus'}) DELETE p");
     }
 
-    private void assertResults(String fileName, Map<String, Object> r, final String source, boolean test100) {
-        assertEquals(test100 ? 108L : 8L, r.get("nodes")); // we're exporting nodes with multiple label multiple times
+    private void assertResults(String fileName, Map<String, Object> r, final String source, long expectedNodes, long expectedRels, int expectedNodesSource) {
+        assertEquals(expectedNodes, r.get("nodes")); // we're exporting nodes with multiple label multiple times
         assertEquals(2L, r.get("relationships"));
         assertEquals(25L, r.get("properties"));
-        assertEquals(source + String.format(": nodes(%s), rels(2)", test100 ? 106 : 6), r.get("source"));
+        assertEquals(source + String.format(": nodes(%s), rels(%s)", expectedNodesSource, expectedRels), r.get("source"));
         assertEquals(fileName, r.get("file"));
         assertEquals("xls", r.get("format"));
         assertTrue("Should get time greater than 0", ((long) r.get("time")) >= 0);
     }
 
     private void assertResults(String fileName, Map<String, Object> r, final String source) {
-        assertResults(fileName, r, source, false);
+        assertResults(fileName, r, source, 8L, 2L, 6);
     }
 
     private void assertExcelFileForGraph(String fileName) {
+        assertExcelFileForGraph(fileName, "<nodeId>", List.of("<relationshipId>", "<startNodeId>", "<endNodeId>"));
+    }
+
+    private void assertExcelFileForGraph(String fileName, String headerNode, List<String> headerRel) {
         try (InputStream inp = new FileInputStream(new File(directory, fileName)); Transaction tx = db.beginTx()) {
             Workbook wb = WorkbookFactory.create(inp);
 
@@ -163,6 +192,25 @@ public class ExportXlsTest {
                 long numberOfNodes = Iterators.count(tx.findNodes(label));
                 Sheet sheet = wb.getSheet(label.name());
                 assertEquals(numberOfNodes, sheet.getLastRowNum());
+                final Set<String> actual = Iterators.stream(sheet.getRow(0).cellIterator()).map(Cell::getStringCellValue).collect(Collectors.toSet());
+                final Set<String> expected = StreamSupport.stream(tx.getAllNodes().spliterator(), false)
+                        .filter(node -> node.hasLabel(label))
+                        .flatMap(i -> StreamSupport.stream(i.getPropertyKeys().spliterator(), false))
+                        .collect(Collectors.toSet());
+                expected.add(headerNode);
+                assertEquals(expected, actual);
+            }
+            for (RelationshipType relType: tx.getAllRelationshipTypesInUse()) {
+                long numberOfRels = tx.getAllRelationships().stream().filter(rel -> rel.isType(relType)).count();
+                Sheet sheet = wb.getSheet(relType.name());
+                assertEquals(numberOfRels, sheet.getLastRowNum());
+                final Set<String> actual = Iterators.stream(sheet.getRow(0).cellIterator()).map(Cell::getStringCellValue).collect(Collectors.toSet());
+                final Set<String> expected = StreamSupport.stream(tx.getAllRelationships().spliterator(), false)
+                        .filter(rel -> rel.isType(relType))
+                        .flatMap(i -> StreamSupport.stream(i.getPropertyKeys().spliterator(), false))
+                        .collect(Collectors.toSet());
+                expected.addAll(headerRel);
+                assertEquals(expected, actual);
             }
             tx.commit();
         } catch (IOException|InvalidFormatException e) {


### PR DESCRIPTION
- Fixes #1949
- Fixes autosize column with `apoc.export.xls.query(..)`