### PR TITLE
Fixes #1952: apoc.meta.stats for 4.1.0.8 fails whereas 4.1.0.3 succeeds when a rel is back ticked

### DIFF
--- a/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -11,6 +11,7 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import java.util.Iterator;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.cypherNode;
+import static apoc.util.Util.quote;
 
 public class DatabaseSubGraph implements SubGraph
 {
@@ -85,7 +86,7 @@ public class DatabaseSubGraph implements SubGraph
     public long countsForRelationship(Label start, RelationshipType type, Label end) {
         String startNode = cypherNode(start);
         String endNode = cypherNode(end);
-        String relationship = String.format("[r:%s]", type.name());
+        String relationship = String.format("[r:%s]", quote(type.name()));
         return transaction.execute(String.format("MATCH %s-%s->%s RETURN count(r) AS count", startNode, relationship, endNode))
                 .<Long>columnAs("count")
                 .next();
@@ -93,7 +94,7 @@ public class DatabaseSubGraph implements SubGraph
 
     @Override
     public long countsForNode(Label label) {
-        return transaction.execute(String.format("MATCH (n:%s) RETURN count(n) AS count", label.name()))
+        return transaction.execute(String.format("MATCH (n:%s) RETURN count(n) AS count", quote(label.name())))
                 .<Long>columnAs("count")
                 .next();
     }

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -1073,4 +1073,20 @@ public class MetaTest {
                         "RETURN *",
                 assertResult);
     }
+    
+    @Test
+    public void testMetaStatsWithTwoDots() {
+        db.executeTransactionally("CREATE (n:`My:Label` {id:1})-[r:`http://www.w3.org/2000/01/rdf-schema#isDefinedBy` {alpha: 'beta'}]->(s:Another)");
+        TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
+            assertEquals(map("My:Label", 1L, "Another", 1L), row.get("labels"));
+            assertEquals(2L, row.get("labelCount"));
+            assertEquals(map("http://www.w3.org/2000/01/rdf-schema#isDefinedBy", 1L), row.get("relTypesCount"));
+            assertEquals(2L, row.get("propertyKeyCount"));
+            assertEquals(map("()-[:http://www.w3.org/2000/01/rdf-schema#isDefinedBy]->(:Another)", 1L,
+                    "()-[:http://www.w3.org/2000/01/rdf-schema#isDefinedBy]->()", 1L,
+                    "(:My:Label)-[:http://www.w3.org/2000/01/rdf-schema#isDefinedBy]->()",1L),
+                    row.get("relTypes"));
+        });
+
+    }
 }


### PR DESCRIPTION
Fixes #1952

Fixes #1956