### PR TITLE
Fixes #1910: apoc.meta.stats return false relationship count when having multi-labeled nodes

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -383,11 +383,11 @@ public class    Meta {
         TokenRead tokenRead = kernelTx.tokenRead();
         Read read = kernelTx.dataRead();
 
-        int labelCount = tokenRead.labelCount();
-        int relTypeCount = tokenRead.relationshipTypeCount();
+        long relTypeCount = Iterables.count(tx.getAllRelationshipTypesInUse());
+        long labelCount = Iterables.count(tx.getAllLabelsInUse());
 
-        Map<String, Long> labelStats = new LinkedHashMap<>(labelCount);
-        Map<String, Long> relStats = new LinkedHashMap<>(2 * relTypeCount);
+        Map<String, Long> labelStats = new LinkedHashMap<>((int) labelCount);
+        Map<String, Long> relStats = new LinkedHashMap<>(2 * (int) relTypeCount);
 
         collectStats(new DatabaseSubGraph(transaction), null, null, new StatsCallback() {
             public void label(int labelId, String labelName, long count) {

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -1092,22 +1092,41 @@ public class MetaTest {
 
     @Test
     public void testMetaStatsWithLabelAndRelTypeCountInUse() {
-        db.executeTransactionally("CREATE (:Node:Test)-[:REL {a:'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)");
+        db.executeTransactionally("CREATE (:Node:Test)-[:REL {a: 'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)");
         db.executeTransactionally("CREATE (:A {e: 'f'})-[:ANOTHER {g: 'h'}]->(:C)");
         
         TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
-            assertEquals(4L, row.get("labelCount"));
-            assertEquals(2L, row.get("relTypeCount"));
+            assertEquals(map("A", 1L, "C", 1L, "Test", 2L, "Node", 3L), row.get("labels"));
             assertEquals(5L, row.get("nodeCount"));
+            assertEquals(4L, row.get("labelCount"));
+            
+            assertEquals(map("REL", 4L, "ANOTHER", 1L), row.get("relTypesCount"));
+            assertEquals(2L, row.get("relTypeCount"));
             assertEquals(3L, row.get("relCount"));
+            Map<String, Object> expectedRelTypes = map("(:A)-[:ANOTHER]->()", 1L,
+                    "()-[:REL]->(:Node)", 2L, 
+                    "(:Test)-[:REL]->()", 2L,
+                    "(:Node)-[:REL]->()", 2L, 
+                    "()-[:ANOTHER]->(:C)", 1L,
+                    "()-[:ANOTHER]->()", 1L, 
+                    "()-[:REL]->()", 2L);
+            assertEquals(expectedRelTypes, row.get("relTypes"));
         });
         
         db.executeTransactionally("match p=(:A)-[:ANOTHER]->(:C) delete p");
         TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
-            assertEquals(2L, row.get("labelCount"));
-            assertEquals(1L, row.get("relTypeCount"));
+            assertEquals(map("Test", 2L, "Node", 3L), row.get("labels"));
             assertEquals(3L, row.get("nodeCount"));
+            assertEquals(2L, row.get("labelCount"));
+            
+            assertEquals(map("REL", 4L), row.get("relTypesCount"));
+            assertEquals(1L, row.get("relTypeCount"));
             assertEquals(2L, row.get("relCount"));
+            Map<String, Object> expectedRelTypes = map("()-[:REL]->(:Node)", 2L,
+                    "(:Test)-[:REL]->()", 2L,
+                    "(:Node)-[:REL]->()", 2L,
+                    "()-[:REL]->()", 2L);
+            assertEquals(expectedRelTypes, row.get("relTypes"));
         });
     }
 }

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -1089,4 +1089,25 @@ public class MetaTest {
         });
 
     }
+
+    @Test
+    public void testMetaStatsWithLabelAndRelTypeCountInUse() {
+        db.executeTransactionally("CREATE (:Node:Test)-[:REL {a:'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)");
+        db.executeTransactionally("CREATE (:A {e: 'f'})-[:ANOTHER {g: 'h'}]->(:C)");
+        
+        TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
+            assertEquals(4L, row.get("labelCount"));
+            assertEquals(2L, row.get("relTypeCount"));
+            assertEquals(5L, row.get("nodeCount"));
+            assertEquals(3L, row.get("relCount"));
+        });
+        
+        db.executeTransactionally("match p=(:A)-[:ANOTHER]->(:C) delete p");
+        TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
+            assertEquals(2L, row.get("labelCount"));
+            assertEquals(1L, row.get("relTypeCount"));
+            assertEquals(3L, row.get("nodeCount"));
+            assertEquals(2L, row.get("relCount"));
+        });
+    }
 }


### PR DESCRIPTION
Fixes #1910

The problem is that `TokenRead.labelCount()` and `TokenRead.relationshipTypeCount()` returns all labels/relTypes (even those deleted).
For consistency with the other results, we should return only labels/relTypes in use.