### PR TITLE
Fixes 2034: The procedure apoc.cypher.mapParallel2 sometime fails with Unable to complete transaction error

### DIFF
--- a/full/src/main/java/apoc/cypher/CypherExtended.java
+++ b/full/src/main/java/apoc/cypher/CypherExtended.java
@@ -324,11 +324,12 @@ public class CypherExtended {
         Util.inFuture(pools, () -> {
             long total = parallelPartitions
                 .map((List<Object> partition) -> {
-                    try {
-                        try (Result result = tx.execute(statement, parallelParams(params, "_", partition))) {
-                            return consumeResult(result, queue, false, timeout);
-                        }
-                    } catch (Exception e) {throw new RuntimeException(e);}}
+                    try (Transaction transaction = db.beginTx();
+                         Result result = transaction.execute(statement, parallelParams(params, "_", partition))) {
+                        return consumeResult(result, queue, false, timeout);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }}
                 ).count();
             queue.put(RowResult.TOMBSTONE);
             return total;

--- a/full/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/full/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
@@ -160,6 +161,19 @@ public class CypherExtendedTest {
                     assertEquals(false, r.hasNext());
                 });
     }
+
+    @Test
+    public void shouldNotFailWithTransactionErrorWithMapParallel2() {
+        // Flaky test. Sometimes it's green even without `db.beginTx()` modification
+        db.executeTransactionally("UNWIND range(1, 100) as i create (p:Page {title: i})-[:Link]->(p1:Page1)<-[:Link]-(p2:Page2 {title: 'myTitle'})");
+        testResult(db, "MATCH (p:Page) WITH collect(p) as pages\n" +
+                    "CALL apoc.cypher.mapParallel2(\"MATCH (_)-[:Link]->(p1)<-[:Link]-(p2)\n" +
+                    "RETURN  p2.title as title\", {}, pages, 1) yield value\n" +
+                    "RETURN value.title limit 5", 
+                r -> assertEquals(5, Iterators.count(r)));
+    }
+    
+    
     @Test
     public void testRunFileWithParameters() throws Exception {
         testResult(db, "CALL apoc.cypher.runFile('parameterized.cypher', {statistics:false,parameters:{foo:123,bar:'baz'}})",

--- a/full/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/full/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.IntStream;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;


### PR DESCRIPTION
Fixes #2034