### PR TITLE
Fixes #2015: Various bugs with Neo4j 4.3 indexes

### DIFF
--- a/core/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
+++ b/core/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
@@ -103,6 +103,14 @@ public class NodesAndRelsSubGraph implements SubGraph {
     }
 
     @Override
+    public Iterable<IndexDefinition> getIndexes(RelationshipType type) {
+        if (!types.contains(type.name())) {
+            return Collections.emptyList();
+        }
+        return tx.schema().getIndexes(type);
+    }
+
+    @Override
     public Iterable<RelationshipType> getAllRelationshipTypesInUse() {
         return types.stream()
                 .map(RelationshipType::withName)

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -614,14 +614,14 @@ public class Meta {
         for (RelationshipType type : graph.getAllRelationshipTypesInUse()) {
             metaData.put(type.name(), new LinkedHashMap<>(10));
             relConstraints.put(type.name(),graph.getConstraints(type));
-            relIndexes.put(type.name(), getSetIndexed(graph.getIndexes(type)));
+            relIndexes.put(type.name(), getIndexedProperties(graph.getIndexes(type)));
         }
         for (Label label : graph.getAllLabelsInUse()) {
             Map<String,MetaResult> nodeMeta = new LinkedHashMap<>(50);
             String labelName = label.name();
             metaData.put(labelName, nodeMeta);
             Iterable<ConstraintDefinition> constraints = graph.getConstraints(label);
-            Set<String> indexed = getSetIndexed(graph.getIndexes(label));
+            Set<String> indexed = getIndexedProperties(graph.getIndexes(label));
             long labelCount = graph.countsForNode(label);
             long sample = getSampleForLabelCount(labelCount, config.getSample());
             Iterator<Node> nodes = graph.findNodes(label);
@@ -637,14 +637,11 @@ public class Meta {
         return metaData;
     }
 
-    private Set<String> getSetIndexed(Iterable<IndexDefinition> indexes) {
-        Set<String> indexed = new LinkedHashSet<>();
-        for (IndexDefinition index : indexes) {
-            for (String prop : index.getPropertyKeys()) {
-                indexed.add(prop);
-            }
-        }
-        return indexed;
+    private Set<String> getIndexedProperties(Iterable<IndexDefinition> indexes) {
+        return Iterables.stream(indexes)
+                .map(IndexDefinition::getPropertyKeys)
+                .flatMap(Iterables::stream)
+                .collect(Collectors.toSet());
     }
 
     private Map<String, Long> getLabelCountStore() {

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -610,21 +610,18 @@ public class Meta {
 
         Set<RelationshipType> types = Iterables.asSet(graph.getAllRelationshipTypesInUse());
         Map<String, Iterable<ConstraintDefinition>> relConstraints = new HashMap<>(20);
+        Map<String, Set<String>> relIndexes = new HashMap<>();
         for (RelationshipType type : graph.getAllRelationshipTypesInUse()) {
             metaData.put(type.name(), new LinkedHashMap<>(10));
             relConstraints.put(type.name(),graph.getConstraints(type));
+            relIndexes.put(type.name(), getSetIndexed(graph.getIndexes(type)));
         }
         for (Label label : graph.getAllLabelsInUse()) {
             Map<String,MetaResult> nodeMeta = new LinkedHashMap<>(50);
             String labelName = label.name();
             metaData.put(labelName, nodeMeta);
             Iterable<ConstraintDefinition> constraints = graph.getConstraints(label);
-            Set<String> indexed = new LinkedHashSet<>();
-            for (IndexDefinition index : graph.getIndexes(label)) {
-                for (String prop : index.getPropertyKeys()) {
-                    indexed.add(prop);
-                }
-            }
+            Set<String> indexed = getSetIndexed(graph.getIndexes(label));
             long labelCount = graph.countsForNode(label);
             long sample = getSampleForLabelCount(labelCount, config.getSample());
             Iterator<Node> nodes = graph.findNodes(label);
@@ -632,12 +629,22 @@ public class Meta {
             while (nodes.hasNext()) {
                 Node node = nodes.next();
                 if(count++ % sample == 0) {
-                    addRelationships(metaData, nodeMeta, labelName, node, relConstraints, types);
+                    addRelationships(metaData, nodeMeta, labelName, node, relConstraints, types, relIndexes);
                     addProperties(nodeMeta, labelName, constraints, indexed, node, node);
                 }
             }
         }
         return metaData;
+    }
+
+    private Set<String> getSetIndexed(Iterable<IndexDefinition> indexes) {
+        Set<String> indexed = new LinkedHashSet<>();
+        for (IndexDefinition index : indexes) {
+            for (String prop : index.getPropertyKeys()) {
+                indexed.add(prop);
+            }
+        }
+        return indexed;
     }
 
     private Map<String, Long> getLabelCountStore() {
@@ -754,7 +761,8 @@ public class Meta {
                     entityProperties.put(entityDataKey, MapUtil.map(
                             "type", metaResult.type,
                             "array", metaResult.array,
-                            "existence", metaResult.existence));
+                            "existence", metaResult.existence,
+                            "indexed", metaResult.index));
                 }
             }
             if (isRelationship) {
@@ -782,7 +790,9 @@ public class Meta {
                                   String labelName,
                                   Node node,
                                   Map<String, Iterable<ConstraintDefinition>> relConstraints,
-                                  Set<RelationshipType> types) {
+                                  Set<RelationshipType> types,
+            Map<String, Set<String >> relIndexes
+    ) {
         StreamSupport.stream(node.getRelationshipTypes().spliterator(), false)
                 .filter(type -> types.contains(type))
                 .forEach(type -> {
@@ -792,17 +802,19 @@ public class Meta {
                     String typeName = type.name();
 
                     Iterable<ConstraintDefinition> constraints = relConstraints.get(typeName);
+                    Set<String> indexes = relIndexes.get(typeName);
                     if (!nodeMeta.containsKey(typeName)) nodeMeta.put(typeName, new MetaResult(labelName,typeName));
 //            int in = node.getDegree(type, Direction.INCOMING);
 
                     Map<String, MetaResult> typeMeta = metaData.get(typeName);
                     if (!typeMeta.containsKey(labelName)) typeMeta.put(labelName,new MetaResult(typeName,labelName));
                     MetaResult relMeta = nodeMeta.get(typeName);
-                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints);
+                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints, indexes);
                 });
     }
 
-    private void addOtherNodeInfo(Node node, String labelName, int out, RelationshipType type, MetaResult relMeta, Map<String, MetaResult> typeMeta, Iterable<ConstraintDefinition> relConstraints) {
+    private void addOtherNodeInfo(Node node, String labelName, int out, RelationshipType type, MetaResult relMeta, Map<String, MetaResult> typeMeta,
+                                  Iterable<ConstraintDefinition> relConstraints, Set<String> indexes) {
         MetaResult relNodeMeta = typeMeta.get(labelName);
         relMeta.elementType(Types.of(node).name());
         for (Relationship rel : node.getRelationships(Direction.OUTGOING, type)) {
@@ -811,7 +823,7 @@ public class Meta {
             int in = endNode.getDegree(type, Direction.INCOMING);
             relMeta.inc().other(labels).rel(out , in);
             relNodeMeta.inc().other(labels).rel(out,in);
-            addProperties(typeMeta, type.name(), relConstraints, Collections.emptySet(), rel, node);
+            addProperties(typeMeta, type.name(), relConstraints, indexes, rel, node);
             relNodeMeta.elementType(Types.RELATIONSHIP.name());
         }
     }

--- a/core/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
+++ b/core/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Created by alberto.delazzari on 04/07/17.
  */
-public class ConstraintRelationshipInfo {
+public class IndexConstraintRelationshipInfo {
 
     public final String name;
 
@@ -15,7 +15,7 @@ public class ConstraintRelationshipInfo {
 
     public final String status;
 
-    public ConstraintRelationshipInfo(String name, String type, List<String> properties, String status) {
+    public IndexConstraintRelationshipInfo(String name, String type, List<String> properties, String status) {
         this.name = name;
         this.type = type;
         this.properties = properties;

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -52,9 +52,6 @@ public class Schemas {
     @Context
     public KernelTransaction ktx;
 
-    @Context
-    public Pools pools;
-
     @Procedure(value = "apoc.schema.assert", mode = Mode.SCHEMA)
     @Description("apoc.schema.assert({indexLabel:[[indexKeys]], ...}, {constraintLabel:[constraintKeys], ...}, dropExisting : true) yield label, key, keys, unique, action - drops all other existing indexes and constraints when `dropExisting` is `true` (default is `true`), and asserts that at the end of the operation the given indexes and unique constraints are there, each label:key pair is considered one constraint/label. Non-constraint indexes can define compound indexes with label:[key1,key2...] pairings.")
     public Stream<AssertSchemaResult> schemaAssert(@Name("indexes") Map<String, List<Object>> indexes, @Name("constraints") Map<String, List<Object>> constraints, @Name(value = "dropExisting", defaultValue = "true") boolean dropExisting) throws ExecutionException, InterruptedException {
@@ -363,11 +360,11 @@ public class Schemas {
             Stream<IndexConstraintNodeInfo> constraintNodeInfoStream = StreamSupport.stream(constraintsIterator.spliterator(), false)
                     .filter(constraintDescriptor -> constraintDescriptor.type().equals(org.neo4j.internal.schema.ConstraintType.EXISTS))
                     .map(constraintDescriptor -> this.nodeInfoFromConstraintDescriptor(constraintDescriptor, tokenRead))
-                    .sorted(Comparator.comparing(i -> i.label.toString()));
+                    .sorted(Comparator.comparing(i -> i.label));
 
             Stream<IndexConstraintNodeInfo> indexNodeInfoStream = StreamSupport.stream(indexesIterator.spliterator(), false)
                     .map(indexDescriptor -> this.nodeInfoFromIndexDefinition(indexDescriptor, schemaRead, tokenRead))
-                    .sorted(Comparator.comparing(i -> i.label.toString()));
+                    .sorted(Comparator.comparing(i -> i.label));
 
             return Stream.of(constraintNodeInfoStream, indexNodeInfoStream).flatMap(e -> e);
         }

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -149,61 +149,53 @@ public class Schemas {
     }
 
     public List<AssertSchemaResult> assertIndexes(Map<String, List<Object>> indexes0, boolean dropExisting) throws ExecutionException, InterruptedException, IllegalArgumentException {
-        // to prevent transaction locks (e.g. with lookup index and assert with creation schema)
-        try (Transaction transaction = db.beginTx()) {
-            Schema schema = transaction.schema();
-            Map<String, List<Object>> indexes = copyMapOfObjects(indexes0);
-            List<AssertSchemaResult> result = new ArrayList<>(indexes.size());
+        Schema schema = tx.schema();
+        Map<String, List<Object>> indexes = copyMapOfObjects(indexes0);
+        List<AssertSchemaResult> result = new ArrayList<>(indexes.size());
 
-            for (IndexDefinition definition : schema.getIndexes()) {
-                if (definition.isConstraintIndex())
-                    continue;
+        for (IndexDefinition definition : schema.getIndexes()) {
+            if (!definition.isNodeIndex())
+                continue;
+            if (definition.getIndexType() == IndexType.LOOKUP)
+                continue;
+            if (definition.isConstraintIndex())
+                continue;
 
-                boolean isNode = definition.isNodeIndex();
-                String label;
-                boolean isLookupIdx = definition.getIndexType() == IndexType.LOOKUP;
-                if (isNode) {
-                    label = isLookupIdx ? TOKEN_LABEL : Iterables.single(definition.getLabels()).name();
-                } else {
-                    label = isLookupIdx ? TOKEN_REL_TYPE : Iterables.single(definition.getRelationshipTypes()).name();
-                }
+            String label = Iterables.single(definition.getLabels()).name();
+            List<String> keys = new ArrayList<>();
+            definition.getPropertyKeys().forEach(keys::add);
 
-                List<String> keys = new ArrayList<>();
-                definition.getPropertyKeys().forEach(keys::add);
-
-                AssertSchemaResult info = new AssertSchemaResult(label, keys);
-                if (indexes.containsKey(label)) {
-                    if (keys.size() > 1) {
-                        indexes.get(label).remove(keys);
-                    } else if (keys.size() == 1) {
-                        indexes.get(label).remove(keys.get(0));
-                    } else
-                        throw new IllegalArgumentException(String.format("%s given with no keys.", isNode ? "Label" : "Type"));
-                }
-
-                if (dropExisting) {
-                    definition.drop();
-                    info.dropped();
-                }
-
-                result.add(info);
+            AssertSchemaResult info = new AssertSchemaResult(label, keys);
+            if(indexes.containsKey(label)) {
+                if (keys.size() > 1) {
+                    indexes.get(label).remove(keys);
+                } else if (keys.size() == 1) {
+                    indexes.get(label).remove(keys.get(0));
+                } else
+                    throw new IllegalArgumentException("Label given with no keys.");
             }
 
-            if (dropExisting)
-                indexes = copyMapOfObjects(indexes0);
-
-            for (Map.Entry<String, List<Object>> index : indexes.entrySet()) {
-                for (Object key : index.getValue()) {
-                    if (key instanceof String) {
-                        result.add(createSinglePropertyIndex(schema, index.getKey(), (String) key));
-                    } else if (key instanceof List) {
-                        result.add(createCompoundIndex(index.getKey(), (List<String>) key, transaction));
-                    }
-                }
+            if (dropExisting) {
+                definition.drop();
+                info.dropped();
             }
-            transaction.commit();
-            return result;
+
+            result.add(info);
         }
+
+        if (dropExisting)
+            indexes = copyMapOfObjects(indexes0);
+
+        for (Map.Entry<String, List<Object>> index : indexes.entrySet()) {
+            for (Object key : index.getValue()) {
+                if (key instanceof String) {
+                    result.add(createSinglePropertyIndex(schema, index.getKey(), (String) key));
+                } else if (key instanceof List) {
+                    result.add(createCompoundIndex(index.getKey(), (List<String>) key));
+                }
+            }
+        }
+        return result;
     }
 
     private AssertSchemaResult createSinglePropertyIndex(Schema schema, String lbl, String key) {
@@ -211,11 +203,11 @@ public class Schemas {
         return new AssertSchemaResult(lbl, key).created();
     }
 
-    private AssertSchemaResult createCompoundIndex(String label, List<String> keys, Transaction transaction) {
+    private AssertSchemaResult createCompoundIndex(String label, List<String> keys) {
         List<String> backTickedKeys = new ArrayList<>();
         keys.forEach(key->backTickedKeys.add(String.format("`%s`", key)));
 
-        transaction.execute(String.format("CREATE INDEX ON :`%s` (%s)", label, String.join(",", backTickedKeys))).close();
+        tx.execute(String.format("CREATE INDEX ON :`%s` (%s)", label, String.join(",", backTickedKeys))).close();
         return new AssertSchemaResult(label, keys).created();
     }
 

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -1,10 +1,8 @@
 package apoc.schema;
 
-import apoc.Pools;
 import apoc.result.AssertSchemaResult;
 import apoc.result.IndexConstraintRelationshipInfo;
 import apoc.result.IndexConstraintNodeInfo;
-import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.common.EntityType;
 import org.neo4j.common.TokenNameLookup;
@@ -25,7 +23,6 @@ import org.neo4j.internal.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.IndexNotFoundKernelException;
 import org.neo4j.internal.schema.ConstraintDescriptor;
 import org.neo4j.internal.schema.IndexDescriptor;
-import org.neo4j.internal.schema.SchemaUserDescription;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.procedure.*;
@@ -34,7 +31,6 @@ import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -26,6 +26,7 @@ import org.neo4j.internal.schema.IndexDescriptor;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.procedure.*;
+import org.neo4j.token.api.TokenConstants;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -383,7 +384,7 @@ public class Schemas {
 
             if(!includeRelationships.isEmpty()) {
                 constraintsIterator = includeRelationships.stream()
-                        .filter(type -> !excludeRelationships.contains(type) && tokenRead.relationshipType(type) != -1)
+                        .filter(type -> !excludeRelationships.contains(type) && tokenRead.relationshipType(type) != TokenConstants.NO_TOKEN)
                         .flatMap(type -> {
                             Iterable<ConstraintDefinition> constraintsForType = schema.getConstraints(RelationshipType.withName(type));
                             return StreamSupport.stream(constraintsForType.spliterator(), false);
@@ -391,7 +392,7 @@ public class Schemas {
                         .collect(Collectors.toList());
 
                 indexesIterator = includeRelationships.stream()
-                        .filter(type -> !excludeRelationships.contains(type) && tokenRead.relationshipType(type) != -1)
+                        .filter(type -> !excludeRelationships.contains(type) && tokenRead.relationshipType(type) != TokenConstants.NO_TOKEN)
                         .flatMap(type -> {
                             Iterable<IndexDescriptor> indexesForRelType = () -> schemaRead.indexesGetForRelationshipType(tokenRead.relationshipType(type));
                             return StreamSupport.stream(indexesForRelType.spliterator(), false);

--- a/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -206,6 +206,13 @@ public class CypherResultSubGraph implements SubGraph
     }
 
     @Override
+    public Iterable<IndexDefinition> getIndexes(RelationshipType type) {
+        return indexes.stream()
+                .filter(idx -> StreamSupport.stream(idx.getRelationshipTypes().spliterator(), false).anyMatch(lb -> lb.equals(type)))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
     public Iterable<RelationshipType> getAllRelationshipTypesInUse() {
         return Collections.unmodifiableCollection(types);
     }

--- a/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -73,6 +73,11 @@ public class DatabaseSubGraph implements SubGraph
     }
 
     @Override
+    public Iterable<IndexDefinition> getIndexes(RelationshipType type) {
+        return transaction.schema().getIndexes(type);
+    }
+
+    @Override
     public Iterable<RelationshipType> getAllRelationshipTypesInUse() {
         return transaction.getAllRelationshipTypesInUse();
     }

--- a/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
@@ -35,6 +35,8 @@ public interface SubGraph
 
     Iterable<IndexDefinition> getIndexes(Label label);
 
+    Iterable<IndexDefinition> getIndexes(RelationshipType label);
+
     Iterable<RelationshipType> getAllRelationshipTypesInUse();
 
     Iterable<Label> getAllLabelsInUse();

--- a/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
@@ -35,7 +35,7 @@ public interface SubGraph
 
     Iterable<IndexDefinition> getIndexes(Label label);
 
-    Iterable<IndexDefinition> getIndexes(RelationshipType label);
+    Iterable<IndexDefinition> getIndexes(RelationshipType type);
 
     Iterable<RelationshipType> getAllRelationshipTypesInUse();
 

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -29,6 +29,8 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 import static org.neo4j.configuration.SettingImpl.newBuilder;
 import static org.neo4j.configuration.SettingValueParsers.BOOL;
+import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_LABEL;
+import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_REL_TYPE;
 
 /**
  * @author mh
@@ -87,11 +89,11 @@ public class SchemasTest {
     @Before
     public void setUp() throws Exception {
         registerProcedure(db, Schemas.class);
+        dropSchema();
     }
 
     @Test
     public void testCreateIndex() throws Exception {
-        dropSchema();
         testCall(db, "CALL apoc.schema.assert({Foo:['bar']},null)", (r) -> {
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
@@ -126,13 +128,47 @@ public class SchemasTest {
 
     @Test
     public void testDropIndexWhenUsingDropExisting() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
+        db.executeTransactionally("CREATE INDEX FOR ()-[r:KNOWS]-() ON (r.id, r.since)");
+        db.executeTransactionally("CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)");
+        db.executeTransactionally("CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)");
+
+        testResult(db, "CALL apoc.schema.assert(null,null) YIELD label, key, unique, action RETURN * ORDER BY label", (res) -> {
+            Map<String, Object> lookupNode = res.next();
+            assertEquals(TOKEN_LABEL, lookupNode.get("label"));
+            assertNull(lookupNode.get("key"));
+            assertEquals(false, lookupNode.get("unique"));
+            assertEquals("DROPPED", lookupNode.get("action"));
+            Map<String, Object> lookupRel = res.next();
+            assertEquals(TOKEN_REL_TYPE, lookupRel.get("label"));
+            assertNull(lookupRel.get("key"));
+            assertEquals(false, lookupRel.get("unique"));
+            assertEquals("DROPPED", lookupRel.get("action"));
+            Map<String, Object> idxNode = res.next();
+            assertEquals("Foo", idxNode.get("label"));
+            assertEquals("bar", idxNode.get("key"));
+            assertEquals(false, idxNode.get("unique"));
+            assertEquals("DROPPED", idxNode.get("action"));
+            Map<String, Object> idxRel = res.next();
+            assertEquals("KNOWS", idxRel.get("label"));
+            assertNull(idxRel.get("key"));
+            assertEquals(false, idxRel.get("unique"));
+            assertEquals("DROPPED", idxRel.get("action"));
+            assertFalse(res.hasNext());
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
+            assertEquals(0, indexes.size());
+        }
+    }
+
+    @Test
+    public void testDropIndexesRelsAndNodes() {
+        db.executeTransactionally("CREATE INDEX FOR ()-[r:KNOWS]-() ON (r.id, r.since)");
         testCall(db, "CALL apoc.schema.assert(null,null)", (r) -> {
-            assertEquals("Foo", r.get("label"));
-            assertEquals("bar", r.get("key"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
+            assertEquals("KNOWS", r.get("label"));
+            assertNull(r.get("key"));
+            assertEquals(asList("id", "since"), r.get("keys"));
         });
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
@@ -142,7 +178,6 @@ public class SchemasTest {
 
     @Test
     public void testDropIndexAndCreateIndexWhenUsingDropExisting() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
         testResult(db, "CALL apoc.schema.assert({Bar:['foo']},null)", (result) -> {
             Map<String, Object> r = result.next();
@@ -165,7 +200,6 @@ public class SchemasTest {
 
     @Test
     public void testRetainIndexWhenNotUsingDropExisting() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
         testResult(db, "CALL apoc.schema.assert({Bar:['foo', 'bar']}, null, false)", (result) -> {
             Map<String, Object> r = result.next();
@@ -230,6 +264,47 @@ public class SchemasTest {
     }
 
     @Test
+    public void testCreateAssertSchemaWithLookupIndexes() {
+        db.executeTransactionally("CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)");
+        db.executeTransactionally("CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)");
+        testResult(db, "CALL apoc.schema.assert({One: ['two']}, {Alpha: ['beta']}) " +
+                        "YIELD label, key, keys, unique, action RETURN * ORDER BY label", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals(TOKEN_LABEL, r.get("label"));
+            assertNull(r.get("key"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+
+            r = result.next();
+            assertEquals(TOKEN_REL_TYPE, r.get("label"));
+            assertNull(r.get("key"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+
+            r = result.next();
+            assertEquals("Alpha", r.get("label"));
+            assertEquals("beta", r.get("key"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+
+            r = result.next();
+            assertEquals("One", r.get("label"));
+            assertEquals("two", r.get("key"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+
+            assertFalse(result.hasNext());
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<ConstraintDefinition> constraints = Iterables.asList(tx.schema().getConstraints());
+            assertEquals(1, constraints.size());
+            List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
+            assertEquals(2, indexes.size());
+        }
+
+    }
+
+    @Test
     public void testRetainSchemaWhenNotUsingDropExisting() throws Exception {
         db.executeTransactionally("CREATE CONSTRAINT ON (f:Foo) ASSERT f.bar IS UNIQUE");
         testResult(db, "CALL apoc.schema.assert(null, {Bar:['foo', 'bar']}, false)", (result) -> {
@@ -259,9 +334,8 @@ public class SchemasTest {
 
     @Test
     public void testKeepIndex() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
-        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']},null,false)", (result) -> { 
+        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']},null,false)", (result) -> {
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
@@ -322,6 +396,18 @@ public class SchemasTest {
             Assertions.assertThat(r.get("userDescription").toString()).contains("name='index_70bffdab', type='GENERAL BTREE', schema=(:Foo {bar}), indexProvider='native-btree-1.0' )");
 
             assertFalse(result.hasNext());
+        });
+    }
+
+    @Test
+    public void testRelIndex() {
+        db.executeTransactionally("CREATE INDEX FOR ()-[r:KNOWS]-() ON (r.id, r.since)");
+        awaitIndexesOnline();
+        testCall(db, "CALL apoc.schema.relationships()", row -> {
+            assertEquals(":KNOWS(id,since)", row.get("name"));
+            assertEquals("", row.get("status"));
+            assertEquals("KNOWS", row.get("type"));
+            assertEquals(List.of("id", "since"), row.get("properties"));
         });
     }
 
@@ -387,7 +473,6 @@ public class SchemasTest {
 
     @Test
     public void testDropCompoundIndexWhenUsingDropExisting() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert(null,null,true)", (result) -> {
@@ -405,7 +490,6 @@ public class SchemasTest {
 
     @Test
     public void testDropCompoundIndexAndRecreateWithDropExisting() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,true)", (result) -> {
@@ -424,7 +508,6 @@ public class SchemasTest {
 
     @Test
     public void testDoesntDropCompoundIndexWhenSupplyingSameCompoundIndex() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,false)", (result) -> {
@@ -444,7 +527,6 @@ public class SchemasTest {
     */
     @Test
     public void testKeepCompoundIndex() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa'], ['foo','faa']]},null,false)", (result) -> {
@@ -468,7 +550,6 @@ public class SchemasTest {
 
     @Test
     public void testDropIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Bar:[['foo','bar']]},null)", (result) -> {
@@ -490,9 +571,9 @@ public class SchemasTest {
         }
     }
 
+    // TODO
     @Test
     public void testDropCompoundIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
-        dropSchema();
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
         testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null)", (result) -> {
@@ -600,6 +681,31 @@ public class SchemasTest {
             assertEquals("Parameters relationships and excluderelationships are both valuated. Please check parameters and valuate only one.", except.getMessage());
             throw e;
         }
+    }
+
+    @Test
+    public void testLookupIndexes() {
+        db.executeTransactionally("CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)");
+        db.executeTransactionally("CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)");
+        awaitIndexesOnline();
+
+        testCall(db, "CALL apoc.schema.nodes()", (row) -> {
+            assertEquals(":" + TOKEN_LABEL + "()", row.get("name"));
+            assertEquals("ONLINE", row.get("status"));
+            assertEquals(TOKEN_LABEL, row.get("label"));
+            assertEquals("INDEX", row.get("type"));
+            assertTrue(((List)row.get("properties")).isEmpty());
+            assertEquals("NO FAILURE", row.get("failure"));
+            assertEquals(100d, row.get("populationProgress"));
+            assertEquals(1d, row.get("valuesSelectivity"));
+            assertTrue(row.get("userDescription").toString().contains("name='node_label_lookup_index', type='TOKEN LOOKUP', schema=(:<any-labels>), indexProvider='token-lookup-1.0' )"));
+        });
+        testCall(db, "CALL apoc.schema.relationships()", (row) -> {
+            assertEquals(":" + TOKEN_REL_TYPE + "()", row.get("name"));
+            assertEquals("", row.get("status"));
+            assertEquals(TOKEN_REL_TYPE, row.get("type"));
+            assertTrue(((List)row.get("properties")).isEmpty());
+        });
     }
 
     private void dropSchema()

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -571,7 +571,6 @@ public class SchemasTest {
         }
     }
 
-    // TODO
     @Test
     public void testDropCompoundIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -127,56 +127,6 @@ public class SchemasTest {
     }
 
     @Test
-    public void testDropIndexWhenUsingDropExisting() throws Exception {
-        db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
-        db.executeTransactionally("CREATE INDEX FOR ()-[r:KNOWS]-() ON (r.id, r.since)");
-        db.executeTransactionally("CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)");
-        db.executeTransactionally("CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)");
-
-        testResult(db, "CALL apoc.schema.assert(null,null) YIELD label, key, unique, action RETURN * ORDER BY label", (res) -> {
-            Map<String, Object> lookupNode = res.next();
-            assertEquals(TOKEN_LABEL, lookupNode.get("label"));
-            assertNull(lookupNode.get("key"));
-            assertEquals(false, lookupNode.get("unique"));
-            assertEquals("DROPPED", lookupNode.get("action"));
-            Map<String, Object> lookupRel = res.next();
-            assertEquals(TOKEN_REL_TYPE, lookupRel.get("label"));
-            assertNull(lookupRel.get("key"));
-            assertEquals(false, lookupRel.get("unique"));
-            assertEquals("DROPPED", lookupRel.get("action"));
-            Map<String, Object> idxNode = res.next();
-            assertEquals("Foo", idxNode.get("label"));
-            assertEquals("bar", idxNode.get("key"));
-            assertEquals(false, idxNode.get("unique"));
-            assertEquals("DROPPED", idxNode.get("action"));
-            Map<String, Object> idxRel = res.next();
-            assertEquals("KNOWS", idxRel.get("label"));
-            assertNull(idxRel.get("key"));
-            assertEquals(false, idxRel.get("unique"));
-            assertEquals("DROPPED", idxRel.get("action"));
-            assertFalse(res.hasNext());
-        });
-        try (Transaction tx = db.beginTx()) {
-            List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
-            assertEquals(0, indexes.size());
-        }
-    }
-
-    @Test
-    public void testDropIndexesRelsAndNodes() {
-        db.executeTransactionally("CREATE INDEX FOR ()-[r:KNOWS]-() ON (r.id, r.since)");
-        testCall(db, "CALL apoc.schema.assert(null,null)", (r) -> {
-            assertEquals("KNOWS", r.get("label"));
-            assertNull(r.get("key"));
-            assertEquals(asList("id", "since"), r.get("keys"));
-        });
-        try (Transaction tx = db.beginTx()) {
-            List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
-            assertEquals(0, indexes.size());
-        }
-    }
-
-    @Test
     public void testDropIndexAndCreateIndexWhenUsingDropExisting() throws Exception {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
         testResult(db, "CALL apoc.schema.assert({Bar:['foo']},null)", (result) -> {
@@ -264,47 +214,6 @@ public class SchemasTest {
     }
 
     @Test
-    public void testCreateAssertSchemaWithLookupIndexes() {
-        db.executeTransactionally("CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)");
-        db.executeTransactionally("CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)");
-        testResult(db, "CALL apoc.schema.assert({One: ['two']}, {Alpha: ['beta']}) " +
-                        "YIELD label, key, keys, unique, action RETURN * ORDER BY label", (result) -> {
-            Map<String, Object> r = result.next();
-            assertEquals(TOKEN_LABEL, r.get("label"));
-            assertNull(r.get("key"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
-
-            r = result.next();
-            assertEquals(TOKEN_REL_TYPE, r.get("label"));
-            assertNull(r.get("key"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
-
-            r = result.next();
-            assertEquals("Alpha", r.get("label"));
-            assertEquals("beta", r.get("key"));
-            assertEquals(true, r.get("unique"));
-            assertEquals("CREATED", r.get("action"));
-
-            r = result.next();
-            assertEquals("One", r.get("label"));
-            assertEquals("two", r.get("key"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("CREATED", r.get("action"));
-
-            assertFalse(result.hasNext());
-        });
-        try (Transaction tx = db.beginTx()) {
-            List<ConstraintDefinition> constraints = Iterables.asList(tx.schema().getConstraints());
-            assertEquals(1, constraints.size());
-            List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
-            assertEquals(2, indexes.size());
-        }
-
-    }
-
-    @Test
     public void testRetainSchemaWhenNotUsingDropExisting() throws Exception {
         db.executeTransactionally("CREATE CONSTRAINT ON (f:Foo) ASSERT f.bar IS UNIQUE");
         testResult(db, "CALL apoc.schema.assert(null, {Bar:['foo', 'bar']}, false)", (result) -> {
@@ -335,7 +244,7 @@ public class SchemasTest {
     @Test
     public void testKeepIndex() throws Exception {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
-        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']},null,false)", (result) -> {
+        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']},null,false)", (result) -> { 
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));


### PR DESCRIPTION
Fixes #2015

  - LOOKUP index handling in `apoc.meta.*` and `apoc.schema.*`
  - `apoc.meta.data` and `apoc.meta.schema` with correct `index` field
  - Added indexes in `apoc.schema.relationships`
  - Added `getIndexes(RelationshipType type)` in all classes implementing `SubGraph` interface
