### PR TITLE
Fixes #1471: Support spatial and temporal datatypes in CSV import (e.g. point, datetime)

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -23,6 +23,7 @@ import org.neo4j.logging.internal.LogService;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -194,6 +195,10 @@ public class ApocConfig extends LifecycleAdapter {
 
             boolean allowFileUrls = neo4jConfig.get(GraphDatabaseSettings.allow_file_urls);
             config.setProperty(APOC_IMPORT_FILE_ALLOW__READ__FROM__FILESYSTEM, allowFileUrls);
+            
+            // todo - evaluate default timezone here [maybe is reusable], otherwise through db.execute('CALL dbms.listConfig()')
+            final Setting<ZoneId> db_temporal_timezone = GraphDatabaseSettings.db_temporal_timezone;
+            config.setProperty(db_temporal_timezone.name(), neo4jConfig.get(db_temporal_timezone));
 
             initLogging();
         } catch (ConfigurationException e) {

--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -64,19 +64,7 @@ public class CsvEntityLoader {
         idMapping.putIfAbsent(idSpace, new HashMap<>());
         final Map<String, Long> idspaceIdMapping = idMapping.get(idSpace);
 
-        final Map<String, Mapping> mapping = fields.stream().collect(
-                Collectors.toMap(
-                        CsvHeaderField::getName,
-                        f -> {
-                            final Map<String, Object> mappingMap = Collections
-                                    .unmodifiableMap(Stream.of(
-                                            new AbstractMap.SimpleEntry<>("type", f.getType()),
-                                            new AbstractMap.SimpleEntry<>("array", f.isArray())
-                                    ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
-                            return new Mapping(f.getName(), mappingMap, clc.getArrayDelimiter(), false);
-                        }
-                )
-        );
+        final Map<String, Mapping> mapping = getMapping(fields);
 
         final CSVReader csv = new CSVReader(reader, clc.getDelimiter(), clc.getQuotationCharacter());
 
@@ -176,20 +164,7 @@ public class CsvEntityLoader {
                 .filter(field -> !CsvLoaderConstants.END_ID_FIELD.equals(field.getType()))
                 .collect(Collectors.toList());
 
-        final Map<String, Mapping> mapping = fields.stream().collect(
-                Collectors.toMap(
-                        CsvHeaderField::getName,
-                        f -> {
-                            final Map<String, Object> mappingMap = Collections
-                                    .unmodifiableMap(Stream.of(
-                                            new AbstractMap.SimpleEntry<>("type", f.getType()),
-                                            new AbstractMap.SimpleEntry<>("array", f.isArray())
-                                    ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
-
-                            return new Mapping(f.getName(), mappingMap, clc.getArrayDelimiter(), false);
-                        }
-                )
-        );
+        final Map<String, Mapping> mapping = getMapping(fields);
 
         final CSVReader csv = new CSVReader(reader, clc.getDelimiter());
         final String[] loadCsvCompatibleHeader = fields.stream().map(f -> f.getName()).toArray(String[]::new);
@@ -238,6 +213,24 @@ public class CsvEntityLoader {
                 reporter.update(0, 1, props);
             }
         }
+    }
+
+    private Map<String, Mapping> getMapping(List<CsvHeaderField> fields) {
+        return fields.stream().collect(
+                Collectors.toMap(
+                        CsvHeaderField::getName,
+                        f -> {
+                            final Map<String, Object> mappingMap = Collections
+                                    .unmodifiableMap(Stream.of(
+                                            new AbstractMap.SimpleEntry<>("type", f.getType()),
+                                            new AbstractMap.SimpleEntry<>("array", f.isArray()),
+                                            new AbstractMap.SimpleEntry<>("optionalData", f.getOptionalData())
+                                    ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
+
+                            return new Mapping(f.getName(), mappingMap, clc.getArrayDelimiter(), false);
+                        }
+                )
+        );
     }
 
     private static String readFirstLine(CountingReader reader) throws IOException {

--- a/core/src/main/java/apoc/export/csv/CsvLoaderConstants.java
+++ b/core/src/main/java/apoc/export/csv/CsvLoaderConstants.java
@@ -4,7 +4,10 @@ import java.util.regex.Pattern;
 
 public class CsvLoaderConstants {
 
-    public static final Pattern FIELD_PATTERN = Pattern.compile("^(?<name>[^:]*)(:(?<type>\\w+))?(\\((?<idspace>[-a-zA-Z_0-9]+)\\))?(?<array>\\[\\])?$");
+    public static final Pattern FIELD_PATTERN = Pattern.compile("^(?<name>[^:]*)(:(?<type>\\w+))?(?<optPar>\\{.*})?(\\((?<idspace>[-a-zA-Z_0-9]+)\\))?(?<array>\\[\\])?$");
+    public static final Pattern KEY_VALUE_PATTERN =
+            Pattern.compile( "(?:\\A|,)\\s*+(?<key>[a-z_A-Z]\\w*+)\\s*:\\s*(?<value>[^\\s,]+)" );
+    
     public static final String ARRAY_PATTERN = "[]";
 
     public static final String IGNORE_FIELD = "IGNORE";

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -2,7 +2,14 @@ package apoc.export.csv;
 
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.PointValue;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -18,7 +25,7 @@ public class CsvPropertyConverter {
             if (listContainingNull) {
                 return false;
             }
-            final Object[] prototype = getPrototypeFor(field.getType());
+            final Object[] prototype = getPrototypeFor(field.getType().toUpperCase());
             final Object[] array = list.toArray(prototype);
             entity.setProperty(field.getName(), array);
         } else {
@@ -33,14 +40,21 @@ public class CsvPropertyConverter {
     static Object[] getPrototypeFor(String type) {
         switch (type) {
             case "INT":
-            case "LONG":    return new Long     [] {};
+            case "LONG":            return new Long         [] {};
             case "FLOAT":
-            case "DOUBLE":  return new Double   [] {};
-            case "BOOLEAN": return new Boolean  [] {};
-            case "BYTE":    return new Byte     [] {};
-            case "SHORT":   return new Short    [] {};
-            case "CHAR":    return new Character[] {};
-            case "STRING":  return new String   [] {};
+            case "DOUBLE":          return new Double       [] {};
+            case "BOOLEAN":         return new Boolean      [] {};
+            case "BYTE":            return new Byte         [] {};
+            case "SHORT":           return new Short        [] {};
+            case "CHAR":            return new Character    [] {};
+            case "STRING":          return new String       [] {};
+            case "DATETIME":        return new ZonedDateTime[] {};
+            case "LOCALTIME":       return new LocalTime    [] {};
+            case "LOCALDATETIME":   return new LocalDateTime[] {};
+            case "POINT":           return new PointValue   [] {};
+            case "TIME":            return new OffsetTime   [] {};
+            case "DATE":            return new LocalDate    [] {};
+            case "DURATION":        return new DurationValue[] {};
         }
         throw new IllegalStateException("Type " + type + " not supported.");
     }

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -40,21 +40,35 @@ public class CsvPropertyConverter {
     static Object[] getPrototypeFor(String type) {
         switch (type) {
             case "INT":
-            case "LONG":            return new Long         [] {};
+            case "LONG":
+                return new Long[] {};
             case "FLOAT":
-            case "DOUBLE":          return new Double       [] {};
-            case "BOOLEAN":         return new Boolean      [] {};
-            case "BYTE":            return new Byte         [] {};
-            case "SHORT":           return new Short        [] {};
-            case "CHAR":            return new Character    [] {};
-            case "STRING":          return new String       [] {};
-            case "DATETIME":        return new ZonedDateTime[] {};
-            case "LOCALTIME":       return new LocalTime    [] {};
-            case "LOCALDATETIME":   return new LocalDateTime[] {};
-            case "POINT":           return new PointValue   [] {};
-            case "TIME":            return new OffsetTime   [] {};
-            case "DATE":            return new LocalDate    [] {};
-            case "DURATION":        return new DurationValue[] {};
+            case "DOUBLE":
+                return new Double[] {};
+            case "BOOLEAN":
+                return new Boolean[] {};
+            case "BYTE":
+                return new Byte[] {};
+            case "SHORT":
+                return new Short[] {};
+            case "CHAR":
+                return new Character[] {};
+            case "STRING":
+                return new String[] {};
+            case "DATETIME":
+                return new ZonedDateTime[] {};
+            case "LOCALTIME":
+                return new LocalTime[] {};
+            case "LOCALDATETIME":
+                return new LocalDateTime[] {};
+            case "POINT":
+                return new PointValue[] {};
+            case "TIME":
+                return new OffsetTime[] {};
+            case "DATE":
+                return new LocalDate[] {};
+            case "DURATION":
+                return new DurationValue[] {};
         }
         throw new IllegalStateException("Type " + type + " not supported.");
     }

--- a/core/src/main/java/apoc/export/json/JsonImporter.java
+++ b/core/src/main/java/apoc/export/json/JsonImporter.java
@@ -281,27 +281,8 @@ public class JsonImporter implements Closeable {
         return value;
     }
 
-    private PointValue toPoint(Map<String, Object> pointMap) {
-        double x;
-        double y;
-        Double z = null;
-
-        final CoordinateReferenceSystem crs = CoordinateReferenceSystem.byName((String) pointMap.get("crs"));
-        if (crs.getName().startsWith("wgs-84")) {
-            x = (double) pointMap.get("latitude");
-            y = (double) pointMap.get("longitude");
-            if (crs.getName().endsWith("-3d")) {
-                z = (double) pointMap.get("height");
-            }
-        } else {
-            x = (double) pointMap.get("x");
-            y = (double) pointMap.get("y");
-            if (crs.getName().endsWith("-3d")) {
-                z = (double) pointMap.get("z");
-            }
-        }
-
-        return z != null ? Values.pointValue(crs, x, y, z) : Values.pointValue(crs, x, y);
+    public static PointValue toPoint(Map<String, Object> pointMap) {
+        return Util.toPoint(pointMap, Collections.emptyMap());
     }
 
     private String getType(Map<String, Object> param) {

--- a/core/src/main/java/apoc/load/Mapping.java
+++ b/core/src/main/java/apoc/load/Mapping.java
@@ -1,10 +1,25 @@
 package apoc.load;
 
+import apoc.export.json.JsonImporter;
 import apoc.load.util.LoadCsvConfig;
 import apoc.meta.Meta;
 import apoc.util.Util;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
+import org.neo4j.values.storable.TimeValue;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -21,10 +36,13 @@ public class Mapping {
     final boolean ignore;
     final char arraySep;
     private final Pattern arrayPattern;
+    private final Map<String, Object> optionalData;
 
     public Mapping(String name, Map<String, Object> mapping, char arraySep, boolean ignore) {
         this.name = mapping.getOrDefault("name", name).toString();
         this.array = (Boolean) mapping.getOrDefault("array", false);
+        this.optionalData = (Map<String, Object>) mapping.get("optionalData");
+        
         this.ignore = (Boolean) mapping.getOrDefault("ignore", ignore);
         this.nullValues = (Collection<String>) mapping.getOrDefault("nullValues", emptyList());
         this.arraySep = parseCharFromConfig(mapping, "arraySep", arraySep);
@@ -55,7 +73,24 @@ public class Mapping {
     private Object convertType(String value) {
         if (nullValues.contains(value)) return null;
         if (type == Meta.Types.STRING) return value;
+        final Supplier<ZoneId> timezone = () -> ZoneId.of((String) optionalData.getOrDefault("timezone", ZoneId.systemDefault().getId()));
         switch (type) {
+            case POINT:
+                return Util.toPoint(Util.fromJson(value, Map.class), optionalData);
+            case LOCAL_DATE_TIME:
+                // asObjectCopy() returns LocalDateTime, 
+                // because in case of array entity.setProperty() fails with LocalDateTimeValue[]
+                return LocalDateTimeValue.parse(value).asObjectCopy();
+            case LOCAL_TIME:
+                return LocalTimeValue.parse(value).asObjectCopy();
+            case DATE_TIME:
+                return DateTimeValue.parse(value, timezone).asObjectCopy();
+            case TIME:
+                return TimeValue.parse(value, timezone).asObjectCopy();
+            case DATE:
+                return DateValue.parse(value).asObjectCopy();
+            case DURATION:
+                return DurationValue.parse(value);
             case INTEGER: return Util.toLong(value);
             case FLOAT: return Util.toDouble(value);
             case BOOLEAN: return Util.toBoolean(value);

--- a/core/src/main/java/apoc/load/Mapping.java
+++ b/core/src/main/java/apoc/load/Mapping.java
@@ -1,6 +1,5 @@
 package apoc.load;
 
-import apoc.export.json.JsonImporter;
 import apoc.load.util.LoadCsvConfig;
 import apoc.meta.Meta;
 import apoc.util.Util;
@@ -11,21 +10,21 @@ import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.TimeValue;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static apoc.load.util.LoadCsvConfig.DEFAULT_ARRAY_SEP;
+import static apoc.ApocConfig.apocConfig;
 import static apoc.util.Util.parseCharFromConfig;
 import static java.util.Collections.emptyList;
+import static org.neo4j.configuration.GraphDatabaseSettings.db_temporal_timezone;
 
 public class Mapping {
     public static final Mapping EMPTY = new Mapping("", Collections.emptyMap(), LoadCsvConfig.DEFAULT_ARRAY_SEP, false);
@@ -73,7 +72,8 @@ public class Mapping {
     private Object convertType(String value) {
         if (nullValues.contains(value)) return null;
         if (type == Meta.Types.STRING) return value;
-        final Supplier<ZoneId> timezone = () -> ZoneId.of((String) optionalData.getOrDefault("timezone", ZoneId.systemDefault().getId()));
+
+        final Supplier<ZoneId> timezone = () -> ZoneId.of((String) optionalData.getOrDefault("timezone", apocConfig().getString(db_temporal_timezone.name())));
         switch (type) {
             case POINT:
                 return Util.toPoint(Util.fromJson(value, Map.class), optionalData);

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -97,6 +97,7 @@ public class    Meta {
     }
 
     public enum Types {
+        // todo ... Ah ecco... questi non ci stanno...
         INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,ANY,MAP,LIST,POINT,DATE,DATE_TIME,LOCAL_TIME,LOCAL_DATE_TIME,TIME,DURATION;
 
         private String typeOfList = "ANY";
@@ -161,7 +162,11 @@ public class    Meta {
             }
             typeName = typeName.toUpperCase();
             for (Types type : values()) {
-                if (type.name().startsWith(typeName)) return type;
+                final String name = type.name();
+                // check, e.g. both "LOCAL_DATE_TIME" and "LOCALDATETIME"
+                if (name.startsWith(typeName) || name.replace("_", "").startsWith(typeName)) {
+                    return type;
+                }
             }
             return STRING;
         }

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -161,9 +161,9 @@ public class    Meta {
             }
             typeName = typeName.toUpperCase();
             for (Types type : values()) {
-                final String name = type.name();
+                final String name = type.name().replace("_", "");
                 // check, e.g. both "LOCAL_DATE_TIME" and "LOCALDATETIME"
-                if (name.startsWith(typeName) || name.replace("_", "").startsWith(typeName)) {
+                if (name.startsWith(typeName)) {
                     return type;
                 }
             }

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -159,7 +159,7 @@ public class    Meta {
             if (typeName == null) {
                 return STRING;
             }
-            typeName = typeName.toUpperCase();
+            typeName = typeName.toUpperCase().replace("_", "");
             for (Types type : values()) {
                 final String name = type.name().replace("_", "");
                 // check, e.g. both "LOCAL_DATE_TIME" and "LOCALDATETIME"

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -97,7 +97,6 @@ public class    Meta {
     }
 
     public enum Types {
-        // todo ... Ah ecco... questi non ci stanno...
         INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,ANY,MAP,LIST,POINT,DATE,DATE_TIME,LOCAL_TIME,LOCAL_DATE_TIME,TIME,DURATION;
 
         private String typeOfList = "ANY";

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -963,8 +963,7 @@ public class Util {
     public static boolean isSelfRel(Relationship rel) {
         return rel.getStartNodeId() == rel.getEndNodeId();
     }
-
-
+    
     public static PointValue toPoint(Map<String, Object> pointMap, Map<String, Object> defaultPointMap) {
         double x;
         double y;

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -28,6 +28,9 @@ import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.TerminationGuard;
+import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.PointValue;
+import org.neo4j.values.storable.Values;
 
 import javax.lang.model.SourceVersion;
 import java.io.BufferedWriter;
@@ -959,5 +962,37 @@ public class Util {
 
     public static boolean isSelfRel(Relationship rel) {
         return rel.getStartNodeId() == rel.getEndNodeId();
+    }
+
+
+    public static PointValue toPoint(Map<String, Object> pointMap, Map<String, Object> defaultPointMap) {
+        double x;
+        double y;
+        Double z = null;
+
+        final CoordinateReferenceSystem crs = CoordinateReferenceSystem.byName((String) getOrDefault(pointMap, defaultPointMap, "crs"));
+
+        // It does not depend on the prefix of crs, I could also pass a point({x: 56.7, y: 12.78, crs: 'wgs-84'})
+        final boolean isLatitudePresent = pointMap.containsKey("latitude") || (!pointMap.containsKey("x") && defaultPointMap.containsKey("latitude"));
+        final boolean isCoord3D = crs.getName().endsWith("-3d");
+        if (isLatitudePresent) {
+            x = Util.toDouble(getOrDefault(pointMap, defaultPointMap, "longitude"));
+            y = Util.toDouble(getOrDefault(pointMap, defaultPointMap, "latitude"));
+            if (isCoord3D) {
+                z = Util.toDouble(getOrDefault(pointMap, defaultPointMap, "height"));
+            }
+        } else {
+            x = Util.toDouble(getOrDefault(pointMap, defaultPointMap, "x"));
+            y = Util.toDouble(getOrDefault(pointMap, defaultPointMap,  "y"));
+            if (isCoord3D) {
+                z = Util.toDouble(getOrDefault(pointMap, defaultPointMap, "z"));
+            }
+        }
+
+        return z != null ? Values.pointValue(crs, x, y, z) : Values.pointValue(crs, x, y);
+    }
+    
+    private static Object getOrDefault(Map<String, Object> firstMap, Map<String, Object> secondMap, String key) {
+        return firstMap.getOrDefault(key, secondMap.get(key));
     }
 }

--- a/core/src/test/java/apoc/export/csv/CsvHeaderFieldTests.java
+++ b/core/src/test/java/apoc/export/csv/CsvHeaderFieldTests.java
@@ -80,10 +80,10 @@ public class CsvHeaderFieldTests {
         assertTrue(matcher.find());
         assertEquals(7, matcher.groupCount());
         assertEquals(TEST_OPT_PAR, matcher.group("optPar"));
-        assertEquals(TEST_NAME,    matcher.group("name"));
-        assertEquals(TEST_TYPE,    matcher.group("type"));
+        assertEquals(TEST_NAME, matcher.group("name"));
+        assertEquals(TEST_TYPE, matcher.group("type"));
         assertEquals(TEST_IDSPACE, matcher.group("idspace"));
-        assertEquals(TEST_ARRAY,   matcher.group("array"));
+        assertEquals(TEST_ARRAY, matcher.group("array"));
     }
 
 }

--- a/core/src/test/java/apoc/export/csv/CsvHeaderFieldTests.java
+++ b/core/src/test/java/apoc/export/csv/CsvHeaderFieldTests.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class CsvHeaderFieldTests {
@@ -15,11 +16,13 @@ public class CsvHeaderFieldTests {
     public static final String TEST_TYPE = "Type";
     public static final String TEST_IDSPACE = "IDSPACE";
     public static final String TEST_ARRAY = "[]";
+    private static final String TEST_OPT_PAR = "{crs:WGS-84}";
 
     public static final String TEST_FIELD_1 = "name:Type(IDSPACE)[]";
     public static final String TEST_FIELD_2 = "name:Type(IDSPACE)";
     public static final String TEST_FIELD_3 = "name:Type";
     public static final String TEST_FIELD_4 = "name";
+    public static final String TEST_FIELD_5 = "name:Type{crs:WGS-84}(IDSPACE)[]";
 
     @Test
     public void testCsvField1() {
@@ -62,7 +65,21 @@ public class CsvHeaderFieldTests {
         Matcher matcher = CsvLoaderConstants.FIELD_PATTERN.matcher(TEST_FIELD_1);
 
         assertTrue(matcher.find());
-        assertEquals(6, matcher.groupCount());
+        assertEquals(7, matcher.groupCount());
+        assertNull(matcher.group("optPar"));
+        assertEquals(TEST_NAME,    matcher.group("name"));
+        assertEquals(TEST_TYPE,    matcher.group("type"));
+        assertEquals(TEST_IDSPACE, matcher.group("idspace"));
+        assertEquals(TEST_ARRAY,   matcher.group("array"));
+    }
+
+    @Test
+    public void testOptionalParamGroup() {
+        Matcher matcher = CsvLoaderConstants.FIELD_PATTERN.matcher(TEST_FIELD_5);
+
+        assertTrue(matcher.find());
+        assertEquals(7, matcher.groupCount());
+        assertEquals(TEST_OPT_PAR, matcher.group("optPar"));
         assertEquals(TEST_NAME,    matcher.group("name"));
         assertEquals(TEST_TYPE,    matcher.group("type"));
         assertEquals(TEST_IDSPACE, matcher.group("idspace"));

--- a/core/src/test/java/apoc/export/csv/CsvHeaderFieldTests.java
+++ b/core/src/test/java/apoc/export/csv/CsvHeaderFieldTests.java
@@ -67,10 +67,10 @@ public class CsvHeaderFieldTests {
         assertTrue(matcher.find());
         assertEquals(7, matcher.groupCount());
         assertNull(matcher.group("optPar"));
-        assertEquals(TEST_NAME,    matcher.group("name"));
-        assertEquals(TEST_TYPE,    matcher.group("type"));
+        assertEquals(TEST_NAME, matcher.group("name"));
+        assertEquals(TEST_TYPE, matcher.group("type"));
         assertEquals(TEST_IDSPACE, matcher.group("idspace"));
-        assertEquals(TEST_ARRAY,   matcher.group("array"));
+        assertEquals(TEST_ARRAY, matcher.group("array"));
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -93,11 +93,11 @@ public class ImportCsvTest {
                             "2,\"{y:51.507222, x:-0.1275}\"\n" +
                             "3,\"{latitude:37.554167, longitude:-122.313056, height: 100, crs:'WGS-84-3D'}\"\n"),
                     new AbstractMap.SimpleEntry<>("nodesMultiTypes",
-                            ":ID|date1:datetime{timezone:Europe/Stockholm}|date2:datetime|foo:string|joined:date|active:boolean|points:int\n" +
+                            ":ID(MultiType-ID)|date1:datetime{timezone:Europe/Stockholm}|date2:datetime|foo:string|joined:date|active:boolean|points:int\n" +
                             "1|2018-05-10T10:30|2018-05-10T12:30|Joe Soap|2017-05-05|true|10\n" +
                             "2|2018-05-10T10:30[Europe/Berlin]|2018-05-10T12:30[Europe/Berlin]|Jane Doe|2017-08-21|true|15\n"),
                     new AbstractMap.SimpleEntry<>("relMultiTypes",
-                            ":START_ID|:END_ID|prop1:IGNORE|prop2:time{timezone:+02:00}[]|foo:int|time:duration[]|baz:localdatetime[]|bar:localtime[]\n" +
+                            ":START_ID(MultiType-ID)|:END_ID(MultiType-ID)|prop1:IGNORE|prop2:time{timezone:+02:00}[]|foo:int|time:duration[]|baz:localdatetime[]|bar:localtime[]\n" +
                             "1|2|a|15:30|1|P14DT16H12M|2020-01-01T00:00:00|11:00:00\n" +
                             "2|1|b|15:30+01:00|2|P5M1.5D|2021|12:00:00\n"),
                     new AbstractMap.SimpleEntry<>("id-with-duplicates", "id:ID|name:STRING\n" +

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -148,7 +148,6 @@ public class ImportCsvTest {
         }
 
         TestUtil.registerProcedure(db, ImportCsv.class);
-        db.executeTransactionally("MATCH (n) DETACH DELETE n");
     }
 
     @Test
@@ -188,7 +187,7 @@ public class ImportCsvTest {
         TestUtil.testCall(db, "MATCH p=(start:Person)-[rel {foo: 1}]->(end:Person)-[relSecond {foo:2}]->(start) RETURN start, end, rel, relSecond", r-> {
             final Map<String, Object> expectedStart = Map.of("joined", LocalDate.of(2017, 5, 5), 
                     "foo", "Joe Soap", "active", true, 
-                    "date2", ZonedDateTime.of(2018, 5, 10, 12, 30, 0, 0, ZoneId.of("Europe/Rome")),
+                    "date2", ZonedDateTime.of(2018, 5, 10, 12, 30, 0, 0, ZoneId.systemDefault()),
                     "date1", ZonedDateTime.of(2018, 5, 10, 10, 30, 0, 0, ZoneId.of("Europe/Stockholm")), 
                     "points", 10L, "__csv_id", "1");
             assertEquals(expectedStart, ((NodeEntity) r.get("start")).getAllProperties());

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -46,12 +46,15 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public class ImportCsvTest {
-
+    
+    private static final ZoneId DEFAULT_TIMEZONE = ZoneId.of("Asia/Tokyo");
+    
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(ApocSettings.apoc_import_file_enabled, true)
             .withSetting(ApocSettings.apoc_export_file_enabled, true)
             .withSetting(GraphDatabaseSettings.allow_file_urls, true)
+            .withSetting(GraphDatabaseSettings.db_temporal_timezone, DEFAULT_TIMEZONE)
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, new File("src/test/resources/csv-inputs").toPath().toAbsolutePath());
 
     final Map<String, String> testCsvs = Collections
@@ -187,7 +190,7 @@ public class ImportCsvTest {
         TestUtil.testCall(db, "MATCH p=(start:Person)-[rel {foo: 1}]->(end:Person)-[relSecond {foo:2}]->(start) RETURN start, end, rel, relSecond", r-> {
             final Map<String, Object> expectedStart = Map.of("joined", LocalDate.of(2017, 5, 5), 
                     "foo", "Joe Soap", "active", true, 
-                    "date2", ZonedDateTime.of(2018, 5, 10, 12, 30, 0, 0, ZoneId.systemDefault()),
+                    "date2", ZonedDateTime.of(2018, 5, 10, 12, 30, 0, 0, DEFAULT_TIMEZONE),
                     "date1", ZonedDateTime.of(2018, 5, 10, 10, 30, 0, 0, ZoneId.of("Europe/Stockholm")), 
                     "points", 10L, "__csv_id", "1");
             assertEquals(expectedStart, ((NodeEntity) r.get("start")).getAllProperties());

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -11,11 +11,24 @@ import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.internal.helpers.collection.Iterators;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.kernel.impl.core.NodeEntity;
+import org.neo4j.kernel.impl.core.RelationshipEntity;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.Values;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Arrays.asList;
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -73,6 +87,19 @@ public class ImportCsvTest {
                     new AbstractMap.SimpleEntry<>("id", "id:ID|name:STRING\n" +
                             "1|John\n" +
                             "2|Jane\n"),
+                    new AbstractMap.SimpleEntry<>("csvPoint", 
+                            ":ID,location:point{crs:WGS-84}\n" +
+                            "1,\"{latitude:55.6121514, longitude:12.9950357}\"\n" +
+                            "2,\"{y:51.507222, x:-0.1275}\"\n" +
+                            "3,\"{latitude:37.554167, longitude:-122.313056, height: 100, crs:'WGS-84-3D'}\"\n"),
+                    new AbstractMap.SimpleEntry<>("nodesMultiTypes",
+                            ":ID|date1:datetime{timezone:Europe/Stockholm}|date2:datetime|foo:string|joined:date|active:boolean|points:int\n" +
+                            "1|2018-05-10T10:30|2018-05-10T12:30|Joe Soap|2017-05-05|true|10\n" +
+                            "2|2018-05-10T10:30[Europe/Berlin]|2018-05-10T12:30[Europe/Berlin]|Jane Doe|2017-08-21|true|15\n"),
+                    new AbstractMap.SimpleEntry<>("relMultiTypes",
+                            ":START_ID|:END_ID|prop1:IGNORE|prop2:time{timezone:+02:00}[]|foo:int|time:duration[]|baz:localdatetime[]|bar:localtime[]\n" +
+                            "1|2|a|15:30|1|P14DT16H12M|2020-01-01T00:00:00|11:00:00\n" +
+                            "2|1|b|15:30+01:00|2|P5M1.5D|2021|12:00:00\n"),
                     new AbstractMap.SimpleEntry<>("id-with-duplicates", "id:ID|name:STRING\n" +
                             "1|John\n" +
                             "1|Jane\n"),
@@ -143,6 +170,75 @@ public class ImportCsvTest {
 
         List<Long> ids = TestUtil.firstColumn(db, "MATCH (n:Person) RETURN n.id AS id ORDER BY id");
         assertThat(ids, Matchers.contains(1L, 2L));
+    }
+
+    @Test
+    public void testNodesAndRelsWithMultiTypes() {
+        TestUtil.testCall(db,
+                "CALL apoc.import.csv([{fileName: $nodeFile, labels: ['Person']}], [{fileName: $relFile, type: 'KNOWS'}], $config)",
+                map("nodeFile", "file:/nodesMultiTypes.csv", 
+                        "relFile", "file:/relMultiTypes.csv",
+                        "config", map("delimiter", '|')),
+                (r) -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(2L, r.get("relationships")); 
+                }
+        );
+        TestUtil.testCall(db, "MATCH p=(start:Person)-[rel {foo: 1}]->(end:Person)-[relSecond {foo:2}]->(start) RETURN start, end, rel, relSecond", r-> {
+            final Map<String, Object> expectedStart = Map.of("joined", LocalDate.of(2017, 5, 5), 
+                    "foo", "Joe Soap", "active", true, 
+                    "date2", ZonedDateTime.of(2018, 5, 10, 12, 30, 0, 0, ZoneId.of("Europe/Rome")),
+                    "date1", ZonedDateTime.of(2018, 5, 10, 10, 30, 0, 0, ZoneId.of("Europe/Stockholm")), 
+                    "points", 10L, "__csv_id", "1");
+            assertEquals(expectedStart, ((NodeEntity) r.get("start")).getAllProperties());
+            
+            final Map<String, Object> expectedEnd = Map.of("joined", LocalDate.of(2017, 8, 21), 
+                    "foo", "Jane Doe", "active", true, 
+                    "date2", ZonedDateTime.of(2018, 5, 10, 12, 30, 0, 0, ZoneId.of("Europe/Berlin")),
+                    "date1", ZonedDateTime.of(2018, 5, 10, 10, 30, 0, 0, ZoneId.of("Europe/Berlin")), 
+                    "points", 15L, "__csv_id", "2");
+            assertEquals(expectedEnd, ((NodeEntity) r.get("end")).getAllProperties());
+
+            final RelationshipEntity rel = (RelationshipEntity) r.get("rel");
+            assertEquals(asList(DurationValue.parse("P14DT16H12M")), asList((DurationValue[]) rel.getProperty("time")));
+            final List<Object> expectedTime = asList(OffsetTime.of(15, 30, 0, 0, ZoneOffset.of("+02:00")));
+            assertEquals(expectedTime, asList((OffsetTime[]) rel.getProperty("prop2")));
+            final List<LocalDateTime> expectedBaz = asList(LocalDateTime.of(2020, 1, 1, 0, 0));
+            assertEquals(expectedBaz, asList((LocalDateTime[]) rel.getProperty("baz")));
+            final List<LocalTime> expectedBar = asList(LocalTime.of(11, 0, 0));
+            assertEquals(expectedBar, asList((LocalTime[]) rel.getProperty("bar")));
+            assertEquals(1L, rel.getProperty("foo"));
+            final RelationshipEntity relSecond = (RelationshipEntity) r.get("relSecond");
+            assertEquals(asList(DurationValue.parse("P5M1.5D")), asList((DurationValue[]) relSecond.getProperty("time")));
+            final List<Object> expectedTimeRelSecond = asList(OffsetTime.of(15, 30, 0, 0, ZoneOffset.of("+01:00")));
+            assertEquals(expectedTimeRelSecond, asList((OffsetTime[]) relSecond.getProperty("prop2")));
+            final List<LocalDateTime> expectedBazRelSecond = asList(LocalDateTime.of(2021, 1, 1, 0, 0));
+            assertEquals(expectedBazRelSecond, asList((LocalDateTime[]) relSecond.getProperty("baz")));
+            final List<LocalTime> expectedBarRelSecond = asList(LocalTime.of(12, 0, 0));
+            assertEquals(expectedBarRelSecond, asList((LocalTime[]) relSecond.getProperty("bar")));
+            assertEquals(2L, relSecond.getProperty("foo"));
+        });
+    }
+
+    @Test
+    public void testNodesWithPoints() {
+        TestUtil.testCall(db,
+                "CALL apoc.import.csv([{fileName: $file, labels: ['Point']}], [], {})",
+                map("file", "file:/csvPoint.csv"),
+                (r) -> {
+                    assertEquals(3L, r.get("nodes"));
+                    assertEquals(0L, r.get("relationships"));
+                }
+        );
+        TestUtil.testResult(db, "MATCH (n:Point) RETURN n ORDER BY n.id", r -> {
+            final ResourceIterator<Node> iterator = r.columnAs("n");
+            final NodeEntity first = (NodeEntity) iterator.next();
+            assertEquals(Values.pointValue(CoordinateReferenceSystem.WGS84, 12.9950357, 55.6121514), first.getProperty("location"));
+            final NodeEntity second = (NodeEntity) iterator.next();
+            assertEquals(Values.pointValue(CoordinateReferenceSystem.WGS84, -0.1275, 51.507222), second.getProperty("location"));
+            final NodeEntity third = (NodeEntity) iterator.next();
+            assertEquals(Values.pointValue(CoordinateReferenceSystem.WGS84_3D, -122.313056, 37.554167, 100D), third.getProperty("location"));
+        });
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -148,6 +148,7 @@ public class ImportCsvTest {
         }
 
         TestUtil.registerProcedure(db, ImportCsv.class);
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
     }
 
     @Test

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -150,7 +150,7 @@ public class ImportJsonTest {
             Assert.assertEquals(7, props.size());
             Assert.assertTrue(props.get("place") instanceof PointValue);
             PointValue point = (PointValue) props.get("place");
-            final PointValue pointValue = Values.pointValue(CoordinateReferenceSystem.WGS84, 13.1D, 33.46789D);
+            final PointValue pointValue = Values.pointValue(CoordinateReferenceSystem.WGS84, 33.46789D, 13.1D);
             Assert.assertTrue(point.equals((Point) pointValue));
             Assert.assertTrue(props.get("born") instanceof LocalDateTime);
 

--- a/docs/asciidoc/modules/ROOT/pages/import/import-csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/import-csv.adoc
@@ -4,7 +4,7 @@
 
 
 
-CSV files that comply with the https://neo4j.com/docs/operations-manual/current/tools/import/file-header-format/[Neo4j import tool's header format] can be imported using the `apoc.import.csv` procedure.
+CSV files that comply with the https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/#import-tool-header-format[Neo4j import tool's header format] can be imported using the `apoc.import.csv` procedure.
 This procedure can be used to load small- to medium-sized data sets in an online database.
 For importing larger data sets, it is recommended to perform a batch import using the (https://neo4j.com/docs/operations-manual/current/tools/import/[import tool], which loads data in bulk to an offline (initially empty) database.
 
@@ -90,6 +90,6 @@ CALL apoc.import.csv(
 
 The loader supports advanced features of the import tool:
 
-* _ID spaces_ are supported, using the link:https://neo4j.com/docs/operations-manual/current/tools/import/file-header-format/#import-tool-id-spaces[import tool's syntax].
-* Node labels can be specified with the link:https://neo4j.com/docs/operations-manual/current/tools/import/file-header-format/#import-tool-header-format-nodes[`:LABEL`] field.
-* Relationship types can be specified with the link:https://neo4j.com/docs/operations-manual/current/tools/import/file-header-format/#import-tool-header-format-rels[`:TYPE`] field.
+* _ID spaces_ are supported, using the link:https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/#import-tool-id-spaces[import tool's syntax].
+* Node labels can be specified with the link:https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/#import-tool-header-format-nodes[`:LABEL`] field.
+* Relationship types can be specified with the link:https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/#import-tool-header-format-rels[`:TYPE`] field.

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.csv.adoc
@@ -97,3 +97,62 @@ RETURN path;
 | path
 | (:Person {name: "John", speaks: ["en", "fr"], __csv_id: 1})-[:KNOWS {since: 2016}]->(:Person {name: "Jane", speaks: ["en", "de"], __csv_id: 2})
 |===
+
+=== Properties
+
+For properties, the `<name>` part of the field designates the property key, 
+while the `<field_type>` part (after `:`) assigns a data type (see below). 
+You can have properties in both node data files and relationship data files.
+
+Use one of `int`, `long`, `float`, `double`, `boolean`, `byte`, `short`, `char`, `string`, `point`, `date`, `localtime`, `time`, `localdatetime`, `datetime`, and `duration` to designate the data type for properties. 
+If no data type is given, this defaults to string. To define an array type, append `[]` to the type.
+For example:
+
+.test.csv
+[source,text]
+----
+:ID,name,joined:date,active:boolean,points:int
+user01,Joe Soap,2017-05-05,true,10
+user02,Jane Doe,2017-08-21,true,15
+user03,Moe Know,2018-02-17,false,7
+----
+
+==== Point
+
+A point is specified using the Cypher syntax for maps. The map allows the same keys as the input to the link:https://neo4j.com/docs/cypher-manual/4.2/functions/spatial/[Point function.]
+The point data type in the header can be amended with a map of default values used for all values of that column, e.g. `point{crs: 'WGS-84'}`. 
+Specifying the header this way allows you to have an incomplete map in the value position in the data file. Optionally, a value in a data file may override default values from the header.
+
+.point.csv
+[source,text]
+----
+:ID,name,location:point{crs:WGS-84}
+city01,"Malmö","{latitude:55.6121514, longitude:12.9950357}"
+city02,"London","{y:51.507222, x:-0.1275}"
+city03,"San Mateo","{latitude:37.554167, longitude:-122.313056, height: 100, crs:'WGS-84-3D'}"
+----
+
+In the above csv:
+
+- the first city’s location is defined using `latitude` and `longitude`, as expected when using the coordinate system defined in the header.
+- the second city uses `x` and `y` instead. This would normally lead to a point using the coordinate reference system cartesian. Since the header defines crs:WGS-84, that coordinate reference system will be used.
+- the third city overrides the coordinate reference system defined in the header, and sets it explicitly to WGS-84-3D.
+
+==== Temporal
+
+The format for all temporal data types must be defined as described in link:https://neo4j.com/docs/cypher-manual/4.2/syntax/temporal/#cypher-temporal-instants[Temporal instants syntax] and link:https://neo4j.com/docs/cypher-manual/4.2/syntax/temporal/#cypher-temporal-durations[Durations syntax]. 
+Two of the temporal types, Time and DateTime, take a time zone parameter which might be common between all or many of the values in the data file. 
+It is therefore possible to specify a default time zone for Time and DateTime values in the header, for example: `time{timezone:+02:00}` and: `datetime{timezone:Europe/Stockholm}`.
+
+.point.csv
+[source,text]
+----
+:ID,date1:datetime{timezone:Europe/Stockholm},date2:datetime
+1,2018-05-10T10:30,2018-05-10T12:30
+2,2018-05-10T10:30[Europe/Berlin],2018-05-10T12:30[Europe/Berlin]
+----
+
+In the above csv:
+
+- the first row has two values that do not specify an explicit timezone. The value for `date1` will use the `Europe/Stockholm` time zone that was specified for that field in the header. The value for `date2` will use the configured default time zone of the database.
+- in the second row, both `date1` and `date2` set the time zone explicitly to be `Europe/Berlin`. This overrides the header definition for date1, as well as the configured default time zone of the database.


### PR DESCRIPTION

- Fixes #1471 (implemented like https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/)
- Fixed `JsonImporter.toPoint()` bug
- Added `toUpperCase()` in `CsvPropertyConverter` to handle `array` fields with lower case