### PR TITLE
Fixes #2074: apoc.import.csv failed for NULL values when using INT datatype with error [null] is not a supported property value

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class CsvPropertyConverter {
 
     public static boolean addPropertyToGraphEntity(Entity entity, CsvHeaderField field, Object value) {
-        if (field.isIgnore()) {
+        if (field.isIgnore() || value == null) {
             return false;
         }
         if (field.isArray()) {

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -3,6 +3,7 @@ package apoc.export.csv;
 import org.neo4j.graphdb.Entity;
 
 import java.util.List;
+import java.util.Objects;
 
 public class CsvPropertyConverter {
 
@@ -11,8 +12,13 @@ public class CsvPropertyConverter {
             return false;
         }
         if (field.isArray()) {
+            final List list = (List) value;
+            final boolean listContainingNull = list.stream().anyMatch(Objects::isNull);
+            if (listContainingNull) {
+                return false;
+            }
             final Object[] prototype = getPrototypeFor(field.getType());
-            final Object[] array = ((List<Object>) value).toArray(prototype);
+            final Object[] array = list.toArray(prototype);
             entity.setProperty(field.getName(), array);
         } else {
             entity.setProperty(field.getName(), value);
@@ -22,9 +28,9 @@ public class CsvPropertyConverter {
 
     static Object[] getPrototypeFor(String type) {
         switch (type) {
-            case "INT":     return new Integer  [] {};
+            case "INT":
             case "LONG":    return new Long     [] {};
-            case "FLOAT":   return new Float    [] {};
+            case "FLOAT":
             case "DOUBLE":  return new Double   [] {};
             case "BOOLEAN": return new Boolean  [] {};
             case "BYTE":    return new Byte     [] {};

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -297,15 +297,11 @@ public class ImportCsvTest {
     
     @Test
     public void testEmptyInteger() {
-        TestUtil.testCall(db,
-                "CALL apoc.import.csv([{fileName: 'file:/emptyInteger.csv', labels: ['entity']}], [], {})",
-                r -> assertEquals(3L, r.get("nodes"))
-        );
+        TestUtil.testCall(db, "CALL apoc.import.csv([{fileName: 'file:/emptyInteger.csv', labels: ['entity']}], [], {})",
+                r -> assertEquals(3L, r.get("nodes")));
 
-        TestUtil.testResult(db, "MATCH (n:Thing) RETURN n.int_attribute as int ORDER BY n.int_attribute", r -> {
-            final List<Object> anInt = Iterators.asList(r.columnAs("int"));
-            assertEquals(Arrays.asList(1L, 2L, null), anInt);
-        });
+        TestUtil.testResult(db, "MATCH (n:Thing) RETURN n.int_attribute as int ORDER BY n.int_attribute", 
+                r -> assertEquals(Arrays.asList(1L, 2L, null), Iterators.asList(r.columnAs("int"))));
     }
 
     @Test


### PR DESCRIPTION
Fixes #2074