### PR TITLE
Fixes 1369 - 1979 - 1757: apoc.export.csv.graph incorrectly exports properties with datatype 'float'

### DIFF
--- a/core/src/main/java/apoc/convert/Convert.java
+++ b/core/src/main/java/apoc/convert/Convert.java
@@ -87,23 +87,28 @@ public class Convert {
         else if (list instanceof Iterable) return Iterators.addToCollection(((Iterable)list).iterator(),(List)new ArrayList<>(100));
         else if (list instanceof Iterator) return Iterators.addToCollection((Iterator)list,(List)new ArrayList<>(100));
         else if (list.getClass().isArray()) {
-            final Object[] objectArray;
-            if (list.getClass().getComponentType().isPrimitive()) {
-                int length = Array.getLength(list);
-                objectArray = new Object[length];
-                for (int i = 0; i < length; i++) {
-                    objectArray[i] = Array.get(list, i);
-                }
-            } else {
-                objectArray = (Object[]) list;
-            }
+            final Object[] objectArray = getObjects(list);
             List result = new ArrayList<>(objectArray.length);
             Collections.addAll(result, objectArray);
             return result;
         }
         return Collections.singletonList(list);
     }
-    
+
+    public static Object[] getObjects(Object list) {
+        final Object[] objectArray;
+        if (list.getClass().getComponentType().isPrimitive()) {
+            int length = Array.getLength(list);
+            objectArray = new Object[length];
+            for (int i = 0; i < length; i++) {
+                objectArray[i] = Array.get(list, i);
+            }
+        } else {
+            objectArray = (Object[]) list;
+        }
+        return objectArray;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> List<T> convertToList(Object list, Class<T> type) {
         List<Object> convertedList = convertToList(list);

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -124,7 +124,7 @@ public class CsvFormat implements Format {
                 for (int col = 0; col < header.length; col++) {
                     String key = header[col];
                     Object value = row.get(key);
-                    data[col] = FormatUtils.toString(value);
+                    data[col] = FormatUtils.toString(value, config.isImportToolArrays(), config.getArrayDelim());
                     reporter.update(value instanceof Node ? 1: 0,value instanceof Relationship ? 1: 0 , value instanceof Entity ? 0 : 1);
                 }
                 out.writeNext(data, applyQuotesToAll);
@@ -148,15 +148,15 @@ public class CsvFormat implements Format {
     public void writeAll(SubGraph graph, Reporter reporter, ExportConfig config, CSVWriter out) {
         Map<String, Class> nodePropTypes = collectPropTypesForNodes(graph, db, config);
         Map<String, Class> relPropTypes = collectPropTypesForRelationships(graph, db, config);
-        List<Map.Entry<String, String>> nodeHeader = generateHeader(nodePropTypes, config.useTypes(), NODE_HEADER_FIXED_COLUMNS);
-        List<Map.Entry<String, String>> relHeader = generateHeader(relPropTypes, config.useTypes(), REL_HEADER_FIXED_COLUMNS);
+        List<Map.Entry<String, String>> nodeHeader = generateHeader(nodePropTypes, config, NODE_HEADER_FIXED_COLUMNS);
+        List<Map.Entry<String, String>> relHeader = generateHeader(relPropTypes, config, REL_HEADER_FIXED_COLUMNS);
         List<Map.Entry<String, String>> header = new ArrayList<>(nodeHeader);
         header.addAll(relHeader);
         out.writeNext(header.stream().map(e -> e.getKey() + e.getValue()).toArray(String[]::new), applyQuotesToAll);
         int cols = header.size();
 
-        writeNodes(graph, out, reporter, getNamesHeader(nodeHeader, NODE_HEADER_FIXED_COLUMNS.length), cols, config.getBatchSize(), config.getDelim());
-        writeRels(graph, out, reporter, getNamesHeader(relHeader, REL_HEADER_FIXED_COLUMNS.length), cols, nodeHeader.size(), config.getBatchSize(), config.getDelim());
+        writeNodes(graph, out, reporter, getNamesHeader(nodeHeader, NODE_HEADER_FIXED_COLUMNS.length), cols, config);
+        writeRels(graph, out, reporter, getNamesHeader(relHeader, REL_HEADER_FIXED_COLUMNS.length), cols, nodeHeader.size(), config);
     }
 
     private List<String> getNamesHeader(List<Map.Entry<String, String>> nodeHeader, int length) {
@@ -175,7 +175,8 @@ public class CsvFormat implements Format {
 
     private void writeNodesBulkImport(Reporter reporter, ExportConfig config, ExportFileManager writer, Map<Iterable<Label>, List<Node>> objectNode) {
         objectNode.entrySet().forEach(entrySet -> {
-            Set<String> headerNode = generateHeaderNodeBulkImport(entrySet);
+            boolean isImportToolArrays = config.isImportToolArrays();
+            Set<String> headerNode = generateHeaderNodeBulkImport(entrySet, isImportToolArrays);
 
             List<List<String>> rows = entrySet.getValue()
                     .stream()
@@ -186,7 +187,7 @@ public class CsvFormat implements Format {
                                 return joinLabels(entrySet.getKey(), config.getArrayDelim());
                             }
                             String prop = s.split(":")[0];
-                            return "".equals(prop) ? String.valueOf(n.getId()) : cleanPoint(FormatUtils.toString(n.getProperty(prop, "")));
+                            return "".equals(prop) ? String.valueOf(n.getId()) : cleanPoint(FormatUtils.toString(n.getProperty(prop, ""), isImportToolArrays, config.getArrayDelim()));
                         }).collect(Collectors.toList());
                     })
                     .collect(Collectors.toList());
@@ -197,8 +198,9 @@ public class CsvFormat implements Format {
     }
 
     private void writeRelsBulkImport(Reporter reporter, ExportConfig config, ExportFileManager writer, Map<RelationshipType, List<Relationship>> objectRel) {
+        boolean isImportToolArrays = config.isImportToolArrays();
         objectRel.entrySet().forEach(entrySet -> {
-            Set<String> headerRel = generateHeaderRelationshipBulkImport(entrySet);
+            Set<String> headerRel = generateHeaderRelationshipBulkImport(entrySet, isImportToolArrays);
 
             List<List<String>> rows = entrySet.getValue()
                     .stream()
@@ -214,7 +216,7 @@ public class CsvFormat implements Format {
                                     return entrySet.getKey().name();
                                 default:
                                     String prop = s.split(":")[0];
-                                    return "".equals(prop) ? String.valueOf(r.getId()) : cleanPoint(FormatUtils.toString(r.getProperty(prop, "")));
+                                    return "".equals(prop) ? String.valueOf(r.getId()) : cleanPoint(FormatUtils.toString(r.getProperty(prop, ""), isImportToolArrays, config.getArrayDelim()));
                             }
                         }).collect(Collectors.toList());
                     })
@@ -230,27 +232,27 @@ public class CsvFormat implements Format {
         return point;
     }
 
-    private Set<String> generateHeaderNodeBulkImport(Map.Entry<Iterable<Label>, List<Node>> entrySet) {
+    private Set<String> generateHeaderNodeBulkImport(Map.Entry<Iterable<Label>, List<Node>> entrySet, boolean isImportToolArrays) {
         Set<String> headerNode = new LinkedHashSet<>();
         headerNode.add(":ID");
         Map<String,Class> keyTypes = new LinkedHashMap<>();
         entrySet.getValue().forEach(node -> updateKeyTypes(keyTypes, node));
         final LinkedHashSet<String> otherFields = keyTypes.entrySet().stream()
-                .map(stringClassEntry -> formatHeader(stringClassEntry))
+                .map(stringClassEntry -> formatHeader(stringClassEntry, isImportToolArrays))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         headerNode.addAll(otherFields);
         headerNode.add(":LABEL");
         return headerNode;
     }
 
-    private Set<String> generateHeaderRelationshipBulkImport(Map.Entry<RelationshipType, List<Relationship>> entrySet) {
+    private Set<String> generateHeaderRelationshipBulkImport(Map.Entry<RelationshipType, List<Relationship>> entrySet, boolean isImportToolArrays) {
         Set<String> headerNode = new LinkedHashSet<>();
         Map<String,Class> keyTypes = new LinkedHashMap<>();
         entrySet.getValue().forEach(relationship -> updateKeyTypes(keyTypes, relationship));
         headerNode.add(":START_ID");
         headerNode.add(":END_ID");
         headerNode.add(":TYPE");
-        headerNode.addAll(keyTypes.entrySet().stream().map(stringClassEntry -> formatHeader(stringClassEntry)).collect(Collectors.toCollection(LinkedHashSet::new)));
+        headerNode.addAll(keyTypes.entrySet().stream().map(stringClassEntry -> formatHeader(stringClassEntry, isImportToolArrays)).collect(Collectors.toCollection(LinkedHashSet::new)));
         return headerNode;
     }
 
@@ -271,7 +273,9 @@ public class CsvFormat implements Format {
         }
     }
 
-    private List<Map.Entry<String, String>> generateHeader(Map<String, Class> propTypes, boolean useTypes, String... startersString) {
+    private List<Map.Entry<String, String>> generateHeader(Map<String, Class> propTypes, ExportConfig config, String... startersString) {
+        boolean useTypes = config.useTypes();
+        boolean isImportToolArrays = config.isImportToolArrays();
         List<Map.Entry<String, String>> result = Arrays.stream(startersString)
                 .map(item -> {
                     final String[] split = item.split(":");
@@ -281,22 +285,22 @@ public class CsvFormat implements Format {
         
         result.addAll(propTypes.entrySet().stream()
                 .map(entry -> {
-                    String type = MetaInformation.typeFor(entry.getValue(), null);
-                    return new AbstractMap.SimpleEntry<>(entry.getKey(),
-                            (type == null || type.equals("string") || !useTypes) ? "" : ":" + type);
+                    String type = useTypes ? MetaInformation.typeFor(entry.getValue(), null, isImportToolArrays) : "";
+                    return new AbstractMap.SimpleEntry<>(entry.getKey(), type == null ? "" : type);
                 })
                 .sorted(Map.Entry.comparingByKey())
                 .collect(Collectors.toList()));
         return result;
     }
 
-    private void writeNodes(SubGraph graph, CSVWriter out, Reporter reporter, List<String> header, int cols, int batchSize, String delimiter) {
+    private void writeNodes(SubGraph graph, CSVWriter out, Reporter reporter, List<String> header, int cols, ExportConfig config) {
+        int batchSize = config.getBatchSize();
         String[] row=new String[cols];
         int nodes = 0;
         for (Node node : graph.getNodes()) {
             row[0]=String.valueOf(node.getId());
             row[1]=getLabelsString(node);
-            collectProps(header, node, reporter, row, 2, delimiter);
+            collectProps(header, node, reporter, row, 2, config);
             out.writeNext(row, applyQuotesToAll);
             nodes++;
             if (batchSize==-1 || nodes % batchSize == 0) {
@@ -309,10 +313,10 @@ public class CsvFormat implements Format {
         }
     }
 
-    private void collectProps(Collection<String> fields, Entity pc, Reporter reporter, String[] row, int offset, String delimiter) {
+    private void collectProps(Collection<String> fields, Entity pc, Reporter reporter, String[] row, int offset, ExportConfig config) {
         for (String field : fields) {
             if (pc.hasProperty(field)) {
-                row[offset] = FormatUtils.toString(pc.getProperty(field));
+                row[offset] = FormatUtils.toString(pc.getProperty(field), config.isImportToolArrays(), config.getArrayDelim());
                 reporter.update(0,0,1);
             }
             else {
@@ -322,14 +326,15 @@ public class CsvFormat implements Format {
         }
     }
 
-    private void writeRels(SubGraph graph, CSVWriter out, Reporter reporter, List<String> relHeader, int cols, int offset, int batchSize, String delimiter) {
+    private void writeRels(SubGraph graph, CSVWriter out, Reporter reporter, List<String> relHeader, int cols, int offset, ExportConfig config) {
+        int batchSize = config.getBatchSize();
         String[] row=new String[cols];
         int rels = 0;
         for (Relationship rel : graph.getRelationships()) {
             row[offset]=String.valueOf(rel.getStartNode().getId());
             row[offset+1]=String.valueOf(rel.getEndNode().getId());
             row[offset+2]=rel.getType().name();
-            collectProps(relHeader, rel, reporter, row, 3 + offset, delimiter);
+            collectProps(relHeader, rel, reporter, row, 3 + offset, config);
             out.writeNext(row, applyQuotesToAll);
             rels++;
             if (batchSize==-1 || rels % batchSize == 0) {

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -33,10 +33,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.export.util.BulkImportUtil.formatHeader;
+import static apoc.export.util.FormatUtils.PointMode.NO_QUOTE;
+import static apoc.export.util.FormatUtils.PointMode.QUOTE;
 import static apoc.export.util.MetaInformation.collectPropTypesForNodes;
 import static apoc.export.util.MetaInformation.collectPropTypesForRelationships;
 import static apoc.export.util.MetaInformation.getLabelsString;
@@ -124,7 +125,7 @@ public class CsvFormat implements Format {
                 for (int col = 0; col < header.length; col++) {
                     String key = header[col];
                     Object value = row.get(key);
-                    data[col] = FormatUtils.toString(value, config.isImportToolArrays(), config.getArrayDelim());
+                    data[col] = FormatUtils.toString(value, config.isImportToolArrays(), config.getArrayDelim(), NO_QUOTE);
                     reporter.update(value instanceof Node ? 1: 0,value instanceof Relationship ? 1: 0 , value instanceof Entity ? 0 : 1);
                 }
                 out.writeNext(data, applyQuotesToAll);
@@ -187,7 +188,7 @@ public class CsvFormat implements Format {
                                 return joinLabels(entrySet.getKey(), config.getArrayDelim());
                             }
                             String prop = s.split(":")[0];
-                            return "".equals(prop) ? String.valueOf(n.getId()) : cleanPoint(FormatUtils.toString(n.getProperty(prop, ""), isImportToolArrays, config.getArrayDelim()));
+                            return "".equals(prop) ? String.valueOf(n.getId()) : FormatUtils.toString(n.getProperty(prop, ""), isImportToolArrays, config.getArrayDelim(), config.isQuotes().equals(ExportConfig.NONE_QUOTES) ? QUOTE : NO_QUOTE );
                         }).collect(Collectors.toList());
                     })
                     .collect(Collectors.toList());
@@ -216,20 +217,14 @@ public class CsvFormat implements Format {
                                     return entrySet.getKey().name();
                                 default:
                                     String prop = s.split(":")[0];
-                                    return "".equals(prop) ? String.valueOf(r.getId()) : cleanPoint(FormatUtils.toString(r.getProperty(prop, ""), isImportToolArrays, config.getArrayDelim()));
+                                    return "".equals(prop) ? String.valueOf(r.getId()) 
+                                            : FormatUtils.toString(r.getProperty(prop, ""), isImportToolArrays, config.getArrayDelim(), config.isQuotes().equals(ExportConfig.NONE_QUOTES) ? QUOTE : NO_QUOTE );
                             }
                         }).collect(Collectors.toList());
                     })
                     .collect(Collectors.toList());
             writeRow(config, writer, headerRel, rows, "relationships." + entrySet.getKey().name());
         });
-    }
-
-    private String cleanPoint(String point) {
-        point = point.replace(",\"z\":null", "");
-        point = point.replace(",\"heigth\":null", "");
-        point = point.replace("\"", "");
-        return point;
     }
 
     private Set<String> generateHeaderNodeBulkImport(Map.Entry<Iterable<Label>, List<Node>> entrySet, boolean isImportToolArrays) {
@@ -316,7 +311,7 @@ public class CsvFormat implements Format {
     private void collectProps(Collection<String> fields, Entity pc, Reporter reporter, String[] row, int offset, ExportConfig config) {
         for (String field : fields) {
             if (pc.hasProperty(field)) {
-                row[offset] = FormatUtils.toString(pc.getProperty(field), config.isImportToolArrays(), config.getArrayDelim());
+                row[offset] = FormatUtils.toString(pc.getProperty(field), config.isImportToolArrays(), config.getArrayDelim(), NO_QUOTE);
                 reporter.update(0,0,1);
             }
             else {

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -146,15 +148,20 @@ public class CsvFormat implements Format {
     public void writeAll(SubGraph graph, Reporter reporter, ExportConfig config, CSVWriter out) {
         Map<String, Class> nodePropTypes = collectPropTypesForNodes(graph, db, config);
         Map<String, Class> relPropTypes = collectPropTypesForRelationships(graph, db, config);
-        List<String> nodeHeader = generateHeader(nodePropTypes, config.useTypes(), NODE_HEADER_FIXED_COLUMNS);
-        List<String> relHeader = generateHeader(relPropTypes, config.useTypes(), REL_HEADER_FIXED_COLUMNS);
-        List<String> header = new ArrayList<>(nodeHeader);
+        List<Map.Entry<String, String>> nodeHeader = generateHeader(nodePropTypes, config.useTypes(), NODE_HEADER_FIXED_COLUMNS);
+        List<Map.Entry<String, String>> relHeader = generateHeader(relPropTypes, config.useTypes(), REL_HEADER_FIXED_COLUMNS);
+        List<Map.Entry<String, String>> header = new ArrayList<>(nodeHeader);
         header.addAll(relHeader);
-        out.writeNext(header.toArray(new String[header.size()]), applyQuotesToAll);
+        out.writeNext(header.stream().map(e -> e.getKey() + e.getValue()).toArray(String[]::new), applyQuotesToAll);
         int cols = header.size();
 
-        writeNodes(graph, out, reporter, nodeHeader.subList(NODE_HEADER_FIXED_COLUMNS.length, nodeHeader.size()), cols, config.getBatchSize(), config.getDelim());
-        writeRels(graph, out, reporter, relHeader.subList(REL_HEADER_FIXED_COLUMNS.length, relHeader.size()), cols, nodeHeader.size(), config.getBatchSize(), config.getDelim());
+        writeNodes(graph, out, reporter, getNamesHeader(nodeHeader, NODE_HEADER_FIXED_COLUMNS.length), cols, config.getBatchSize(), config.getDelim());
+        writeRels(graph, out, reporter, getNamesHeader(relHeader, REL_HEADER_FIXED_COLUMNS.length), cols, nodeHeader.size(), config.getBatchSize(), config.getDelim());
+    }
+
+    private List<String> getNamesHeader(List<Map.Entry<String, String>> nodeHeader, int length) {
+        return nodeHeader.subList(length, nodeHeader.size())
+                .stream().map(Map.Entry::getKey).collect(Collectors.toList());
     }
 
     private void writeAllBulkImport(SubGraph graph, Reporter reporter, ExportConfig config, ExportFileManager writer) {
@@ -264,20 +271,21 @@ public class CsvFormat implements Format {
         }
     }
 
-    private List<String> generateHeader(Map<String, Class> propTypes, boolean useTypes, String... starters) {
-        List<String> result = new ArrayList<>();
-        if (useTypes) {
-            Collections.addAll(result, starters);
-        } else {
-            result.addAll(Stream.of(starters).map(s -> s.split(":")[0]).collect(Collectors.toList()));
-        }
+    private List<Map.Entry<String, String>> generateHeader(Map<String, Class> propTypes, boolean useTypes, String... startersString) {
+        List<Map.Entry<String, String>> result = Arrays.stream(startersString)
+                .map(item -> {
+                    final String[] split = item.split(":");
+                    return new AbstractMap.SimpleEntry<>(split[0], useTypes ? (":" + split[1]) : "");
+                })
+                .collect(Collectors.toList());
+        
         result.addAll(propTypes.entrySet().stream()
                 .map(entry -> {
                     String type = MetaInformation.typeFor(entry.getValue(), null);
-                    return (type == null || type.equals("string") || !useTypes)
-                            ? entry.getKey() : entry.getKey() + ":" + type;
+                    return new AbstractMap.SimpleEntry<>(entry.getKey(),
+                            (type == null || type.equals("string") || !useTypes) ? "" : ":" + type);
                 })
-                .sorted()
+                .sorted(Map.Entry.comparingByKey())
                 .collect(Collectors.toList()));
         return result;
     }

--- a/core/src/main/java/apoc/export/csv/ImportCsv.java
+++ b/core/src/main/java/apoc/export/csv/ImportCsv.java
@@ -8,6 +8,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,8 @@ public class ImportCsv {
                     final Map<String, Map<String, Long>> idMapping = new HashMap<>();
                     for (Map<String, Object> node : nodes) {
                         final Object data = node.getOrDefault("fileName", node.get("data"));
-                        final List<String> labels = (List<String>) node.get("labels");
+                        // default emptyList() to avoid NullPointer if import without `labels` key
+                        final List<String> labels = (List<String>) node.getOrDefault("labels", Collections.emptyList());
                         loader.loadNodes(data, labels, db, idMapping);
                     }
 

--- a/core/src/main/java/apoc/export/util/BulkImportUtil.java
+++ b/core/src/main/java/apoc/export/util/BulkImportUtil.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 public class BulkImportUtil {
 
-    private static Map<Class<?>, String> allowedMapping = Collections.unmodifiableMap(new HashMap(){{
+    public static Map<Class<?>, String> allowedMapping = Collections.unmodifiableMap(new HashMap(){{
         put(Double.class, "double");
         put(Float.class, "float");
         put(Integer.class, "int");

--- a/core/src/main/java/apoc/export/util/BulkImportUtil.java
+++ b/core/src/main/java/apoc/export/util/BulkImportUtil.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static apoc.export.util.MetaInformation.typeFor;
+
 public class BulkImportUtil {
 
     public static Map<Class<?>, String> allowedMapping = Collections.unmodifiableMap(new HashMap(){{
@@ -29,12 +31,9 @@ public class BulkImportUtil {
     }});
 
 
-    public static String formatHeader(Map.Entry<String, Class> r) {
-        if (allowedMapping.containsKey(r.getValue())) {
-            return r.getKey() + ":" + allowedMapping.get(r.getValue());
-        } else {
-            return r.getKey();
-        }
+    public static String formatHeader(Map.Entry<String, Class> r, boolean isImportToolArrays) {
+        String type = typeFor(r.getValue(), null, isImportToolArrays);
+        return r.getKey() + type;
     }
 
 }

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -29,8 +29,9 @@ public class ExportConfig extends CompressionConfig {
 
     private int batchSize;
     private boolean silent;
-    private boolean bulkImport = false;
+    private boolean bulkImport;
     private boolean sampling;
+    private boolean importToolArrays;
     private String delim;
     private String quotes;
     private boolean useTypes;
@@ -60,6 +61,10 @@ public class ExportConfig extends CompressionConfig {
 
     public boolean isBulkImport() {
         return bulkImport;
+    }
+
+    public boolean isImportToolArrays() {
+        return importToolArrays;
     }
 
     public char getDelimChar() {
@@ -94,6 +99,7 @@ public class ExportConfig extends CompressionConfig {
         this.caption = convertCaption(config.getOrDefault("caption", asList("name", "title", "label", "id")));
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
         this.bulkImport = toBoolean(config.get("bulkImport"));
+        this.importToolArrays = toBoolean(config.getOrDefault("importToolArrays", false));
         this.separateHeader = toBoolean(config.get("separateHeader"));
         this.format = ExportFormat.fromString((String) config.getOrDefault("format", "cypher-shell"));
         this.cypherFormat = CypherFormat.fromString((String) config.getOrDefault("cypherFormat", "create"));

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -99,7 +99,10 @@ public class ExportConfig extends CompressionConfig {
         this.caption = convertCaption(config.getOrDefault("caption", asList("name", "title", "label", "id")));
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
         this.bulkImport = toBoolean(config.get("bulkImport"));
-        this.importToolArrays = toBoolean(config.getOrDefault("importToolArrays", false));
+        
+        // with bulkImport by default we want to export list in CSVs which can be used neo4j-import import, 
+        // that is without square brackets and with array delimiter. Otherwise will be used OBJECT_MAPPER.writeValueAsString() method
+        this.importToolArrays = toBoolean(config.getOrDefault("importToolArrays", this.bulkImport));
         this.separateHeader = toBoolean(config.get("separateHeader"));
         this.format = ExportFormat.fromString((String) config.getOrDefault("format", "cypher-shell"));
         this.cypherFormat = CypherFormat.fromString((String) config.getOrDefault("cypherFormat", "create"));
@@ -125,12 +128,16 @@ public class ExportConfig extends CompressionConfig {
         if (!OptimizationType.NONE.equals(this.optimizationType) && this.unwindBatchSize > this.batchSize) {
             throw new RuntimeException("`unwindBatchSize` must be <= `batchSize`, but got [unwindBatchSize:" + unwindBatchSize + ", batchSize:" + batchSize + "]");
         }
+        if (this.delim.equals(this.arrayDelim)) {
+            throw new RuntimeException(String.format("Both delim and arrayDelim are `%s`. These configs must be different", delim));
+        }
     }
 
     private void exportQuotes(Map<String, Object> config)
     {
         try {
-            this.quotes = (String) config.getOrDefault("quotes", DEFAULT_QUOTES);
+            // bulkImport with NONE_QUOTES not to break change
+            this.quotes = (String) config.getOrDefault("quotes", bulkImport ? NONE_QUOTES : DEFAULT_QUOTES);
 
             if ( !quotes.equals(ALWAYS_QUOTES) && !quotes.equals(NONE_QUOTES) && !quotes.equals(IF_NEEDED_QUUOTES) ) {
                 throw new RuntimeException("The string value of the field quote is not valid");
@@ -219,5 +226,9 @@ public class ExportConfig extends CompressionConfig {
     
     public boolean ifNotExists() {
         return ifNotExists;
+    }
+
+    public void setQuotes(String quotes) {
+        this.quotes = quotes;
     }
 }

--- a/core/src/main/java/apoc/export/util/FormatUtils.java
+++ b/core/src/main/java/apoc/export/util/FormatUtils.java
@@ -4,7 +4,7 @@ import apoc.convert.Convert;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -27,6 +27,7 @@ import static apoc.util.Util.map;
  * @since 23.02.16
  */
 public class FormatUtils {
+    public enum PointMode { NO_QUOTE, QUOTE, AS_JSON }
 
     public static String formatNumber(Number value) {
         if (value == null) return null;
@@ -61,10 +62,10 @@ public class FormatUtils {
         throw new RuntimeException("Invalid graph element "+pc);
     }
 
-    public static String toString(Object value, boolean importToolArrays, String arrayDelimiter) {
+    public static String toString(Object value, boolean importToolArrays, String arrayDelimiter, PointMode pointMode) {
         if (value == null) return "";
         if (value instanceof Path) {
-            return toString(StreamSupport.stream(((Path)value).spliterator(),false).map(FormatUtils::toMap).collect(Collectors.toList()));
+            return toString(StreamSupport.stream(((Path)value).spliterator(),false).map(FormatUtils::toMap).collect(Collectors.toList()), importToolArrays, arrayDelimiter, pointMode);
         }
         if (value instanceof Entity) {
             return Util.toJson(toMap((Entity) value)); // todo id, label, type ?
@@ -76,7 +77,7 @@ public class FormatUtils {
                         ? Arrays.stream(Convert.getObjects(value))
                         : StreamSupport.stream(((Iterable) value).spliterator(), false);
 
-                return (String) stream.map(item -> toString(item, true, arrayDelimiter))
+                return (String) stream.map(item -> toString(item, true, arrayDelimiter, pointMode))
                         .collect(Collectors.joining(arrayDelimiter));
             }
             return Util.toJson(value);
@@ -88,23 +89,32 @@ public class FormatUtils {
             return formatNumber((Number)value);
         }
         if (value instanceof Point) {
-            return formatPoint((Point) value);
+            return formatPoint((Point) value, pointMode);
         }
         return value.toString();
     }
 
     public static String toString(Object value) {
-        return toString(value, false, null);
+        return toString(value, false, null, PointMode.AS_JSON);
     }
 
-    public static String formatPoint(Point value) {
-        try {
-            return JsonUtil.OBJECT_MAPPER.writeValueAsString(value);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+    public static String formatPoint(Point value, PointMode pointMode) {
+        String replacement = StringUtils.EMPTY;
+        switch (pointMode) {
+            case QUOTE:
+                replacement = String.valueOf(ExportConfig.QUOTECHAR);
+            case NO_QUOTE:
+                // leverage on PointValue.toString() which return point({x: NUM, y: NUM, z: NUM}) without double quotes on x,y,z
+                return value.toString().replace("point(", replacement)
+                        .replace(")", replacement);
+            default:
+                try {
+                    return JsonUtil.OBJECT_MAPPER.writeValueAsString(value);
+                } catch (JsonProcessingException e) {
+                    throw new RuntimeException(e);
+                }
         }
     }
-
     public static List<String> getLabelsSorted(Node node) {
         return getLabelsAsStream(node).collect(Collectors.toList());
     }

--- a/core/src/main/java/apoc/export/util/MetaInformation.java
+++ b/core/src/main/java/apoc/export/util/MetaInformation.java
@@ -97,13 +97,19 @@ public class MetaInformation {
     public final static Set<String> GRAPHML_ALLOWED = new HashSet<>(asList("boolean", "int", "long", "float", "double", "string"));
     
     public static String typeFor(Class value, Set<String> allowed) {
+        return typeFor(value, allowed, true);
+    }
+
+    public static String typeFor(Class value, Set<String> allowed, boolean isImportToolArrays) {
         if (value == void.class) return null; // Is this necessary?
         final boolean isArray = value.isArray();
         value = isArray ? value.getComponentType() : value;
+        String defaultType = "string";
         // csv case
         if (allowed == null) {
-            return allowedMapping.getOrDefault(primitiveToWrapper(value), "string")
-                    + (isArray ? "[]" : "");
+            String string = allowedMapping.getOrDefault(primitiveToWrapper(value), defaultType)
+                    + (isArray && isImportToolArrays ? "[]" : "");
+            return string.equals(defaultType) ? "" : (":" + string);
         }
         // graphML case
         String name = value.getSimpleName().toLowerCase();
@@ -115,7 +121,7 @@ public class MetaInformation {
             case INTEGER: case FLOAT:
                 return "integer".equals(name) || !isAllowed ? "int" : name;
             default:
-                return isAllowed ? name : "string"; // We manage all other data types as strings
+                return isAllowed ? name : defaultType; // We manage all other data types as strings
         }
     }
 

--- a/core/src/main/java/apoc/export/util/MetaInformation.java
+++ b/core/src/main/java/apoc/export/util/MetaInformation.java
@@ -20,10 +20,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static apoc.export.util.BulkImportUtil.allowedMapping;
 import static apoc.gephi.GephiFormatUtils.getCaption;
 import static apoc.meta.tablesforlabels.PropertyTracker.typeMappings;
 import static java.util.Arrays.asList;
 import static org.neo4j.internal.helpers.collection.Iterables.stream;
+import static org.apache.commons.lang3.ClassUtils.primitiveToWrapper;
 
 /**
  * @author mh
@@ -96,9 +98,17 @@ public class MetaInformation {
     
     public static String typeFor(Class value, Set<String> allowed) {
         if (value == void.class) return null; // Is this necessary?
+        final boolean isArray = value.isArray();
+        value = isArray ? value.getComponentType() : value;
+        // csv case
+        if (allowed == null) {
+            return allowedMapping.getOrDefault(primitiveToWrapper(value), "string")
+                    + (isArray ? "[]" : "");
+        }
+        // graphML case
+        String name = value.getSimpleName().toLowerCase();
+        boolean isAllowed = allowed.contains(name);
         Meta.Types type = Meta.Types.of(value);
-        String name = (value.isArray() ? value.getComponentType() : value).getSimpleName().toLowerCase();
-        boolean isAllowed = allowed != null && allowed.contains(name);
         switch (type) {
             case NULL:
                 return null;

--- a/core/src/main/java/apoc/load/Mapping.java
+++ b/core/src/main/java/apoc/load/Mapping.java
@@ -75,6 +75,8 @@ public class Mapping {
 
         final Supplier<ZoneId> timezone = () -> ZoneId.of((String) optionalData.getOrDefault("timezone", apocConfig().getString(db_temporal_timezone.name())));
         switch (type) {
+            case BYTE:
+                return Util.toInteger(value).byteValue();
             case POINT:
                 return Util.toPoint(Util.fromJson(value, Map.class), optionalData);
             case LOCAL_DATE_TIME:
@@ -91,12 +93,21 @@ public class Mapping {
                 return DateValue.parse(value).asObjectCopy();
             case DURATION:
                 return DurationValue.parse(value);
-            case INTEGER: return Util.toLong(value);
-            case FLOAT: return Util.toDouble(value);
-            case BOOLEAN: return Util.toBoolean(value);
-            case NULL: return null;
-            case LIST: return Arrays.stream(arrayPattern.split(value)).map(this::convertType).collect(Collectors.toList());
-            default: return value;
+            case LONG:
+            case SHORT:
+            case INTEGER: 
+                return Util.toLong(value);
+            case FLOAT: 
+            case DOUBLE:
+                return Util.toDouble(value);
+            case BOOLEAN: 
+                return Util.toBoolean(value);
+            case NULL: 
+                return null;
+            case LIST: 
+                return Arrays.stream(arrayPattern.split(value)).map(this::convertType).collect(Collectors.toList());
+            default:
+                return value;
         }
     }
 }

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -96,9 +96,13 @@ public class    Meta {
         public static final Map<String, List<String>> relConstraints = new HashMap<>(20);;
         public static final Map<String, List<String>> nodeConstraints = new HashMap<>(20);;
     }
+    
 
     public enum Types {
-        INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,ANY,MAP,LIST,POINT,DATE,DATE_TIME,LOCAL_TIME,LOCAL_DATE_TIME,TIME,DURATION;
+        // prop types can be Byte[], Integer, Float, String, Boolean, Point, Date, Time, LocalTime, DateTime, LocalDateTime, and Duration
+        // but, since this class is also used for Mapping.java (to map the header of apoc.import.csv)
+        // for consistency with neo4j-admin import tool, we can have also an header with 'short', 'long' and 'double'
+        DOUBLE,SHORT,INTEGER,LONG,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,ANY,MAP,LIST,POINT,DATE,DATE_TIME,LOCAL_TIME,LOCAL_DATE_TIME,TIME,DURATION,BYTE;
 
         private String typeOfList = "ANY";
 

--- a/core/src/main/resources/manyTypes.csv
+++ b/core/src/main/resources/manyTypes.csv
@@ -1,0 +1,5 @@
+_id:id,_labels:label,alpha:short,beta:byte[],epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,kappa:string[],one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
+0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
+1,:AnotherNode,1,"cXdlcnR5",1,1,,,A,bar,["un","deux","trois"],,,,10.1,,,1.1,,,,
+,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
+

--- a/core/src/main/resources/manyTypes.csv
+++ b/core/src/main/resources/manyTypes.csv
@@ -1,5 +1,5 @@
 _id:id,_labels:label,alpha:short,beta:byte[],epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,kappa:string[],one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
 0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
-1,:AnotherNode,1,"cXdlcnR5",1,1,,,A,bar,["un","deux","trois"],,,,10.1,,,1.1,,,,
+1,:AnotherNode,1,113;119;101;114;116;121,1,1,,,A,bar,un;deux;trois,,,,10.1,,,1.1,,,,
 ,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
 

--- a/core/src/main/resources/manyTypes.csv
+++ b/core/src/main/resources/manyTypes.csv
@@ -1,5 +1,7 @@
-_id:id,_labels:label,alpha:short,beta:byte[],epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,kappa:string[],one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
-0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
-1,:AnotherNode,1,113;119;101;114;116;121,1,1,,,A,bar,un;deux;trois,,,,10.1,,,1.1,,,,
-,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
+_id:id,_labels:label,alpha:short,beta:byte[],epsilon:int,eta:long,five:date,foo,four:localdatetime,gamma:char,iota,kappa:string[],one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
+0,:SuperNode,,,,,2020-01-01,,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P14DT16H12M,,17:58:30,12:02:33Z,,,,,
+1,:AnotherNode,12,113;119;101;114;116;121,1,133,,,,A,bar e " bar,un;deux;trois,,,,10.1,,,1.1,,,,
+2,:Bar:Foo:SuperNode,,,,,,bar,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{x: 56.7, y: 12.78, crs: 'cartesian'}
+,,,,,,,,,,,,,,,,,,,1,2,ANOTHER_REL,
 

--- a/core/src/main/resources/manyTypesWithArrayLegacy.csv
+++ b/core/src/main/resources/manyTypesWithArrayLegacy.csv
@@ -1,0 +1,5 @@
+_id:id,_labels:label,alpha:short,beta:byte,epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,kappa,one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
+0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
+1,:AnotherNode,1,"cXdlcnR5",1,1,,,A,bar,["un","deux","trois"],,,,10.1,,,1.1,,,,
+,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
+

--- a/core/src/main/resources/manyTypesWithArrayLegacy.csv
+++ b/core/src/main/resources/manyTypesWithArrayLegacy.csv
@@ -1,5 +1,7 @@
-_id:id,_labels:label,alpha:short,beta:byte,epsilon:int,eta:long,five:date,four:localdatetime,gamma:char,iota,kappa,one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
-0,:SuperNode,,,,,2020-01-01,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,,17:58:30,18:02:33Z,,,,,
-1,:AnotherNode,1,"cXdlcnR5",1,1,,,A,bar,["un","deux","trois"],,,,10.1,,,1.1,,,,
-,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
+_id:id,_labels:label,alpha:short,beta:byte,epsilon:int,eta:long,five:date,foo,four:localdatetime,gamma:char,iota,kappa,one:datetime,seven,six:duration,theta:double,three:localtime,two:time,zeta:float,_start:id,_end:id,_type:label,rel:point
+0,:SuperNode,,,,,2020-01-01,,2021-06-08T00:00,,,,2018-05-10T10:30+02:00[Europe/Berlin],2020,P14DT16H12M,,17:58:30,12:02:33Z,,,,,
+1,:AnotherNode,12,"cXdlcnR5",1,133,,,,A,bar e " bar,["un","deux","trois"],,,,10.1,,,1.1,,,,
+2,:Bar:Foo:SuperNode,,,,,,bar,,,,,,,,,,,,,,,
+,,,,,,,,,,,,,,,,,,,0,1,REL_TYPE,{x: 56.7, y: 12.78, crs: 'cartesian'}
+,,,,,,,,,,,,,,,,,,,1,2,ANOTHER_REL,
 

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -30,7 +30,7 @@ public class ExportCsvNeo4jAdminTest {
             .format(":ID;born_3D:point;localtime:localtime;time:time;localDateTime:localdatetime;duration:duration;dateTime:datetime;born_2D:point;date:date;:LABEL%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE = String
-            .format("6;{crs:wgs-84-3d,latitude:12.78,longitude:56.7,height:100.0};12:50:35.556;12:50:35.556+01:00;2018-10-30T19:32:24;P5M1DT12H;2018-10-30T12:50:35.556+01:00;{crs:cartesian,x:2.3,y:4.5};2018-10-30;Types%n");
+            .format("6;\"{x: 56.7, y: 12.78, z: 100.0, crs: 'wgs-84-3d'}\";12:50:35.556;12:50:35.556+01:00;2018-10-30T19:32:24;P5M1DT12H;2018-10-30T12:50:35.556+01:00;\"{x: 2.3, y: 4.5, crs: 'cartesian'}\";2018-10-30;Types%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS = String
             .format(":ID;name;street;:LABEL%n");
@@ -55,7 +55,7 @@ public class ExportCsvNeo4jAdminTest {
                     "5;;via Benni;Address%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1 = String
-            .format("3;Via Garibaldi, 7;Andrea;Milano;\"Address1;Address\"%n");
+            .format("3;Via Garibaldi, 7;Andrea;Milano;Address1.Address%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1_IMPORT_TOOL_ARRAY =
             "3;Via Garibaldi, 7;Andrea;Milano;Address1-Address\n";
@@ -65,7 +65,7 @@ public class ExportCsvNeo4jAdminTest {
                     "2;;12;User%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1 = String
-            .format("0;foo;42;true;[a,b,c];\"User1;User\"%n");
+            .format("0;foo;42;true;[\"a\",\"b\",\"c\"];User1.User%n");
 
     private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1_IMPORT_TOOL_ARRAY =
             ":ID;name;age:long;male:boolean;kids:string[];:LABEL\n" +
@@ -102,8 +102,9 @@ public class ExportCsvNeo4jAdminTest {
         String fileName = "query_nodes.csv";
         File dir = new File(directory, fileName);
 
-        TestUtil.testCall(db, "CALL apoc.export.csv.all($fileName,{bulkImport: true, separateHeader: true, delim: ';'})",
-                map("fileName", fileName), r -> {
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($fileName, $config)",
+                map("fileName", fileName, 
+                        "config", map("importToolArrays", false, "bulkImport", true, "arrayDelim", ".", "separateHeader", true, "delim", ';')), r -> {
                     assertEquals(20000L, r.get("batchSize"));
                     assertEquals(1L, r.get("batches"));
                     assertEquals(7L, r.get("nodes"));
@@ -135,7 +136,7 @@ public class ExportCsvNeo4jAdminTest {
     @Test
     public void testExportGraphNeo4jAdminCsv() throws Exception {
         String query = "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                "CALL apoc.export.csv.graph(graph, $fileName,{bulkImport: true, delim: ';'}) " +
+                "CALL apoc.export.csv.graph(graph, $fileName,{importToolArrays: false, bulkImport: true, delim: ';', arrayDelim: '.'}) " +
                 "YIELD nodes, relationships, properties, file, source,format, time " +
                 "RETURN *";
         assertionsExportGraphNeo4jAdmin(query, false);
@@ -144,7 +145,7 @@ public class ExportCsvNeo4jAdminTest {
     @Test
     public void testExportCypherWithIdFieldWithisImportToolArrays() {
         String query = "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                "CALL apoc.export.csv.graph(graph, $fileName, {bulkImport: true, delim: ';', importToolArrays: true, arrayDelim: '-' }) " +
+                "CALL apoc.export.csv.graph(graph, $fileName, {bulkImport: true, delim: ';', arrayDelim: '.', importToolArrays: true, arrayDelim: '-' }) " +
                 "YIELD nodes, relationships, properties, file, source, format, time " +
                 "RETURN *";
         assertionsExportGraphNeo4jAdmin(query, true);

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -281,7 +281,12 @@ public class ExportCsvTest {
         assertResults(fileName, r, source, 6L, 2L, 12L, true);
     }
 
-    private void assertResults(String fileName, Map<String, Object> r, final String source, 
+    public static void assertResults(String fileName, Map<String, Object> r, final String source,
+                                     Long expectedNodes, Long expectedRelationships, Long expectedProperties) {
+        assertResults(fileName, r, source, expectedNodes, expectedRelationships, expectedProperties, true);
+    }
+
+    public static void assertResults(String fileName, Map<String, Object> r, final String source, 
                                Long expectedNodes, Long expectedRelationships, Long expectedProperties, boolean assertPropEquality) {
         assertEquals(expectedNodes, r.get("nodes"));
         assertEquals(expectedRelationships, r.get("relationships"));
@@ -295,7 +300,7 @@ public class ExportCsvTest {
         assertCsvCommon(fileName, r);
     }
 
-    private void assertCsvCommon(String fileName, Map<String, Object> r) {
+    private static void assertCsvCommon(String fileName, Map<String, Object> r) {
         assertEquals(fileName, r.get("file"));
         assertEquals("csv", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -5,8 +5,10 @@ import apoc.graph.Graphs;
 import apoc.meta.Meta;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Result;
@@ -455,11 +457,22 @@ public class ExportCsvTest {
                 (r) -> {
                     String data = (String) r.get("data");
                     Map<String, Object> place = Util.fromJson(data.split(System.lineSeparator())[1], Map.class);
-                    assertEquals(12.78D, (double) place.get("latitude"), 0);
-                    assertEquals(56.7D, (double) place.get("longitude"), 0);
-                    assertEquals(1.1D, (double) place.get("height"), 0);
+                    assertEquals(12.78D, (double) place.get("y"), 0);
+                    assertEquals(56.7D, (double) place.get("x"), 0);
+                    assertEquals(1.1D, (double) place.get("z"), 0);
                 });
         db.executeTransactionally("MATCH (n:Position) DETACH DELETE n");
+    }
+    
+    @Test(expected = RuntimeException.class)
+    public void testFailsIfDelimAndArrayDelimAreEquals() {
+        try {
+            TestUtil.testCall(db, "CALL apoc.export.csv.all('fails.csv' ,{delim: ';'})", (r) -> {});
+        } catch (RuntimeException e) {
+            Throwable except = ExceptionUtils.getRootCause(e);
+            assertEquals("Both delim and arrayDelim are `;`. These configs must be different", except.getMessage());
+            throw e;
+        }
     }
 
     private Consumer<Result> getAndCheckStreamingMetadataQueryMatchAddress(StringBuilder sb)

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -24,7 +24,10 @@ import java.util.function.Consumer;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testResult;
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author mh
@@ -100,7 +103,7 @@ public class ExportCsvTest {
             ",,,,,,,,0,1,KNOWS%n" +
             ",,,,,,,,3,4,NEXT_DELIVERY%n");
 
-    private static File directory = new File("target/import");
+    public static File directory = new File("target/import");
     static { //noinspection ResultOfMethodCallIgnored
         directory.mkdirs();
     }
@@ -117,7 +120,7 @@ public class ExportCsvTest {
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
     }
 
-    private String readFile(String fileName) {
+    public static String readFile(String fileName) {
         return TestUtil.readFileToString(new File(directory, fileName));
     }
 

--- a/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
@@ -20,6 +20,7 @@ import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
 
+
 // Created to not affect ExportCsvTest results
 public class ExportCsvUseTypeTest {
 
@@ -55,13 +56,13 @@ public class ExportCsvUseTypeTest {
     @Test
     public void testExportCsvAll() {
         String fileName = "manyTypes.csv";
-        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
+        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none', importToolArrays: true})", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database", 2L, 1L, 17L));
-        final String expected = Util.readResourceFile("manyTypes.csv");
+        final String expected = Util.readResourceFile(fileName);
         assertEquals(expected, readFile(fileName));
 
         // -- streaming mode
-        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none'})";
+        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none', importToolArrays: true})";
         testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
     }
 
@@ -69,11 +70,24 @@ public class ExportCsvUseTypeTest {
     public void testExportCsvGraph() {
         String fileName = "manyTypes.csv";
         testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                        "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none'}) " +
+                        "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none', importToolArrays: true}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *", map("file", fileName),
                 (r) -> assertResults(fileName, r, "graph", 2L, 1L, 17L));
-        final String expected = Util.readResourceFile("manyTypes.csv");
+        final String expected = Util.readResourceFile(fileName);
         assertEquals(expected, readFile(fileName));
+    }
+
+    @Test
+    public void testExportCsvGraphWithoutImportToolArrays() {
+        String fileName = "manyTypesWithArrayLegacy.csv";
+        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
+                (r) -> assertResults(fileName, r, "database", 2L, 1L, 17L));
+        final String expected = Util.readResourceFile(fileName);
+        assertEquals(expected, readFile(fileName));
+
+        // -- streaming mode
+        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none'})";
+        testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
     }
 }

--- a/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
@@ -1,0 +1,79 @@
+package apoc.export.csv;
+
+import apoc.ApocSettings;
+import apoc.graph.Graphs;
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import static apoc.export.csv.ExportCsvTest.assertResults;
+import static apoc.export.csv.ExportCsvTest.readFile;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+
+// Created to not affect ExportCsvTest results
+public class ExportCsvUseTypeTest {
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, ExportCsvTest.directory.toPath().toAbsolutePath())
+            .withSetting(ApocSettings.apoc_export_file_enabled, true);
+
+
+    @BeforeClass
+    public static void setUp() {
+        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
+        db.executeTransactionally("CREATE (n:SuperNode { one: datetime('2018-05-10T10:30[Europe/Berlin]'), two: time('18:02:33'), three: localtime('17:58:30'), \n" +
+                "four: localdatetime('2021-06-08'), five: date('2020'), six: duration({months: 5, days: 1.5}), seven : '2020'}) \n" +
+                "WITH n CREATE (n)-[:REL_TYPE {rel: point({x: 56.7, y: 12.78, crs: 'cartesian'})}]->(m:AnotherNode)");
+        
+        try(Transaction tx = db.beginTx()) {
+            final Node node = tx.findNodes(Label.label("AnotherNode")).next();
+            // force property type
+            node.setProperty("alpha", (short) 1);
+            node.setProperty("beta", "qwerty".getBytes());
+            node.setProperty("gamma", 'A');
+            node.setProperty("epsilon", 1);
+            node.setProperty("zeta", 1.1F);
+            node.setProperty("eta", 1L);
+            node.setProperty("theta", 10.1D);
+            node.setProperty("iota", "bar");
+            node.setProperty("kappa", new String[] {"un", "deux", "trois"});
+            tx.commit();
+        }
+    }
+
+    @Test
+    public void testExportCsvAll() {
+        String fileName = "manyTypes.csv";
+        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
+                (r) -> assertResults(fileName, r, "database", 2L, 1L, 17L));
+        final String expected = Util.readResourceFile("manyTypes.csv");
+        assertEquals(expected, readFile(fileName));
+
+        // -- streaming mode
+        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none'})";
+        testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
+    }
+
+    @Test
+    public void testExportCsvGraph() {
+        String fileName = "manyTypes.csv";
+        testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none'}) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("file", fileName),
+                (r) -> assertResults(fileName, r, "graph", 2L, 1L, 17L));
+        final String expected = Util.readResourceFile("manyTypes.csv");
+        assertEquals(expected, readFile(fileName));
+    }
+}

--- a/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
@@ -3,95 +3,79 @@ package apoc.export.csv;
 import apoc.ApocSettings;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
-import apoc.util.Util;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
-import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.PointValue;
 
-import static apoc.export.csv.ExportCsvTest.assertResults;
-import static apoc.export.csv.ExportCsvTest.readFile;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
 import static apoc.util.MapUtil.map;
-import static apoc.util.TestUtil.testCall;
-import static org.junit.Assert.assertEquals;
+import static org.neo4j.graphdb.Label.label;
 
 
 // Created to not affect ExportCsvTest results
 public class ExportCsvUseTypeTest {
+    protected static final long EXPECTED_NODES = 3L;
+    protected static final long EXPECTED_RELS = 2L;
+    protected static final long EXPECTED_PROPS = 18L;
+    protected static final String ANOTHER_NODE = "AnotherNode";
 
-    private static final long EXPECTED_NODES = 2L;
-    private static final long EXPECTED_RELS = 1L;
-    private static final long EXPECTED_PROPS = 17L;
+    protected static final Map<String, Object> SUPER_NODE_PROPS = Map.of("one", ZonedDateTime.of(2018, 5, 10, 10, 30, 0,0, ZoneId.of("Europe/Berlin")),
+            "two", OffsetTime.of(12, 2, 33, 0, ZoneOffset.of(GraphDatabaseSettings.db_temporal_timezone.defaultValue().getId())),
+            "three", LocalTime.of(17, 58, 30),
+            "four", LocalDateTime.of(2021, 6, 8, 0, 0, 0),
+            "five", DateValue.parse("2020").asObjectCopy(),
+            "six", DurationValue.parse("P14DT16H12M"),
+            "seven", "2020");
+    
+    protected static final Map<String, Object> ANOTHER_NODE_PROPS = new HashMap<>(Map.of(
+            "alpha", (short) 12,
+            "beta", "qwerty".getBytes(),
+            "gamma", 'A',
+            "epsilon", 1,
+            "zeta", 1.1F,
+            "eta", 133L,
+            "theta", 10.1D,
+            "iota", "bar e \" bar",
+            "kappa", new String[] {"un", "deux", "trois"}
+    ));
+    protected static final Map<String, Object> REL_PROPS = Map.of("rel", PointValue.parse("{x: 56.7, y: 12.78, crs: 'cartesian'}"));
+
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, ExportCsvTest.directory.toPath().toAbsolutePath())
+            .withSetting(ApocSettings.apoc_import_file_enabled, true)
             .withSetting(ApocSettings.apoc_export_file_enabled, true);
 
 
     @BeforeClass
     public static void setUp() {
-        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
-        db.executeTransactionally("CREATE (n:SuperNode { one: datetime('2018-05-10T10:30[Europe/Berlin]'), two: time('18:02:33'), three: localtime('17:58:30'), \n" +
-                "four: localdatetime('2021-06-08'), five: date('2020'), six: duration({months: 5, days: 1.5}), seven : '2020'}) \n" +
-                "WITH n CREATE (n)-[:REL_TYPE {rel: point({x: 56.7, y: 12.78, crs: 'cartesian'})}]->(m:AnotherNode)");
+        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class, ImportCsv.class);
         
+        db.executeTransactionally("CREATE (n:SuperNode $superNodeProps)-[:REL_TYPE $relProps]->(m:AnotherNode), \n" +
+                "(m)-[:ANOTHER_REL]->(:SuperNode:Foo:Bar {foo: 'bar'})", 
+                map("superNodeProps", SUPER_NODE_PROPS, "anotherNodProps", ANOTHER_NODE_PROPS, "relProps", REL_PROPS));
+
         try(Transaction tx = db.beginTx()) {
-            final Node node = tx.findNodes(Label.label("AnotherNode")).next();
-            // force property type
-            node.setProperty("alpha", (short) 1);
-            node.setProperty("beta", "qwerty".getBytes());
-            node.setProperty("gamma", 'A');
-            node.setProperty("epsilon", 1);
-            node.setProperty("zeta", 1.1F);
-            node.setProperty("eta", 1L);
-            node.setProperty("theta", 10.1D);
-            node.setProperty("iota", "bar");
-            node.setProperty("kappa", new String[] {"un", "deux", "trois"});
+            final Node node = tx.findNodes(label(ANOTHER_NODE)).next();
+            // force property types
+            ANOTHER_NODE_PROPS.forEach(node::setProperty);
             tx.commit();
         }
-    }
-
-    @Test
-    public void testExportCsvAll() {
-        String fileName = "manyTypes.csv";
-        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none', importToolArrays: true})", map("file", fileName),
-                (r) -> assertResults(fileName, r, "database", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
-        final String expected = Util.readResourceFile(fileName);
-        assertEquals(expected, readFile(fileName));
-
-        // -- streaming mode
-        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none', importToolArrays: true})";
-        testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
-    }
-
-    @Test
-    public void testExportCsvGraph() {
-        String fileName = "manyTypes.csv";
-        testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                        "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none', importToolArrays: true}) " +
-                        "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", fileName),
-                (r) -> assertResults(fileName, r, "graph", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
-        final String expected = Util.readResourceFile(fileName);
-        assertEquals(expected, readFile(fileName));
-    }
-
-    @Test
-    public void testExportCsvGraphWithoutImportToolArrays() {
-        String fileName = "manyTypesWithArrayLegacy.csv";
-        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
-                (r) -> assertResults(fileName, r, "database", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
-        final String expected = Util.readResourceFile(fileName);
-        assertEquals(expected, readFile(fileName));
-
-        // -- streaming mode
-        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none'})";
-        testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
     }
 }

--- a/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvUseTypeTest.java
@@ -24,6 +24,10 @@ import static org.junit.Assert.assertEquals;
 // Created to not affect ExportCsvTest results
 public class ExportCsvUseTypeTest {
 
+    private static final long EXPECTED_NODES = 2L;
+    private static final long EXPECTED_RELS = 1L;
+    private static final long EXPECTED_PROPS = 17L;
+
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, ExportCsvTest.directory.toPath().toAbsolutePath())
@@ -57,7 +61,7 @@ public class ExportCsvUseTypeTest {
     public void testExportCsvAll() {
         String fileName = "manyTypes.csv";
         testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none', importToolArrays: true})", map("file", fileName),
-                (r) -> assertResults(fileName, r, "database", 2L, 1L, 17L));
+                (r) -> assertResults(fileName, r, "database", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
         final String expected = Util.readResourceFile(fileName);
         assertEquals(expected, readFile(fileName));
 
@@ -73,7 +77,7 @@ public class ExportCsvUseTypeTest {
                         "CALL apoc.export.csv.graph(graph, $file,{useTypes: true, quotes: 'none', importToolArrays: true}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *", map("file", fileName),
-                (r) -> assertResults(fileName, r, "graph", 2L, 1L, 17L));
+                (r) -> assertResults(fileName, r, "graph", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
         final String expected = Util.readResourceFile(fileName);
         assertEquals(expected, readFile(fileName));
     }
@@ -82,7 +86,7 @@ public class ExportCsvUseTypeTest {
     public void testExportCsvGraphWithoutImportToolArrays() {
         String fileName = "manyTypesWithArrayLegacy.csv";
         testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
-                (r) -> assertResults(fileName, r, "database", 2L, 1L, 17L));
+                (r) -> assertResults(fileName, r, "database", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
         final String expected = Util.readResourceFile(fileName);
         assertEquals(expected, readFile(fileName));
 

--- a/core/src/test/java/apoc/export/csv/ExportWithMultiTypes.java
+++ b/core/src/test/java/apoc/export/csv/ExportWithMultiTypes.java
@@ -1,0 +1,54 @@
+package apoc.export.csv;
+
+import apoc.util.Util;
+import org.junit.Test;
+
+import static apoc.export.csv.ExportCsvTest.assertResults;
+import static apoc.export.csv.ExportCsvTest.readFile;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+
+public class ExportWithMultiTypes extends ExportCsvUseTypeTest {
+    
+    @Test
+    public void testExportCsvAll() {
+        String fileName = "manyTypes.csv";
+        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none', importToolArrays: true})", map("file", fileName),
+                (r) -> assertResults(fileName, r, "database", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
+        final String expected = Util.readResourceFile(fileName);
+        assertEquals(expected, readFile(fileName));
+
+        // -- streaming mode
+        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none', importToolArrays: true})";
+        testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
+    }
+
+    @Test
+    public void testExportCsvGraph() {
+        String fileName = "manyTypes.csv";
+        testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.csv.graph(graph, $file, $config) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("file", fileName, 
+                        "config", map("useTypes", true, "quotes", "none", "importToolArrays", true)),
+                (r) -> assertResults(fileName, r, "graph", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
+        final String expected = Util.readResourceFile(fileName);
+        assertEquals(expected, readFile(fileName));
+    }
+
+    @Test
+    public void testExportCsvGraphWithoutImportToolArrays() {
+        String fileName = "manyTypesWithArrayLegacy.csv";
+        testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})", map("file", fileName),
+                (r) -> assertResults(fileName, r, "database", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
+        final String expected = Util.readResourceFile(fileName);
+        assertEquals(expected, readFile(fileName));
+
+        // -- streaming mode
+        String statement = "CALL apoc.export.csv.all(null, {stream:true, useTypes: true, quotes: 'none'})";
+        testCall(db, statement, (r) -> assertEquals(expected, r.get("data")));
+    }
+
+}

--- a/core/src/test/java/apoc/export/csv/ImportExportRoundtripTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportExportRoundtripTest.java
@@ -1,0 +1,104 @@
+package apoc.export.csv;
+
+import org.junit.Test;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.internal.helpers.collection.Iterables;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static apoc.export.csv.CsvLoaderConstants.TYPE_ATTR;
+import static apoc.export.csv.ExportCsvTest.assertResults;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.graphdb.Label.label;
+
+public class ImportExportRoundtripTest extends ExportCsvUseTypeTest {
+    
+    // entities props + 5(:ID, :LABELS, :START_ID, :END_ID and :TYPE)
+    private static final long EXPECTED_EXPORT_PROPS = EXPECTED_PROPS + 5;
+
+    @Test
+    public void testRoundtripCsv() {
+        final String anotherRel = "ANOTHER_REL";
+        final String relType = "REL_TYPE";
+        final String superNode = "SuperNode";
+        final String superNodeFooBar = "SuperNode.Foo.Bar";
+        
+        String ext = ".csv";
+        String fileName = "roundtrip";
+
+        // export file
+        String queryExport = "CALL apoc.export.csv.all($fileName,{importToolArrays: true, quotes: 'always', bulkImport: true, separateHeader: false})";
+        final String exportFileName = fileName + ext;
+        testCall(db, queryExport, map("fileName", exportFileName),
+                (r) -> assertResults(exportFileName, r, "database", EXPECTED_NODES, EXPECTED_RELS, EXPECTED_PROPS));
+
+        // cancel current entities
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+
+        // import file
+        List<Map<String, String>> nodes = List.of(ANOTHER_NODE, superNode, superNodeFooBar).stream()
+                .map(label -> Map.of("fileName", fileName + ".nodes." + label + ext))
+                .collect(Collectors.toList());
+
+        List<Map<String, String>> rels = List.of(relType, anotherRel).stream()
+                .map(type -> Map.of("fileName", fileName + ".relationships." + type + ext))
+                .collect(Collectors.toList());
+
+        testCall(db, "CALL apoc.import.csv($nodes, $rels, {})",
+                map("nodes", nodes, "rels", rels),
+                (r) -> {
+                    assertEquals("file", r.get("source"));
+                    assertEquals(EXPECTED_NODES, r.get("nodes"));
+                    assertEquals(EXPECTED_RELS, r.get("relationships"));
+                    assertEquals(EXPECTED_EXPORT_PROPS, r.get("properties"));
+                });
+
+        // entities assertions
+        try(Transaction tx = db.beginTx()) {
+            final Node anotherNode = tx.findNodes(label(ANOTHER_NODE)).next();
+            final Map<String, Object> expectedProps = new HashMap<>(Map.copyOf(ANOTHER_NODE_PROPS));
+            expectedProps.putAll(Map.of("alpha", 12L, "zeta", 1.1D, "epsilon", 1L, "gamma", "A"));
+            deepEqualsAssertions(anotherNode, expectedProps);
+
+            tx.findNodes(label(superNode)).forEachRemaining(node -> {
+                if (node.getProperty("foo", null) != null) {
+                    final Set<String> actual = Iterables.stream(node.getLabels()).map(Label::name).collect(Collectors.toSet());
+                    assertEquals(Set.of(superNode, "Foo", "Bar"), actual);
+                } else {
+                    deepEqualsAssertions(node, SUPER_NODE_PROPS);
+                }
+            });
+
+            tx.getAllRelationships().forEach(rel -> {
+                if (rel.getType().name().equals(relType)) {
+                    deepEqualsAssertions(rel, REL_PROPS);
+                } else {
+                    assertEquals(anotherRel, rel.getType().name());
+                    assertEquals(Map.of(TYPE_ATTR, anotherRel), rel.getAllProperties());
+                }
+            });
+        }
+    }
+
+    private void deepEqualsAssertions(Entity entity, Map<String, Object> superNodeProps) {
+        superNodeProps.forEach((k, v) -> {
+            final Object property = entity.getProperty(k);
+            assertTrue("Expected: " + v + ", actual: " + property, Objects.deepEquals(v, property));
+        });
+    }
+}

--- a/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
@@ -321,6 +321,37 @@ RETURN file, nodes, relationships, properties, data
 |===
 
 
+=== Export with typing
+The `apoc.export.csv.graph` and  `apoc.export.csv.all` procedures allow you to insert in the header the dataType,
+in order to be used from, for example, the link:https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/#import-tool-header-format/[Neo4j import tool's header format].
+
+So, with the following dataset:
+
+[source,cypher]
+----
+CREATE (n:SuperNode { one: datetime('2018-05-10T10:30[Europe/Berlin]'), two: time('18:02:33'), three: localtime('17:58:30'),
+        four: localdatetime('2021-06-08'), five: date('2020'), six: duration({months: 5, days: 1.5}), seven : '2020'})
+WITH n CREATE (n)-[:REL_TYPE {rel: point({x: 56.7, y: 12.78, crs: 'cartesian'})}]->(m:AnotherNode);
+----
+
+we can execute:
+
+[source,cypher]
+----
+CALL apoc.export.csv.all($file, {useTypes: true, quotes: 'none'})
+----
+
+with this result:
+
+[source,csv]
+----
+_id:id,_labels:label,five:date,four:localdatetime,one:datetime,seven,six:duration,three:localtime,two:time,_start:id,_end:id,_type:label,rel:point
+0,:SuperNode,2020-01-01,2021-06-08T00:00,2018-05-10T10:30+02:00[Europe/Berlin],2020,P5M1DT12H,17:58:30,18:02:33Z,,,,
+1,:AnotherNode,,,,,,,,,,,
+,,,,,,,,,0,1,REL_TYPE,{"crs":"cartesian","x":56.7,"y":12.78,"z":null}
+----
+
+
 [[export-cypher-query-csv]]
 === Export results of Cypher query to CSV
 

--- a/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
@@ -376,6 +376,50 @@ _id:id,_labels:label,propList
 
 This consideration is also valid with `{bulkImport: true}`.
 
+=== Round trip CSV
+
+We can use the `apoc.export.csv.*` and the `apoc.import.csv` procedures to export and import data in another db.
+For example, with this dataset:
+
+[source,cypher]
+----
+CREATE (n:SuperNode $superNodeProps)-[:REL_TYPE $relProps]->(m:AnotherNode), 
+(m)-[:ANOTHER_REL]->(:SuperNode:Foo:Bar {foo: 'bar'})
+----
+
+we can execute, with `bulkImport` mode:
+
+[source,cypher]
+----
+CALL apoc.export.csv.all('rountrip.csv',
+{importToolArrays: true, quotes: 'always', bulkImport: true, separateHeader: false})
+----
+
+This will create 5 files, 3 for nodes (`roundtrip.nodes.SuperNode.csv`, `roundtrip.nodes.AnotherNode.csv`, `roundtrip.nodes.SuperNode.Foo.Bar.csv`) 
+and 2 for relationships (`roundtrip.relationships.ANOTHER_REL.csv`, `roundtrip.relationships.REL_TYPE.csv`).
+
+Therefore, we can execute, in another db:
+
+[source,cypher]
+----
+CALL apoc.import.csv(
+  [
+    {fileName: 'roundtrip.nodes.SuperNode.csv'},
+    {fileName: 'roundtrip.nodes.AnotherNode.csv'},
+    {fileName: 'rroundtrip.nodes.SuperNode.Foo.Bar.csv'}
+  ], 
+  [
+    {fileName: 'roundtrip.relationships.ANOTHER_REL.csv'},
+    {fileName: 'roundtrip.relationships.REL_TYPE.csv'},
+  ], 
+{})
+----
+
+Note that it's not necessary specify `labels` key in files maps, but only `fileName`, because node files have `:LABEL` field and relationship files have `:TYPE` field, similarly to https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin/neo4j-admin-import/#import-tool-header-format-nodes[Neo4j Import Tool]
+
+The above query will recreate the initial dataset.
+
+
 [[export-cypher-query-csv]]
 === Export results of Cypher query to CSV
 

--- a/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
@@ -352,6 +352,30 @@ _id:id,_labels:label,five:date,four:localdatetime,one:datetime,seven,six:duratio
 ----
 
 
+Note that, in case of lists,
+to export in a format valid for neo4j-admin-import,
+you need to add the configuration `{importToolArrays: true}`,
+otherwise the header will not have the wording `:DataType[]`
+and the array will be converted using the `com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString()`.
+That is, with a node `(n:Test {propList: ["a", "b", "c"]})`,
+using `{importToolArrays: true, arrayDelim: ';'}`, we would have:
+
+[source,csv]
+----
+_id:id,_labels:label,propList:string[]
+0,:Test,a;b;c
+----
+
+otherwise, with `{importToolArrays: false}`:
+
+[source,csv]
+----
+_id:id,_labels:label,propList
+0,:Test,["a","b","c"]
+----
+
+This consideration is also valid with `{bulkImport: true}`.
+
 [[export-cypher-query-csv]]
 === Export results of Cypher query to CSV
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.csv.adoc
@@ -193,3 +193,46 @@ In the above csv:
 
 - the first row has two values that do not specify an explicit timezone. The value for `date1` will use the `Europe/Stockholm` time zone that was specified for that field in the header. The value for `date2` will use the configured default time zone of the database.
 - in the second row, both `date1` and `date2` set the time zone explicitly to be `Europe/Berlin`. This overrides the header definition for date1, as well as the configured default time zone of the database.
+
+=== Round trip CSV
+
+We can use the `apoc.export.csv.*` and the `apoc.import.csv` procedures to export and import data in another db.
+For example, with this dataset:
+
+[source,cypher]
+----
+CREATE (n:SuperNode {one: datetime(), two: 123})-[:REL_TYPE {relProp: point({x: 1, y: 1, z: 1})}]->(m:AnotherNode), 
+(m)-[:ANOTHER_REL]->(:SuperNode:Foo:Bar {foo: 'bar'})
+----
+
+we can execute, with `bulkImport` mode:
+
+[source,cypher]
+----
+CALL apoc.export.csv.all('roundtrip.csv',
+{importToolArrays: true, quotes: 'always', bulkImport: true, separateHeader: false})
+----
+
+This will create 5 files, 3 for nodes (`roundtrip.nodes.SuperNode.csv`, `roundtrip.nodes.AnotherNode.csv`, `roundtrip.nodes.SuperNode.Foo.Bar.csv`)
+and 2 for relationships (`roundtrip.relationships.ANOTHER_REL.csv`, `roundtrip.relationships.REL_TYPE.csv`).
+
+Therefore, we can execute, in another db:
+
+[source,cypher]
+----
+CALL apoc.import.csv(
+  [
+    {fileName: 'roundtrip.nodes.SuperNode.csv'},
+    {fileName: 'roundtrip.nodes.AnotherNode.csv'},
+    {fileName: 'roundtrip.nodes.SuperNode.Foo.Bar.csv'}
+  ], 
+  [
+    {fileName: 'roundtrip.relationships.ANOTHER_REL.csv'},
+    {fileName: 'roundtrip.relationships.REL_TYPE.csv'}
+  ], 
+{})
+----
+
+Note that it's not necessary specify `labels` key in files maps, but only `fileName`, because node files have `:LABEL` field and relationship files have `:TYPE` field, similarly to https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin/neo4j-admin-import/#import-tool-header-format-nodes[Neo4j Import Tool]
+
+The above query will recreate the initial dataset.


### PR DESCRIPTION
Fixes 1369
Fixes 1979 
Fixes 1757

Currently append propType to propName, so in `collectProps()` get the wrong prop.

- removed `cleanPoint()`: this always removes quotes 
- testFailsIfDelimAndArrayDelimAreEquals
- roundtrip example (issue 1979)
- Added support to all `neo4j-admin-tool` types
- Added array support with `bulkImport` mode
- Added boolean config `importToolArrays` (default: false) to maintain current behavior. With `false` the array will be parsed using `ObjectMapper.writeValueAsString()`, with `true` will be exported a neo4j-admin import compatible value (that is, with header like `nameProp:dataType[]` and with properties like `a;b;c` instead of `[a,b,c]`