### PR TITLE
Fixes #1625: apoc periodic repeat should have an option to tolerate errors

### DIFF
--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -4,6 +4,7 @@ import apoc.Pools;
 import apoc.util.Util;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
@@ -173,9 +174,10 @@ public class Periodic {
     public Stream<JobInfo> repeat(@Name("name") String name, @Name("statement") String statement, @Name("rate") long rate, @Name(value = "config", defaultValue = "{}") Map<String,Object> config ) {
         validateQuery(statement);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
-        JobInfo info = schedule(name, () -> {
-            db.executeTransactionally(statement, params);
-        },0,rate);
+        long retries = Util.toLong(config.getOrDefault("retries", 0L));
+        boolean tolerateErrors = Util.toBoolean(config.getOrDefault("tolerateErrors", false));
+        JobInfo info = schedule(name, () -> Util.retryInTx(
+                        log, db, tx -> tx.execute(statement, params), 0, retries, r -> {}, tolerateErrors),0,rate);
         return Stream.of(info);
     }
 

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -175,9 +175,9 @@ public class Periodic {
         validateQuery(statement);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         long retries = Util.toLong(config.getOrDefault("retries", 0L));
-        boolean tolerateErrors = Util.toBoolean(config.getOrDefault("tolerateErrors", false));
+        boolean failOnError = Util.toBoolean(config.getOrDefault("failOnError", false));
         JobInfo info = schedule(name, () -> Util.retryInTx(
-                        log, db, tx -> tx.execute(statement, params), 0, retries, r -> {}, tolerateErrors),0,rate);
+                        log, db, tx -> tx.execute(statement, params), 0, retries, r -> {}, failOnError),0,rate);
         return Stream.of(info);
     }
 

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -210,14 +210,14 @@ public class Util {
         return retryInTx(log, db, function, retry, maxRetries, callbackForRetry, false);
     }
 
-    public static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry, boolean tolerateError) {
+    public static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry, boolean tolerateErrors) {
         try (Transaction tx = db.beginTx()) {
             T result = function.apply(tx);
             tx.commit();
             return result;
         } catch (Exception e) {
             if (retry >= maxRetries) {
-                if (tolerateError) {
+                if (tolerateErrors) {
                     if (log != null) {
                         log.error(String.format("Max number of attempts (%d) reached.", maxRetries));
                     }
@@ -231,7 +231,7 @@ public class Util {
             }
             callbackForRetry.accept(retry);
             Util.sleep(100);
-            return retryInTx(log, db, function, retry + 1, maxRetries, callbackForRetry, tolerateError);
+            return retryInTx(log, db, function, retry + 1, maxRetries, callbackForRetry, tolerateErrors);
         }
     }
 

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -207,18 +207,31 @@ public class Util {
     }
 
     public static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry) {
+        return retryInTx(log, db, function, retry, maxRetries, callbackForRetry, false);
+    }
+
+    public static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry, boolean tolerateError) {
         try (Transaction tx = db.beginTx()) {
             T result = function.apply(tx);
             tx.commit();
             return result;
         } catch (Exception e) {
-            if (retry >= maxRetries) throw e;
+            if (retry >= maxRetries) {
+                if (tolerateError) {
+                    if (log != null) {
+                        log.error(String.format("Max number of attempts (%d) reached.", maxRetries));
+                    }
+                    return null;
+                } else {
+                    throw e;
+                }
+            }
             if (log!=null) {
                 log.warn("Retrying operation %d of %d", retry, maxRetries);
             }
             callbackForRetry.accept(retry);
             Util.sleep(100);
-            return retryInTx(log, db, function, retry + 1, maxRetries, callbackForRetry);
+            return retryInTx(log, db, function, retry + 1, maxRetries, callbackForRetry, tolerateError);
         }
     }
 

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -210,14 +210,14 @@ public class Util {
         return retryInTx(log, db, function, retry, maxRetries, callbackForRetry, false);
     }
 
-    public static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry, boolean tolerateErrors) {
+    public static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry, boolean failOnError) {
         try (Transaction tx = db.beginTx()) {
             T result = function.apply(tx);
             tx.commit();
             return result;
         } catch (Exception e) {
             if (retry >= maxRetries) {
-                if (tolerateErrors) {
+                if (failOnError) {
                     if (log != null) {
                         log.error(String.format("Max number of attempts (%d) reached.", maxRetries));
                     }
@@ -231,7 +231,7 @@ public class Util {
             }
             callbackForRetry.accept(retry);
             Util.sleep(100);
-            return retryInTx(log, db, function, retry + 1, maxRetries, callbackForRetry, tolerateErrors);
+            return retryInTx(log, db, function, retry + 1, maxRetries, callbackForRetry, failOnError);
         }
     }
 

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -7,6 +7,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.common.DependencyResolver;
 import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransientTransactionFailureException;
@@ -25,6 +26,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
@@ -32,6 +36,8 @@ import static apoc.periodic.Periodic.applyPlanner;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;
+import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -42,6 +48,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.driver.internal.util.Iterables.count;
+import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class PeriodicTest {
 
@@ -504,6 +511,55 @@ public class PeriodicTest {
                 "MATCH (p:Person {name: 'John Doe'}) RETURN p.name AS name",
                 row -> assertEquals( row.get( "name" ), "John Doe" )
         );
+    }
+
+    @Test
+    public void testRepeatParams1() throws InterruptedException {
+        final List<String> labels = IntStream.range(0, 20).mapToObj(i -> UUID.randomUUID().toString()).collect(toList());
+        // rate set to 1 second
+        // without tolerateErrors, any of these procedures should throw an exception because of toInteger(rand()*2) = 0 or 1
+        // and then they don't repeat after a second
+        labels.forEach(label -> db.executeTransactionally(
+                format("CALL apoc.periodic.repeat('%1$s', 'CREATE (n:`%1$s` {id: 1 / toInteger(rand()*2)})', 1, {tolerateErrors: true})", label)));
+        Thread.sleep(10000);
+
+        testCall(db, "CALL apoc.periodic.list() YIELD name RETURN count(name) as count", r -> assertEquals(20L, r.get("count")));
+
+        labels.forEach(label -> {
+            testCall(db, format("MATCH (n:`%s`) RETURN count(n) as count", label), r -> assertTrue((long) r.get("count") > 0));
+            db.executeTransactionally(format("CALL apoc.periodic.cancel('%s')", label));
+        });
+    }
+
+    @Test
+    public void testRepeatParamsWithRetry() throws InterruptedException {
+        final List<String> labels = IntStream.range(0, 20).mapToObj(i -> UUID.randomUUID().toString()).collect(toList());
+        // rate set to 60 seconds
+        // without retries, any of these procedures should not create node because of toInteger(rand()*2) = 0 or 1
+        labels.forEach(label -> db.executeTransactionally(
+                format("CALL apoc.periodic.repeat('%1$s', 'CREATE (n:`%1$s` {id: 1 / toInteger(rand()*2)})', 60, {retries: 10})", label)));
+
+        Thread.sleep(3000);
+        
+        labels.forEach(label -> {
+            testCall(db, format("MATCH (n:`%s`) RETURN count(n) as count", label), r -> assertTrue((long) r.get("count") > 0));
+            db.executeTransactionally(format("CALL apoc.periodic.cancel('%s')", label));
+        });
+    }
+    
+    @Test
+    public void testRepeatParamsWithRetryAndTolerate() {
+        // 2 "certainly failing" procedures, one with tolerateErrors: true and one with tolerateErrors: false
+        db.executeTransactionally("CALL apoc.periodic.repeat('retryAndTolerate', 'MATCH (n:Chuck) WITH count(n) as c CREATE (:Norris {id: 1/c})', 1, {retries: 3, tolerateErrors: true})");
+        db.executeTransactionally("CALL apoc.periodic.repeat('retryAndNOTolerate', 'MATCH (n:Chuck) WITH count(n) as c CREATE (:Norris {id: 1/c})', 1, {retries: 3, tolerateErrors: false})");
+        assertEventually(() -> db.executeTransactionally("CALL apoc.periodic.list()",
+                emptyMap(), (r) -> {
+                    final ResourceIterator<String> nameIterator = r.columnAs("name");
+                    // only first periodic remains, because of 'tolerateErrors: true'
+                    return nameIterator.next().equals("retryAndTolerate") && !nameIterator.hasNext();
+                }), (value) -> value, 15L, TimeUnit.SECONDS);
+
+        db.executeTransactionally("CALL apoc.periodic.cancel('retryAndTolerate')");
     }
 
     private long tryReadCount(int maxAttempts, String statement, long expected) throws InterruptedException {

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -514,21 +514,24 @@ public class PeriodicTest {
     }
 
     @Test
-    public void testRepeatParams1() throws InterruptedException {
+    public void testRepeatParamsWithFailOnErrors() throws InterruptedException {
         final List<String> labels = IntStream.range(0, 20).mapToObj(i -> UUID.randomUUID().toString()).collect(toList());
         // rate set to 1 second
-        // without tolerateErrors, any of these procedures should throw an exception because of toInteger(rand()*2) = 0 or 1
+        // without failOnError, any of these procedures should throw an exception because of toInteger(rand()*2) = 0 or 1
         // and then they don't repeat after a second
         labels.forEach(label -> db.executeTransactionally(
-                format("CALL apoc.periodic.repeat('%1$s', 'CREATE (n:`%1$s` {id: 1 / toInteger(rand()*2)})', 1, {tolerateErrors: true})", label)));
-        Thread.sleep(10000);
+                format("CALL apoc.periodic.repeat('%1$s', 'CREATE (n:`%1$s` {id: 1 / toInteger(rand()*2)})', 1, {failOnError: true})", label)));
 
         testCall(db, "CALL apoc.periodic.list() YIELD name RETURN count(name) as count", r -> assertEquals(20L, r.get("count")));
 
-        labels.forEach(label -> {
-            testCall(db, format("MATCH (n:`%s`) RETURN count(n) as count", label), r -> assertTrue((long) r.get("count") > 0));
-            db.executeTransactionally(format("CALL apoc.periodic.cancel('%s')", label));
-        });
+        Thread.sleep(10000);
+        assertEventually(() -> db.executeTransactionally("UNWIND $labels AS label WITH label MATCH (n) WHERE labels(n) = [label] RETURN label, count(n) as count",
+            map("labels", labels), (r) -> {
+                final ResourceIterator<Long> nameIterator = r.columnAs("count");
+                return Iterators.stream(nameIterator).allMatch(count -> count > 0);
+            }), (value) -> value, 15L, TimeUnit.SECONDS);
+        
+        labels.forEach(label -> db.executeTransactionally(format("CALL apoc.periodic.cancel('%s')", label)));
     }
 
     @Test
@@ -549,13 +552,13 @@ public class PeriodicTest {
     
     @Test
     public void testRepeatParamsWithRetryAndTolerate() {
-        // 2 "certainly failing" procedures, one with tolerateErrors: true and one with tolerateErrors: false
-        db.executeTransactionally("CALL apoc.periodic.repeat('retryAndTolerate', 'MATCH (n:Chuck) WITH count(n) as c CREATE (:Norris {id: 1/c})', 1, {retries: 3, tolerateErrors: true})");
-        db.executeTransactionally("CALL apoc.periodic.repeat('retryAndNOTolerate', 'MATCH (n:Chuck) WITH count(n) as c CREATE (:Norris {id: 1/c})', 1, {retries: 3, tolerateErrors: false})");
+        // 2 "certainly failing" procedures, one with failOnError: true and one with failOnError: false
+        db.executeTransactionally("CALL apoc.periodic.repeat('retryAndTolerate', 'MATCH (n:Chuck) WITH count(n) as c CREATE (:Norris {id: 1/c})', 1, {retries: 3, failOnError: true})");
+        db.executeTransactionally("CALL apoc.periodic.repeat('retryAndNOTolerate', 'MATCH (n:Chuck) WITH count(n) as c CREATE (:Norris {id: 1/c})', 1, {retries: 3, failOnError: false})");
         assertEventually(() -> db.executeTransactionally("CALL apoc.periodic.list()",
                 emptyMap(), (r) -> {
                     final ResourceIterator<String> nameIterator = r.columnAs("name");
-                    // only first periodic remains, because of 'tolerateErrors: true'
+                    // only first periodic remains, because of 'failOnError: true'
                     return nameIterator.next().equals("retryAndTolerate") && !nameIterator.hasNext();
                 }), (value) -> value, 15L, TimeUnit.SECONDS);
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.periodic.repeat.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.periodic.repeat.adoc
@@ -31,4 +31,19 @@ RETURN count(*) AS count;
 | 110
 |===
 
+We can also configure a retry number for every execution:
+
+[source,cypher]
+----
+CALL apoc.periodic.repeat("create-people", "QUERY_WHICH_CAN_FAIL", 1, {retries: 5});
+----
+
+Moreover, we can pass a `tolerateErrors`, to continue the execution in case of failed query, without interrupt the procedure.
+
+[source,cypher]
+----
+CALL apoc.periodic.repeat("create-people", "QUERY_WHICH_CAN_FAIL", 1, {tolerateErrors: true});
+----
+
+
 If we want to cancel this job, we can use the xref::overview/apoc.periodic/apoc.periodic.cancel.adoc[] procedure.

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.periodic.repeat.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.periodic.repeat.adoc
@@ -38,11 +38,11 @@ We can also configure a retry number for every execution:
 CALL apoc.periodic.repeat("create-people", "QUERY_WHICH_CAN_FAIL", 1, {retries: 5});
 ----
 
-Moreover, we can pass a `tolerateErrors`, to continue the execution in case of failed query, without interrupt the procedure.
+Moreover, we can pass a `failOnError`, to continue the execution in case of failed query, without interrupt the procedure.
 
 [source,cypher]
 ----
-CALL apoc.periodic.repeat("create-people", "QUERY_WHICH_CAN_FAIL", 1, {tolerateErrors: true});
+CALL apoc.periodic.repeat("create-people", "QUERY_WHICH_CAN_FAIL", 1, {failOnError: true});
 ----
 
 


### PR DESCRIPTION
Fixes #1625

- added `tolerateErrors` (skip current execution)
- added `retries` (retry current execution)