### PR TITLE
Fixes #1260: Separate data preparation and add string templates to apoc.export.cypher

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'net.minidev', name: 'json-smart', version: '2.4.2'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
+    compile group: 'com.github.jknack', name: 'handlebars', version: '4.2.0'
 
     antlr "org.antlr:antlr4:4.7.2", {
         exclude group: 'org.glassfish'

--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -142,7 +142,7 @@ public class ExportCypher {
         MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph, c, db);
 
         if (onlySchema)
-            exporter.exportOnlySchema(cypherFileManager, c);
+            exporter.exportOnlySchema(cypherFileManager);
         else
             exporter.export(c, reporter, cypherFileManager);
     }

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -243,11 +243,6 @@ public class MultiStatementCypherSubGraphExporter {
     private List<IndexDefinition> exportConstraints() {
         return StreamSupport.stream(graph.getIndexes().spliterator(), false)
                 .filter(index -> index.isConstraintIndex())
-                .map(index -> {
-                    String label = Iterables.single(index.getLabels()).name();
-                    Iterable<String> props = index.getPropertyKeys();
-                    return this.cypherFormat.statementForConstraint(label, props, exportConfig.ifNotExists());
-                })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -1,5 +1,6 @@
 package apoc.export.cypher;
 
+import apoc.export.cypher.formatter.CypherFormatter;
 import apoc.export.cypher.formatter.CypherFormatterUtils;
 import apoc.export.cypher.formatter.TemplateCypherHelpers;
 import apoc.export.util.ExportConfig;
@@ -64,7 +65,7 @@ public class MultiStatementCypherSubGraphExporter {
     private Set<String> indexNames        = new LinkedHashSet<>();
     private Set<String> indexedProperties = new LinkedHashSet<>();
 
-    private ExportConfig exportConfig;
+    private CypherFormatter cypherFormat;
     private GraphDatabaseService db;
     private TemplateCypher templateCypher;
 
@@ -72,7 +73,7 @@ public class MultiStatementCypherSubGraphExporter {
         this.graph = graph;
         gatherUniqueConstraints();
         this.templateCypher = new TemplateCypher(config, uniqueConstraints, indexNames, indexedProperties);
-        this.exportConfig = config;
+        this.cypherFormat = config.getCypherFormat().getFormatter();
         this.db = db;
     }
 
@@ -177,7 +178,7 @@ public class MultiStatementCypherSubGraphExporter {
 
     private void exportNodesUnwindBatch() {
         if (graph.getNodes().iterator().hasNext()) {
-            exportConfig.getCypherFormat().getFormatter().groupNodes(graph.getNodes(), uniqueConstraints, db, templateCypher);
+            cypherFormat.groupNodes(graph.getNodes(), uniqueConstraints, db, templateCypher);
         }
     }
 
@@ -185,7 +186,7 @@ public class MultiStatementCypherSubGraphExporter {
 
     private void exportRelationshipsUnwindBatch() {
         if (graph.getRelationships().iterator().hasNext()) {
-            exportConfig.getCypherFormat().getFormatter().groupRelationships(graph.getRelationships(), uniqueConstraints, db, templateCypher);
+            cypherFormat.groupRelationships(graph.getRelationships(), uniqueConstraints, db, templateCypher);
         }
     }
 

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -1,24 +1,24 @@
 package apoc.export.cypher;
 
-import apoc.export.cypher.formatter.CypherFormatter;
 import apoc.export.cypher.formatter.CypherFormatterUtils;
+import apoc.export.cypher.formatter.TemplateCypherHelpers;
 import apoc.export.util.ExportConfig;
-import apoc.export.util.ExportFormat;
 import apoc.export.util.Reporter;
-import apoc.util.Util;
-import org.apache.commons.lang3.StringUtils;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.helper.ConditionalHelpers;
+import com.github.jknack.handlebars.helper.StringHelpers;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.internal.helpers.collection.Iterables;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_LABEL;
-import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
+
 
 /*
  * Idea is to lookup nodes for relationships via a unique index
@@ -28,6 +28,10 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
  * Outputs indexes and constraints at the beginning as their own transactions
  */
 public class MultiStatementCypherSubGraphExporter {
+    private static final String SCHEMA_FILE = "schema";
+    private static final String CLEANUP_FILE = "cleanup";
+    private static final String REL_FILE = "relationships";
+    private static final String NODES_FILE = "nodes";
 
     /*private enum IndexType {
         NODE_LABEL_PROPERTY("node_label_property"),
@@ -56,23 +60,20 @@ public class MultiStatementCypherSubGraphExporter {
     }*/
 
     private final SubGraph graph;
-    private final Map<String, Set<String>> uniqueConstraints = new HashMap<>();
+    private static final Map<String, Set<String>> uniqueConstraints = new HashMap<>();
     private Set<String> indexNames        = new LinkedHashSet<>();
     private Set<String> indexedProperties = new LinkedHashSet<>();
-    private Long artificialUniques = 0L;
 
-    private ExportFormat exportFormat;
-    private CypherFormatter cypherFormat;
     private ExportConfig exportConfig;
     private GraphDatabaseService db;
+    private TemplateCypher templateCypher;
 
     public MultiStatementCypherSubGraphExporter(SubGraph graph, ExportConfig config, GraphDatabaseService db) {
         this.graph = graph;
-        this.exportFormat = config.getFormat();
-        this.exportConfig = config;
-        this.cypherFormat = config.getCypherFormat().getFormatter();
-        this.db = db;
         gatherUniqueConstraints();
+        this.templateCypher = new TemplateCypher(config, uniqueConstraints, indexNames, indexedProperties);
+        this.exportConfig = config;
+        this.db = db;
     }
 
     /**
@@ -91,148 +92,115 @@ public class MultiStatementCypherSubGraphExporter {
      * @param cypherFileManager
      */
     public void export(ExportConfig config, Reporter reporter, ExportFileManager cypherFileManager) {
+        try {
+            Handlebars handlebars = getHandlebars();
+            Template templateHandlebarsNodes = handlebars.compile(NODES_FILE);
+            Template templateHandlebarsRels = handlebars.compile(REL_FILE);
+            Template templateHandlebarsCleanup = handlebars.compile(CLEANUP_FILE);
+            Template templateHandlebarsSchema = handlebars.compile(SCHEMA_FILE);
 
-        int batchSize = config.getBatchSize();
-        ExportConfig.OptimizationType useOptimizations = config.getOptimizationType();
+            templateCypher.setReporter(reporter);
 
-        PrintWriter schemaWriter = cypherFileManager.getPrintWriter("schema");
-        PrintWriter nodesWriter = cypherFileManager.getPrintWriter("nodes");
-        PrintWriter relationshipsWriter = cypherFileManager.getPrintWriter("relationships");
-        PrintWriter cleanupWriter = cypherFileManager.getPrintWriter("cleanup");
+            ExportConfig.OptimizationType useOptimizations = config.getOptimizationType();
 
-        switch (useOptimizations) {
-            case NONE:
-                exportNodes(nodesWriter, reporter, batchSize);
-                exportSchema(schemaWriter, config);
-                exportRelationships(relationshipsWriter, reporter, batchSize);
-                break;
-            default:
-                artificialUniques += countArtificialUniques(graph.getNodes());
-                exportSchema(schemaWriter, config);
-                exportNodesUnwindBatch(nodesWriter, reporter);
-                exportRelationshipsUnwindBatch(relationshipsWriter, reporter);
-                break;
+            PrintWriter schemaWriter = cypherFileManager.getPrintWriter(SCHEMA_FILE);
+            PrintWriter nodesWriter = cypherFileManager.getPrintWriter(NODES_FILE);
+            PrintWriter relationshipsWriter = cypherFileManager.getPrintWriter(REL_FILE);
+            PrintWriter cleanupWriter = cypherFileManager.getPrintWriter(CLEANUP_FILE);
+
+            switch (useOptimizations) {
+                case NONE:
+                    templateCypher.setNodes(graph.getNodes());
+                    exportSchema();
+                    templateCypher.setRelationships(graph.getRelationships());
+
+                    templateHandlebarsNodes.apply(templateCypher, nodesWriter);
+                    templateHandlebarsSchema.apply(templateCypher, schemaWriter);
+                    templateHandlebarsRels.apply(templateCypher, relationshipsWriter);
+                    break;
+                default:
+                    templateCypher.incrementArtificialUniques(countArtificialUniques(graph.getNodes()));
+
+                    exportSchema();
+                    exportNodesUnwindBatch();
+                    exportRelationshipsUnwindBatch();
+                    
+                    templateHandlebarsSchema.apply(templateCypher, schemaWriter);
+                    templateHandlebarsNodes.apply(templateCypher, nodesWriter);
+                    templateHandlebarsRels.apply(templateCypher, relationshipsWriter);
+                    
+                    reporter.update(templateCypher.getNodeCount().get(), templateCypher.getRelCount().get(), templateCypher.getPropertyCount().get());
+                    break;
+            }
+            
+            if (cypherFileManager.separatedFiles()) {
+                nodesWriter.close();
+                schemaWriter.close();
+                relationshipsWriter.close();
+            }
+
+            templateHandlebarsCleanup.apply(templateCypher, cleanupWriter);
+            cleanupWriter.close();
+            reporter.done();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        if (cypherFileManager.separatedFiles()) {
-            nodesWriter.close();
-            schemaWriter.close();
-            relationshipsWriter.close();
-        }
-        exportCleanUp(cleanupWriter, batchSize);
-        cleanupWriter.close();
-        reporter.done();
     }
 
-    public void exportOnlySchema(ExportFileManager cypherFileManager, ExportConfig config) {
-        PrintWriter schemaWriter = cypherFileManager.getPrintWriter("schema");
-        exportSchema(schemaWriter, config);
-        schemaWriter.close();
+    public void exportOnlySchema(ExportFileManager cypherFileManager) {
+        try {
+            Handlebars handlebars = new Handlebars()
+                    .prettyPrint(true)
+                    .registerHelpers(ConditionalHelpers.class)
+                    .registerHelpers(StringHelpers.class)
+                    .registerHelpers(TemplateCypherHelpers.class);
+            Template templateHandlebars = handlebars.compile(SCHEMA_FILE);
+
+            PrintWriter schemaWriter = cypherFileManager.getPrintWriter(SCHEMA_FILE);
+            exportSchema();
+            templateHandlebars.apply(templateCypher, schemaWriter);
+            schemaWriter.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Handlebars getHandlebars() {
+        return new Handlebars()
+                .prettyPrint(false)
+                .registerHelpers(StringHelpers.class)
+                .registerHelpers(ConditionalHelpers.class)
+                .registerHelpers(TemplateCypherHelpers.class);
     }
 
     // ---- Nodes ----
 
-    private void exportNodes(PrintWriter out, Reporter reporter, int batchSize) {
+    private void exportNodesUnwindBatch() {
         if (graph.getNodes().iterator().hasNext()) {
-            begin(out);
-            appendNodes(out, batchSize, reporter);
-            commit(out);
-            out.flush();
-        }
-    }
-
-    private void exportNodesUnwindBatch(PrintWriter out, Reporter reporter) {
-        if (graph.getNodes().iterator().hasNext()) {
-            this.cypherFormat.statementForNodes(graph.getNodes(), uniqueConstraints, exportConfig, out, reporter, db);
-            out.flush();
-        }
-    }
-
-    private long appendNodes(PrintWriter out, int batchSize, Reporter reporter) {
-        long count = 0;
-        for (Node node : graph.getNodes()) {
-            if (count > 0 && count % batchSize == 0) restart(out);
-            count++;
-            appendNode(out, node, reporter);
-        }
-        return count;
-    }
-
-    private void appendNode(PrintWriter out, Node node, Reporter reporter) {
-        artificialUniques += countArtificialUniques(node);
-        String cypher = this.cypherFormat.statementForNode(node, uniqueConstraints, indexedProperties, indexNames);
-        if (Util.isNotNullOrEmpty(cypher)) {
-            out.println(cypher);
-            reporter.update(1, 0, Iterables.count(node.getPropertyKeys()));
+            exportConfig.getCypherFormat().getFormatter().groupNodes(graph.getNodes(), uniqueConstraints, db, templateCypher);
         }
     }
 
     // ---- Relationships ----
 
-    private void exportRelationships(PrintWriter out, Reporter reporter, int batchSize) {
+    private void exportRelationshipsUnwindBatch() {
         if (graph.getRelationships().iterator().hasNext()) {
-            begin(out);
-            appendRelationships(out, batchSize, reporter);
-            commit(out);
-            out.flush();
-        }
-    }
-
-    private void exportRelationshipsUnwindBatch(PrintWriter out, Reporter reporter) {
-        if (graph.getRelationships().iterator().hasNext()) {
-            this.cypherFormat.statementForRelationships(graph.getRelationships(), uniqueConstraints, exportConfig, out, reporter, db);
-            out.flush();
-        }
-    }
-
-    private long appendRelationships(PrintWriter out, int batchSize, Reporter reporter) {
-        long count = 0;
-        for (Relationship rel : graph.getRelationships()) {
-            if (count > 0 && count % batchSize == 0) restart(out);
-            count++;
-            appendRelationship(out, rel, reporter);
-        }
-        return count;
-    }
-
-    private void appendRelationship(PrintWriter out, Relationship rel, Reporter reporter) {
-        String cypher = this.cypherFormat.statementForRelationship(rel, uniqueConstraints, indexedProperties);
-        if (cypher != null && !"".equals(cypher)) {
-            out.println(cypher);
-            reporter.update(0, 1, Iterables.count(rel.getPropertyKeys()));
+            exportConfig.getCypherFormat().getFormatter().groupRelationships(graph.getRelationships(), uniqueConstraints, db, templateCypher);
         }
     }
 
     // ---- Schema ----
 
-    private void exportSchema(PrintWriter out, ExportConfig config) {
-        List<String> indexesAndConstraints = new ArrayList<>();
-        indexesAndConstraints.addAll(exportIndexes());
-        indexesAndConstraints.addAll(exportConstraints());
-        if (indexesAndConstraints.isEmpty() && artificialUniques == 0) return;
-        begin(out);
-        for (String index : indexesAndConstraints) {
-            out.println(index);
-        }
-        if (artificialUniques > 0) {
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), config.ifNotExists());
-            if (cypher != null && !"".equals(cypher)) {
-                out.println(cypher);
-            }
-        }
-        commit(out);
-        if (graph.getIndexes().iterator().hasNext()) {
-            out.print(this.exportFormat.indexAwait(this.exportConfig.getAwaitForIndexes()));
-        }
-        schemaAwait(out);
-        out.flush();
+    private void exportSchema() {
+        final TemplateSchema templateSchema = templateCypher.getTemplateSchema();
+        templateSchema.setIndexes(exportIndexes());
+        templateSchema.setConstraints(exportConstraints());
     }
 
-    private List<String> exportIndexes() {
+    private List<Map<String, Object>> exportIndexes() {
         return db.executeTransactionally("CALL db.indexes()", Collections.emptyMap(), result -> result.stream()
                 .map(map -> {
-                    List<String> props = (List<String>) map.get("properties");
                     List<String> tokenNames = (List<String>) map.get("labelsOrTypes");
-                    String name = (String) map.get("name");
                     boolean inGraph = tokensInGraph(tokenNames);
                     if (!inGraph) {
                         return null;
@@ -242,21 +210,9 @@ public class MultiStatementCypherSubGraphExporter {
                         return null;  // delegate to the constraint creation
                     }
 
-                    if ("FULLTEXT".equals(map.get("type"))) {
-                        if ("NODE".equals(map.get("entityType"))) {
-                            List<Label> labels = toLabels(tokenNames);
-                            return this.cypherFormat.statementForNodeFullTextIndex(name, labels, props);
-                        } else {
-                            List<RelationshipType> types = toRelationshipTypes(tokenNames);
-                            return this.cypherFormat.statementForRelationshipFullTextIndex(name, types, props);
-                        }
-                    }
-                    // "normal" schema index
-                    String tokenName = tokenNames.get(0);
-                    return this.cypherFormat.statementForIndex(tokenName, props, exportConfig.ifNotExists());
-
+                    return map;
                 })
-                .filter(StringUtils::isNotBlank)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList()));
     }
 
@@ -277,19 +233,13 @@ public class MultiStatementCypherSubGraphExporter {
                 });
     }
 
-    private List<Label> toLabels(List<String> tokenNames) {
+    public static List<Label> toLabels(List<String> tokenNames) {
         return tokenNames.stream()
                 .map(Label::label)
                 .collect(Collectors.toList());
     }
 
-    private List<RelationshipType> toRelationshipTypes(List<String> tokenNames) {
-        return tokenNames.stream()
-                .map(RelationshipType::withName)
-                .collect(Collectors.toList());
-    }
-
-    private List<String> exportConstraints() {
+    private List<IndexDefinition> exportConstraints() {
         return StreamSupport.stream(graph.getIndexes().spliterator(), false)
                 .filter(index -> index.isConstraintIndex())
                 .map(index -> {
@@ -297,52 +247,11 @@ public class MultiStatementCypherSubGraphExporter {
                     Iterable<String> props = index.getPropertyKeys();
                     return this.cypherFormat.statementForConstraint(label, props, exportConfig.ifNotExists());
                 })
-                .filter(StringUtils::isNotBlank)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 
-    // ---- CleanUp ----
-
-    private void exportCleanUp(PrintWriter out, int batchSize) {
-        if (artificialUniques > 0) {
-            while (artificialUniques > 0) {
-                String cypher = this.cypherFormat.statementForCleanUp(batchSize);
-                begin(out);
-                if (cypher != null && !"".equals(cypher)) {
-                    out.println(cypher);
-                }
-                commit(out);
-                artificialUniques -= batchSize;
-            }
-            begin(out);
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false)
-                    .replaceAll("^CREATE", "DROP");
-            if (cypher != null && !"".equals(cypher)) {
-                out.println(cypher);
-            }
-            commit(out);
-        }
-        out.flush();
-    }
-
     // ---- Common ----
-
-    public void begin(PrintWriter out) {
-        out.print(exportFormat.begin());
-    }
-
-    private void schemaAwait(PrintWriter out){
-        out.print(exportFormat.schemaAwait());
-    }
-
-    private void restart(PrintWriter out) {
-        commit(out);
-        begin(out);
-    }
-
-    public void commit(PrintWriter out){
-        out.print(exportFormat.commit());
-    }
 
     private void gatherUniqueConstraints() {
         for (IndexDefinition indexDefinition : graph.getIndexes()) {
@@ -360,13 +269,13 @@ public class MultiStatementCypherSubGraphExporter {
         }
     }
 
-    private long countArtificialUniques(Node node) {
+    public static long countArtificialUniques(Node node) {
         long artificialUniques = 0;
         artificialUniques = getArtificialUniques(node, artificialUniques);
         return artificialUniques;
     }
 
-    private long countArtificialUniques(Iterable<Node> n) {
+    private static long countArtificialUniques(Iterable<Node> n) {
         long artificialUniques = 0;
         for (Node node : n) {
             artificialUniques = getArtificialUniques(node, artificialUniques);
@@ -374,7 +283,7 @@ public class MultiStatementCypherSubGraphExporter {
         return artificialUniques;
     }
 
-    private long getArtificialUniques(Node node, long artificialUniques) {
+    private static long getArtificialUniques(Node node, long artificialUniques) {
         Iterator<Label> labels = node.getLabels().iterator();
         boolean uniqueFound = false;
         while (labels.hasNext()) {

--- a/core/src/main/java/apoc/export/cypher/TemplateCypher.java
+++ b/core/src/main/java/apoc/export/cypher/TemplateCypher.java
@@ -1,0 +1,169 @@
+package apoc.export.cypher;
+
+import apoc.export.cypher.formatter.CypherFormatterUtils;
+import apoc.export.util.ExportConfig;
+import apoc.export.util.ExportFormat;
+import apoc.export.util.Reporter;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TemplateCypher extends CypherFormatterUtils {
+    private final Map<String, Set<String>> uniqueConstraints;
+    private final Set<String> indexNames;
+    private final Set<String> indexedProperties;
+    private final ExportConfig exportConfig;
+    private final TemplateSchema templateSchema;
+
+    private long artificialUniques;
+    
+    private Reporter reporter;
+    private Iterable<Node> nodes;
+    private Iterable<Relationship> relationships; 
+    
+    private Map<Map<String, Object>, List<Relationship>> groupedRelationships;
+    private Map<Map.Entry<Set<String>, Set<String>>, List<Node>> groupedNodes;
+    
+    private final String begin;
+    private final String commit;
+    
+    private final AtomicInteger nodeCount = new AtomicInteger(0);
+    private final AtomicInteger relCount = new AtomicInteger(0);
+    private final AtomicInteger relBatchCount = new AtomicInteger(0);
+    private final AtomicInteger nodeBatchCount = new AtomicInteger(0);
+    private final AtomicInteger unwindCount = new AtomicInteger(0);
+    private final AtomicInteger propertyCount = new AtomicInteger(0);
+
+    public TemplateCypher(ExportConfig exportConfig, Map<String, Set<String>> uniqueConstraints, Set<String> indexNames, Set<String> indexedProperties) {
+        final ExportFormat format = exportConfig.getFormat();
+        this.uniqueConstraints = uniqueConstraints;
+        this.exportConfig = exportConfig;
+        this.indexNames = indexNames;
+        this.indexedProperties = indexedProperties;
+        this.begin = format.begin();
+        this.commit = format.commit();
+
+        this.templateSchema = new TemplateSchema(new ArrayList<>(), new ArrayList<>(), format.schemaAwait(), format.indexAwait(exportConfig.getAwaitForIndexes()));
+    }
+
+    public boolean isRelBatchMatch() {
+        return relBatchCount.get() % exportConfig.getBatchSize() == 0;
+    }
+
+    public boolean isNodeBatchMatch() {
+        return nodeBatchCount.get() % exportConfig.getBatchSize() == 0;
+    }
+
+    public Map<Map.Entry<Set<String>, Set<String>>, List<Node>> getGroupedNodes() {
+        return groupedNodes;
+    }
+
+    public Map<Map<String, Object>, List<Relationship>> getGroupedRelationships() {
+        return groupedRelationships;
+    }
+
+    public AtomicInteger getPropertyCount() {
+        return propertyCount;
+    }
+
+    public AtomicInteger getRelBatchCount() {
+        return relBatchCount;
+    }
+
+    public AtomicInteger getNodeBatchCount() {
+        return nodeBatchCount;
+    }
+
+    public AtomicInteger getUnwindCount() {
+        return unwindCount;
+    }
+
+    public AtomicInteger getRelCount() {
+        return relCount;
+    }
+
+    public AtomicInteger getNodeCount() {
+        return nodeCount;
+    }
+
+    public Reporter getReporter() {
+        return reporter;
+    }
+
+    public String getBegin() {
+        return begin;
+    }
+
+    public String getCommit() {
+        return commit;
+    }
+
+    public Iterable<Node> getNodes() {
+        return nodes;
+    }
+
+    public Iterable<Relationship> getRelationships() {
+        return relationships;
+    }
+
+    public ExportConfig getExportConfig() {
+        return exportConfig;
+    }
+
+    public long getArtificialUniques() {
+        return artificialUniques;
+    }
+    public void setReporter(Reporter reporter) {
+        this.reporter = reporter;
+    }
+
+    public void setGroupedNodes(Map<Map.Entry<Set<String>, Set<String>>, List<Node>> groupedNodes) {
+        this.groupedNodes = groupedNodes;
+    }
+
+    public void incrementNodeCount(int nodeCount) {
+        this.nodeCount.addAndGet(nodeCount);
+    }
+
+    public void incrementRelCount(int relCount) {
+        this.relCount.addAndGet(relCount);
+    }
+
+    public void incrementArtificialUniques(long artificialUniques) {
+        this.artificialUniques += artificialUniques;
+    }
+
+
+    public void setNodes(Iterable<Node> nodes) {
+        this.nodes = nodes;
+    }
+
+    public void setRelationships(Iterable<Relationship> relationships) {
+        this.relationships = relationships;
+    }
+
+    public Map<String, Set<String>> getUniqueConstraints() {
+        return uniqueConstraints;
+    }
+
+    public Set<String> getIndexNames() {
+        return indexNames;
+    }
+
+    public Set<String> getIndexedProperties() {
+        return indexedProperties;
+    }
+
+    public TemplateSchema getTemplateSchema() {
+        return templateSchema;
+    }
+
+    public void setGroupedRelationships(Map<Map<String, Object>, List<Relationship>> groupedRelationships) {
+        this.groupedRelationships = groupedRelationships;
+    }
+}

--- a/core/src/main/java/apoc/export/cypher/TemplateSchema.java
+++ b/core/src/main/java/apoc/export/cypher/TemplateSchema.java
@@ -1,0 +1,48 @@
+package apoc.export.cypher;
+
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+public class TemplateSchema {
+    private List<Map<String, Object>> indexes;
+    private List<IndexDefinition>  constraints;
+    private String schemaAwait;
+    private String indexAwait;
+
+    public TemplateSchema(List<Map<String, Object>> indexes, List<IndexDefinition> constraints, String schemaAwait, String indexAwait) {
+        this.indexes = indexes;
+        this.constraints = constraints;
+        this.schemaAwait = schemaAwait;
+        this.indexAwait = indexAwait;
+    }
+
+    public String getSchemaAwait() {
+        return schemaAwait;
+    }
+
+    public String getIndexAwait() {
+        return indexAwait;
+    }
+
+    public boolean isWithIndexes() {
+        return indexes.size() > 0;
+    }
+
+    public List<Map<String, Object>> getIndexes() {
+        return indexes;
+    }
+
+    public List<IndexDefinition> getConstraints() {
+        return constraints;
+    }
+
+    public void setIndexes(List<Map<String, Object>> indexes) {
+        this.indexes = indexes;
+    }
+
+    public void setConstraints(List<IndexDefinition> constraints) {
+        this.constraints = constraints;
+    }
+}

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -171,7 +171,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 				result.append(notUniqueLabels);
 			}
 		}
-		result.append(";\n");
+		result.append(";" + StringUtils.LF);
 		return result.toString();
 	}
 
@@ -186,7 +186,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 			result.append(cypherFormat.equals(CypherFormat.UPDATE_STRUCTURE) ? " ON CREATE SET " : " SET ");
 			result.append(CypherFormatterUtils.formatRelationshipProperties("r", relationship, false));
 		}
-		result.append(";\n");
+		result.append(";" + StringUtils.LF);
 		return result.toString();
 	}
 
@@ -250,7 +250,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	private String formatNodeId(String key) {
-		if (UNIQUE_ID_PROP.equals(key)) {
+		if (CypherFormatterUtils.UNIQUE_ID_PROP.equals(key)) {
 			key = "_id";
 		}
 		return Util.quote(key);

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -49,7 +49,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 	@Override
 	public String statementForIndex(String label, Iterable<String> keys, boolean ifNotExists) {
-		return String.format("CREATE INDEX%s FOR (node:%s) ON (%s);" + StringUtils.LF;, 
+		return String.format("CREATE INDEX%s FOR (node:%s) ON (%s);" + StringUtils.LF, 
 				getIfNotExists(ifNotExists),
 				Util.quote(label),
 				getPropertiesQuoted(keys));

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -1,8 +1,8 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.cypher.TemplateCypher;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.ExportFormat;
-import apoc.export.util.Reporter;
 import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -13,15 +13,18 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterables;
 
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_LABEL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.getUniqueConstrainedLabel;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.getUniqueConstrainedProperties;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.quote;
 
 /**
@@ -31,22 +34,22 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.quote;
  */
 abstract class AbstractCypherFormatter implements CypherFormatter {
 
-	private static final String STATEMENT_CONSTRAINTS = "CREATE CONSTRAINT%s ON (node:%s) ASSERT (%s) %s;";
+	private static final String STATEMENT_CONSTRAINTS = "CREATE CONSTRAINT%s ON (node:%s) ASSERT (%s) %s;" + StringUtils.LF;
 
-	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CALL db.index.fulltext.createNodeIndex('%s',[%s],[%s]);";
-	private static final String STATEMENT_REL_FULLTEXT_IDX = "CALL db.index.fulltext.createRelationshipIndex('%s',[%s],[%s]);";
+	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CALL db.index.fulltext.createNodeIndex('%s',[%s],[%s]);" + StringUtils.LF;
+	private static final String STATEMENT_REL_FULLTEXT_IDX = "CALL db.index.fulltext.createRelationshipIndex('%s',[%s],[%s]);" + StringUtils.LF;
 	public static final String PROPERTY_QUOTING_FORMAT = "'%s'";
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
 		return "MATCH (n:" + Q_UNIQUE_ID_LABEL + ") " +
 				" WITH n LIMIT " + batchSize +
-				" REMOVE n:" + Q_UNIQUE_ID_LABEL + " REMOVE n." + quote(UNIQUE_ID_PROP) + ";";
+				" REMOVE n:" + Q_UNIQUE_ID_LABEL + " REMOVE n." + quote(UNIQUE_ID_PROP) + ";" + StringUtils.LF;
 	}
 
 	@Override
 	public String statementForIndex(String label, Iterable<String> keys, boolean ifNotExists) {
-		return String.format("CREATE INDEX%s FOR (node:%s) ON (%s);", 
+		return String.format("CREATE INDEX%s FOR (node:%s) ON (%s);" + StringUtils.LF;, 
 				getIfNotExists(ifNotExists),
 				Util.quote(label),
 				getPropertiesQuoted(keys));
@@ -98,155 +101,17 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 				.collect(Collectors.joining(", "));
 	}
 
-	protected String mergeStatementForNode(CypherFormat cypherFormat, Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		StringBuilder result = new StringBuilder(1000);
-		result.append("MERGE ");
-		result.append(CypherFormatterUtils.formatNodeLookup("n", node, uniqueConstraints, indexNames));
-		if (node.getPropertyKeys().iterator().hasNext()) {
-			String notUniqueProperties = CypherFormatterUtils.formatNotUniqueProperties("n", node, uniqueConstraints, indexedProperties, false);
-			String notUniqueLabels = CypherFormatterUtils.formatNotUniqueLabels("n", node, uniqueConstraints);
-			if (!"".equals(notUniqueProperties) || !"".equals(notUniqueLabels)) {
-				result.append(cypherFormat.equals(CypherFormat.ADD_STRUCTURE) ? " ON CREATE SET " : " SET ");
-				result.append(notUniqueProperties);
-				result.append(!"".equals(notUniqueProperties) && !"".equals(notUniqueLabels) ? ", " : "");
-				result.append(notUniqueLabels);
-			}
+	private Set<String> getLabels(Node node) {
+		Set<String> labels = StreamSupport.stream(node.getLabels().spliterator(), false)
+				.map(Label::name)
+				.collect(Collectors.toSet());
+		if (labels.isEmpty()) {
+			labels.add(CypherFormatterUtils.UNIQUE_ID_LABEL);
 		}
-		result.append(";");
-		return result.toString();
+		return labels;
 	}
-
-	public String mergeStatementForRelationship(CypherFormat cypherFormat, Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-		StringBuilder result = new StringBuilder(1000);
-		result.append("MATCH ");
-		result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));
-		result.append(", ");
-		result.append(CypherFormatterUtils.formatNodeLookup("n2", relationship.getEndNode(), uniqueConstraints, indexedProperties));
-		result.append(" MERGE (n1)-[r:" + CypherFormatterUtils.quote(relationship.getType().name()) + "]->(n2)");
-		if (relationship.getPropertyKeys().iterator().hasNext()) {
-			result.append(cypherFormat.equals(CypherFormat.UPDATE_STRUCTURE) ? " ON CREATE SET " : " SET ");
-			result.append(CypherFormatterUtils.formatRelationshipProperties("r", relationship, false));
-		}
-		result.append(";");
-		return result.toString();
-	}
-
-	public void buildStatementForNodes(String nodeClause, String setClause,
-									   Iterable<Node> nodes, Map<String, Set<String>> uniqueConstraints,
-									   ExportConfig exportConfig,
-									   PrintWriter out, Reporter reporter,
-									   GraphDatabaseService db) {
-		AtomicInteger nodeCount = new AtomicInteger(0);
-		Function<Node, Map.Entry<Set<String>, Set<String>>> keyMapper = (node) -> {
-			try (Transaction tx = db.beginTx()) {
-				node = tx.getNodeById(node.getId());
-				Set<String> idProperties = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).keySet();
-				Set<String> labels = getLabels(node);
-				tx.commit();
-				return new AbstractMap.SimpleImmutableEntry<>(labels, idProperties);
-			}
-		};
-		Map<Map.Entry<Set<String>, Set<String>>, List<Node>> groupedData = StreamSupport.stream(nodes.spliterator(), true)
-				.collect(Collectors.groupingByConcurrent(keyMapper));
-
-		AtomicInteger propertiesCount = new AtomicInteger(0);
-
-		AtomicInteger batchCount = new AtomicInteger(0);
-		groupedData.forEach((key, nodeList) -> {
-			AtomicInteger unwindCount = new AtomicInteger(0);
-			final int nodeListSize = nodeList.size();
-			final Node last = nodeList.get(nodeListSize - 1);
-			nodeCount.addAndGet(nodeListSize);
-			for (int index = 0; index < nodeList.size(); index++) {
-				Node node = nodeList.get(index);
-				writeBatchBegin(exportConfig, out, batchCount);
-				writeUnwindStart(exportConfig, out, unwindCount);
-				batchCount.incrementAndGet();
-				unwindCount.incrementAndGet();
-				Map<String, Object> props = node.getAllProperties();
-				// start element
-				out.append("{");
-
-				// id
-				Map<String, Object> idMap = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints);
-				writeNodeIds(out, idMap);
-
-				// properties
-				out.append(", ");
-				out.append("properties:");
-
-				propertiesCount.addAndGet(props.size());
-				props.keySet().removeAll(idMap.keySet());
-				writeProperties(out, props);
-
-				// end element
-				out.append("}");
-				if (last.equals(node) || isBatchMatch(exportConfig, batchCount) || isUnwindBatchMatch(exportConfig, unwindCount)) {
-					closeUnwindNodes(nodeClause, setClause, uniqueConstraints, exportConfig, out, key, last);
-					writeBatchEnd(exportConfig, out, batchCount);
-					unwindCount.set(0);
-				} else {
-					out.append(", ");
-				}
-			}
-		});
-		addCommitToEnd(exportConfig, out, batchCount);
-
-		reporter.update(nodeCount.get(), 0, propertiesCount.longValue());
-	}
-
-	private void closeUnwindNodes(String nodeClause, String setClause, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Map.Entry<Set<String>, Set<String>> key, Node last) {
-		writeUnwindEnd(exportConfig, out);
-		out.append(StringUtils.LF);
-		out.append(nodeClause);
-
-		String label = getUniqueConstrainedLabel(last, uniqueConstraints);
-		out.append("(n:");
-		out.append(Util.quote(label));
-		out.append("{");
-		writeSetProperties(out, key.getValue());
-		out.append("}) ");
-		out.append(setClause);
-		out.append("n += row.properties");
-		String addLabels = key.getKey().stream()
-				.filter(l -> !l.equals(label))
-				.map(Util::quote)
-				.collect(Collectors.joining(":"));
-		if (!addLabels.isEmpty()) {
-			out.append(" SET n:");
-			out.append(addLabels);
-		}
-		out.append(";");
-		out.append(StringUtils.LF);
-	}
-
-	private void writeSetProperties(PrintWriter out, Set<String> value) {
-		writeSetProperties(out, value, null);
-	}
-
-	private void writeSetProperties(PrintWriter out, Set<String> value, String prefix) {
-		if (prefix == null) prefix = "";
-		int size = value.size();
-		for (String s: value) {
-			--size;
-			out.append(Util.quote(s) + ": row." + prefix + formatNodeId(s));
-			if (size > 0) {
-				out.append(", ");
-			}
-		}
-	}
-
-	private boolean isBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
-		return batchCount.get() % exportConfig.getBatchSize() == 0;
-	}
-
-	public void buildStatementForRelationships(String relationshipClause,
-											   String setClause, Iterable<Relationship> relationship,
-											   Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig,
-											   PrintWriter out, Reporter reporter,
-											   GraphDatabaseService db) {
-		AtomicInteger relCount = new AtomicInteger(0);
-
+	
+	public void groupRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher) {
 		Function<Relationship, Map<String, Object>> keyMapper = (rel) -> {
 			try (Transaction tx = db.beginTx()) {
 				rel = tx.getRelationshipById(rel.getId());
@@ -272,60 +137,101 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		Map<Map<String, Object>, List<Relationship>> groupedData = StreamSupport.stream(relationship.spliterator(), true)
 				.collect(Collectors.groupingByConcurrent(keyMapper));
 
-		AtomicInteger propertiesCount = new AtomicInteger(0);
-		AtomicInteger batchCount = new AtomicInteger(0);
-
-		String start = "start";
-		String end = "end";
-		groupedData.forEach((path, relationshipList) -> {
-			AtomicInteger unwindCount = new AtomicInteger(0);
-			final int relSize = relationshipList.size();
-			relCount.addAndGet(relSize);
-			final Relationship last = relationshipList.get(relSize - 1);
-			for (int index = 0; index < relationshipList.size(); index++) {
-				Relationship rel = relationshipList.get(index);
-				writeBatchBegin(exportConfig, out, batchCount);
-				writeUnwindStart(exportConfig, out, unwindCount);
-				batchCount.incrementAndGet();
-				unwindCount.incrementAndGet();
-				Map<String, Object> props = rel.getAllProperties();
-				// start element
-				out.append("{");
-
-				// start node
-				Node startNode = rel.getStartNode();
-				writeRelationshipNodeIds(uniqueConstraints, out, start, startNode);
-
-				out.append(", ");
-
-				// end node
-				Node endNode = rel.getEndNode();
-				writeRelationshipNodeIds(uniqueConstraints, out, end, endNode);
-
-				// properties
-				out.append(", ");
-				out.append("properties:");
-				writeProperties(out, props);
-				propertiesCount.addAndGet(props.size());
-
-				// end element
-				out.append("}");
-
-				if (last.equals(rel) || isBatchMatch(exportConfig, batchCount) || isUnwindBatchMatch(exportConfig, unwindCount)) {
-					closeUnwindRelationships(relationshipClause, setClause, uniqueConstraints, exportConfig, out, start, end, path, last);
-					writeBatchEnd(exportConfig, out, batchCount);
-					unwindCount.set(0);
-				} else {
-					out.append(", ");
-				}
-			}
-		});
-		addCommitToEnd(exportConfig, out, batchCount);
-
-		reporter.update(0, relCount.get(), propertiesCount.longValue());
+		templateCypher.setGroupedRelationships(groupedData);
 	}
 
-	private void closeUnwindRelationships(String relationshipClause, String setClause, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, String start, String end, Map<String, Object> path, Relationship last) {
+	public void groupNodes(Iterable<Node> nodes, Map<String, Set<String>> uniqueConstraints,
+											 GraphDatabaseService db, TemplateCypher templateCypher) {
+		Function<Node, Map.Entry<Set<String>, Set<String>>> keyMapper = (node) -> {
+			try (Transaction tx = db.beginTx()) {
+				node = tx.getNodeById(node.getId());
+				Set<String> idProperties = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).keySet();
+				Set<String> labels = getLabels(node);
+				tx.commit();
+				return new AbstractMap.SimpleImmutableEntry<>(labels, idProperties);
+			}
+		};
+		Map<Map.Entry<Set<String>, Set<String>>, List<Node>> groupedData = StreamSupport.stream(nodes.spliterator(), true)
+				.collect(Collectors.groupingByConcurrent(keyMapper));
+		templateCypher.setGroupedNodes(groupedData);
+
+	}
+
+	protected String mergeStatementForNode(CypherFormat cypherFormat, Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+		StringBuilder result = new StringBuilder(1000);
+		result.append("MERGE ");
+		result.append(CypherFormatterUtils.formatNodeLookup("n", node, uniqueConstraints, indexNames));
+		if (node.getPropertyKeys().iterator().hasNext()) {
+			String notUniqueProperties = CypherFormatterUtils.formatNotUniqueProperties("n", node, uniqueConstraints, indexedProperties, false);
+			String notUniqueLabels = CypherFormatterUtils.formatNotUniqueLabels("n", node, uniqueConstraints);
+			if (!"".equals(notUniqueProperties) || !"".equals(notUniqueLabels)) {
+				result.append(cypherFormat.equals(CypherFormat.ADD_STRUCTURE) ? " ON CREATE SET " : " SET ");
+				result.append(notUniqueProperties);
+				result.append(!"".equals(notUniqueProperties) && !"".equals(notUniqueLabels) ? ", " : "");
+				result.append(notUniqueLabels);
+			}
+		}
+		result.append(";\n");
+		return result.toString();
+	}
+
+	public String mergeStatementForRelationship(CypherFormat cypherFormat, Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
+		StringBuilder result = new StringBuilder(1000);
+		result.append("MATCH ");
+		result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));
+		result.append(", ");
+		result.append(CypherFormatterUtils.formatNodeLookup("n2", relationship.getEndNode(), uniqueConstraints, indexedProperties));
+		result.append(" MERGE (n1)-[r:" + CypherFormatterUtils.quote(relationship.getType().name()) + "]->(n2)");
+		if (relationship.getPropertyKeys().iterator().hasNext()) {
+			result.append(cypherFormat.equals(CypherFormat.UPDATE_STRUCTURE) ? " ON CREATE SET " : " SET ");
+			result.append(CypherFormatterUtils.formatRelationshipProperties("r", relationship, false));
+		}
+		result.append(";\n");
+		return result.toString();
+	}
+
+	public void closeUnwindNodes(String nodeClause, String setClause, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, Map.Entry<Set<String>, Set<String>> key, Node last) throws IOException {
+		writeUnwindEnd(exportConfig, out);
+		out.append(StringUtils.LF);
+		out.append(nodeClause);
+
+		String label = getUniqueConstrainedLabel(last, uniqueConstraints);
+		out.append("(n:");
+		out.append(Util.quote(label));
+		out.append("{");
+		writeSetProperties(out, key.getValue());
+		out.append("}) ");
+		out.append(setClause);
+		out.append("n += row.properties");
+		String addLabels = key.getKey().stream()
+				.filter(l -> !l.equals(label))
+				.map(Util::quote)
+				.collect(Collectors.joining(":"));
+		if (!addLabels.isEmpty()) {
+			out.append(" SET n:");
+			out.append(addLabels);
+		}
+		out.append(";");
+		out.append(StringUtils.LF);
+	}
+	
+	private void writeSetProperties(Writer out, Set<String> value) throws IOException {
+		writeSetProperties(out, value, null);
+	}
+
+	private void writeSetProperties(Writer out, Set<String> value, String prefix) throws IOException {
+		if (prefix == null) prefix = "";
+		int size = value.size();
+		for (String s: value) {
+			--size;
+			out.append(Util.quote(s) + ": row." + prefix + formatNodeId(s));
+			if (size > 0) {
+				out.append(", ");
+			}
+		}
+	}
+
+	public void closeUnwindRelationships(String relationshipClause, String setClause, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, String start, String end, Map<String, Object> path, Relationship last) throws IOException {
 		writeUnwindEnd(exportConfig, out);
 		// match start node
 		writeRelationshipMatchAsciiNode(last.getStartNode(), out, start, uniqueConstraints);
@@ -343,62 +249,14 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		out.append(StringUtils.LF);
 	}
 
-	private boolean isUnwindBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
-		return batchCount.get() % exportConfig.getUnwindBatchSize() == 0;
-	}
-
-	private void writeBatchEnd(ExportConfig exportConfig, PrintWriter out, AtomicInteger batchCount) {
-		if (isBatchMatch(exportConfig, batchCount)) {
-			out.append(exportConfig.getFormat().commit());
-		}
-	}
-
-	public void writeProperties(PrintWriter out, Map<String, Object> props) {
-		out.append("{");
-		if (!props.isEmpty()) {
-			int size = props.size();
-			for (Map.Entry<String, Object> es : props.entrySet()) {
-				--size;
-				out.append(Util.quote(es.getKey()));
-				out.append(":");
-				out.append(CypherFormatterUtils.toString(es.getValue()));
-				if (size > 0) {
-					out.append(", ");
-				}
-			}
-		}
-		out.append("}");
-	}
-
 	private String formatNodeId(String key) {
-		if (CypherFormatterUtils.UNIQUE_ID_PROP.equals(key)) {
+		if (UNIQUE_ID_PROP.equals(key)) {
 			key = "_id";
 		}
 		return Util.quote(key);
 	}
 
-	private void addCommitToEnd(ExportConfig exportConfig, PrintWriter out, AtomicInteger batchCount) {
-		if (batchCount.get() % exportConfig.getBatchSize() != 0) {
-			out.append(exportConfig.getFormat().commit());
-		}
-	}
-
-	private void writeBatchBegin(ExportConfig exportConfig, PrintWriter out, AtomicInteger batchCount) {
-		if (isBatchMatch(exportConfig, batchCount)) {
-			out.append(exportConfig.getFormat().begin());
-		}
-	}
-
-	private void writeUnwindStart(ExportConfig exportConfig, PrintWriter out, AtomicInteger batchCount) {
-		if (isUnwindBatchMatch(exportConfig, batchCount)) {
-			String start = (exportConfig.getFormat() == ExportFormat.CYPHER_SHELL
-					&& exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) ?
-					":param rows => [" : "UNWIND [";
-			out.append(start);
-		}
-	}
-
-	private void writeUnwindEnd(ExportConfig exportConfig, PrintWriter out) {
+	private void writeUnwindEnd(ExportConfig exportConfig, Writer out) throws IOException {
 		out.append("]");
 		if (exportConfig.getFormat() == ExportFormat.CYPHER_SHELL
 				&& exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) {
@@ -408,33 +266,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		out.append(" AS row");
 	}
 
-	private String getUniqueConstrainedLabel(Node node, Map<String, Set<String>> uniqueConstraints) {
-		return uniqueConstraints.entrySet().stream()
-				.filter(e -> node.hasLabel(Label.label(e.getKey())) && e.getValue().stream().anyMatch(k -> node.hasProperty(k)))
-				.map(e -> e.getKey())
-				.findFirst()
-				.orElse(CypherFormatterUtils.UNIQUE_ID_LABEL);
-	}
-
-	private Set<String> getUniqueConstrainedProperties(Map<String, Set<String>> uniqueConstraints, String uniqueConstrainedLabel) {
-		Set<String> props = uniqueConstraints.get(uniqueConstrainedLabel);
-		if (props == null || props.isEmpty()) {
-			props = Collections.singleton(UNIQUE_ID_PROP);
-		}
-		return props;
-	}
-
-	private Set<String> getLabels(Node node) {
-		Set<String> labels = StreamSupport.stream(node.getLabels().spliterator(), false)
-				.map(Label::name)
-				.collect(Collectors.toSet());
-		if (labels.isEmpty()) {
-			labels.add(CypherFormatterUtils.UNIQUE_ID_LABEL);
-		}
-		return labels;
-	}
-
-	private void writeRelationshipMatchAsciiNode(Node node, PrintWriter out, String key, Map<String, Set<String>> uniqueConstraints) {
+	private void writeRelationshipMatchAsciiNode(Node node, Writer out, String key, Map<String, Set<String>> uniqueConstraints) throws IOException {
 		String uniqueConstrainedLabel = getUniqueConstrainedLabel(node, uniqueConstraints);
 		Set<String> uniqueConstrainedProps = getUniqueConstrainedProperties(uniqueConstraints, uniqueConstrainedLabel);
 
@@ -447,37 +279,6 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		out.append("{");
 		writeSetProperties(out, uniqueConstrainedProps, key + ".");
 		out.append("})");
-	}
-
-	private void writeRelationshipNodeIds(Map<String, Set<String>> uniqueConstraints, PrintWriter out, String key, Node node) {
-		String uniqueConstrainedLabel = getUniqueConstrainedLabel(node, uniqueConstraints);
-		Set<String> props = getUniqueConstrainedProperties(uniqueConstraints, uniqueConstrainedLabel);
-		Map<String, Object> properties;
-		if (!props.contains(UNIQUE_ID_PROP)) {
-			String[] propsArray = props.toArray(new String[props.size()]);
-			properties = node.getProperties(propsArray);
-		} else {
-			// UNIQUE_ID_PROP is always the only member of the Set
-			properties = Util.map(UNIQUE_ID_PROP, node.getId());
-		}
-
-		out.append(key + ": ");
-		out.append("{");
-		writeNodeIds(out, properties);
-		out.append("}");
-	}
-
-	private void writeNodeIds(PrintWriter out, Map<String, Object> properties) {
-		int size = properties.size();
-		for (Map.Entry<String, Object> es : properties.entrySet()) {
-			--size;
-			out.append(formatNodeId(es.getKey()));
-			out.append(":");
-			out.append(CypherFormatterUtils.toString(es.getValue()));
-			if (size > 0) {
-				out.append(", ");
-			}
-		}
 	}
 }
 

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -1,12 +1,13 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.cypher.TemplateCypher;
 import apoc.export.util.ExportConfig;
-import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
-import java.io.PrintWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,12 +44,22 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForNodes("MERGE ", "ON CREATE SET ", node, uniqueConstraints, exportConfig, out, reporter, db);
+	public void groupNodes(Iterable<Node> nodes, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher) {
+		super.groupNodes(nodes, uniqueConstraints, db, templateCypher);
 	}
 
 	@Override
-	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForRelationships("CREATE ", " SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+	public void groupRelationships(Iterable<Relationship> relationships, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher) {
+		super.groupRelationships(relationships, uniqueConstraints, db, templateCypher);
+	}
+
+	@Override
+	public void closeUnwindNodes(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, Map.Entry<Set<String>, Set<String>> key, Node node) throws IOException {
+		closeUnwindNodes("MERGE ", "ON CREATE SET ", uniqueConstraints, exportConfig, out, key, node);
+	}
+
+	@Override
+	public void closeUnwindRelationships(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, String start, String end, Map<String, Object> path, Relationship relationship) throws IOException {
+		closeUnwindRelationships("CREATE ", " SET ", uniqueConstraints, exportConfig, out, start, end, path, relationship);
 	}
 }

--- a/core/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
@@ -1,12 +1,12 @@
 package apoc.export.cypher.formatter;
 
 import apoc.export.util.ExportConfig;
-import apoc.export.util.Reporter;
-import org.neo4j.graphdb.GraphDatabaseService;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
-import java.io.PrintWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,7 +31,7 @@ public class CreateCypherFormatter extends AbstractCypherFormatter implements Cy
             result.append(CypherFormatterUtils.formatNodeProperties("", node, uniqueConstraints, indexNames, true));
             result.append("}");
         }
-        result.append(");");
+        result.append(");" + StringUtils.LF);
         return result.toString();
     }
 
@@ -48,18 +48,18 @@ public class CreateCypherFormatter extends AbstractCypherFormatter implements Cy
             result.append(CypherFormatterUtils.formatRelationshipProperties("", relationship, true));
             result.append("}");
         }
-        result.append("]->(n2);");
+        result.append("]->(n2);" + StringUtils.LF);
         return result.toString();
     }
 
     @Override
-    public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-        buildStatementForNodes("CREATE ", "SET ", node, uniqueConstraints, exportConfig, out, reporter, db);
+    public void closeUnwindNodes(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, Map.Entry<Set<String>, Set<String>> key, Node node) throws IOException {
+        closeUnwindNodes("CREATE ", "SET ", uniqueConstraints, exportConfig, out, key, node);
     }
 
     @Override
-    public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-        buildStatementForRelationships("CREATE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+    public void closeUnwindRelationships(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, String start, String end, Map<String, Object> path, Relationship relationship) throws IOException {
+        closeUnwindRelationships("CREATE ", "SET ", uniqueConstraints, exportConfig, out, start, end, path, relationship);
     }
 
 }

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -1,10 +1,11 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.cypher.TemplateCypher;
 import apoc.export.util.ExportConfig;
-import apoc.export.util.Reporter;
 import org.neo4j.graphdb.*;
 
-import java.io.PrintWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,8 +30,12 @@ public interface CypherFormatter {
 
 	String statementForCleanUp(int batchSize);
 
-	void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
+	void groupRelationships(Iterable<Relationship> relationships, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher);
+	
+	void groupNodes(Iterable<Node> nodes, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher);
+	
+	void closeUnwindNodes(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, Map.Entry<Set<String>, Set<String>> key, Node node) throws IOException;
 
-	void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
+	void closeUnwindRelationships(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, String start, String end, Map<String, Object> path, Relationship rel) throws IOException;
 
 }

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -42,30 +42,46 @@ public class CypherFormatterUtils {
 
     public final static String FUNCTION_TEMPLATE = "%s('%s')";
 
-    private static boolean isBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
-        return batchCount.get() % exportConfig.getBatchSize() == 0;
-    }
+    // ---- handlebars helpers ----
 
-    private static void writeBatchBegin(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
-        if (isBatchMatch(exportConfig, batchCount)) {
-            out.append(exportConfig.getFormat().begin());
+    public static void getGroupedNodes(Writer out, TemplateCypher templateCypher, Node node, Map<String, Set<String>> uniqueConstraints, Map.Entry<Set<String>, Set<String>> key, boolean isLast) throws IOException {
+        ExportConfig exportConfig = templateCypher.getExportConfig();
+        AtomicInteger unwindCount = templateCypher.getUnwindCount();
+        AtomicInteger batchCount = templateCypher.getNodeBatchCount();
+        final AtomicInteger propertiesCount = templateCypher.getPropertyCount();
+
+        writeBatchBegin(exportConfig, out, batchCount);
+        writeUnwindStart(exportConfig, out, unwindCount);
+        batchCount.incrementAndGet();
+        unwindCount.incrementAndGet();
+        Map<String, Object> props = node.getAllProperties();
+        // start element
+        out.append("{");
+
+        // id
+        Map<String, Object> idMap = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints);
+        writeNodeIds(out, idMap);
+
+        // properties
+        out.append(", ");
+        out.append("properties:");
+
+        propertiesCount.addAndGet(props.size());
+        props.keySet().removeAll(idMap.keySet());
+        writeProperties(out, props);
+
+        // end element
+        out.append("}");
+        if (isLast || isBatchMatch(exportConfig, batchCount) || isUnwindBatchMatch(exportConfig, unwindCount)) {
+            exportConfig.getCypherFormat().getFormatter().closeUnwindNodes(uniqueConstraints, exportConfig, out, key, node);
+            writeBatchEnd(exportConfig, out, batchCount);
+            unwindCount.set(0);
+        } else {
+            out.append(", ");
         }
     }
-    
-	private static void writeUnwindStart(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
-		if (isUnwindBatchMatch(exportConfig, batchCount)) {
-			String start = (exportConfig.getFormat() == ExportFormat.CYPHER_SHELL
-					&& exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) ?
-					":param rows => [" : "UNWIND [";
-			out.append(start);
-		}
-	}
 
-    private static boolean isUnwindBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
-        return batchCount.get() % exportConfig.getUnwindBatchSize() == 0;
-    }
-
-    public static void getGroupedRels(/*String relationshipClause, String setClause, */Writer out, TemplateCypher templateCypher, Relationship rel, Map<String, Set<String>> uniqueConstraints, Map<String, Object> path, boolean isLast) throws IOException {
+    public static void getGroupedRels(Writer out, TemplateCypher templateCypher, Relationship rel, Map<String, Set<String>> uniqueConstraints, Map<String, Object> path, boolean isLast) throws IOException {
         ExportConfig exportConfig = templateCypher.getExportConfig();
         AtomicInteger unwindCount = templateCypher.getUnwindCount();
         AtomicInteger batchCount = templateCypher.getRelBatchCount();
@@ -109,7 +125,30 @@ public class CypherFormatterUtils {
             out.append(", ");
         }
     }
-    
+
+    private static boolean isBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
+        return batchCount.get() % exportConfig.getBatchSize() == 0;
+    }
+
+    private static void writeBatchBegin(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
+        if (isBatchMatch(exportConfig, batchCount)) {
+            out.append(exportConfig.getFormat().begin());
+        }
+    }
+
+    private static void writeUnwindStart(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
+        if (isUnwindBatchMatch(exportConfig, batchCount)) {
+            String start = (exportConfig.getFormat() == ExportFormat.CYPHER_SHELL
+                    && exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) ?
+                    ":param rows => [" : "UNWIND [";
+            out.append(start);
+        }
+    }
+
+    private static boolean isUnwindBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
+        return batchCount.get() % exportConfig.getUnwindBatchSize() == 0;
+    }
+
 
     private static void writeRelationshipNodeIds(Map<String, Set<String>> uniqueConstraints, Writer out, String key, Node node) throws IOException {
         String uniqueConstrainedLabel = getUniqueConstrainedLabel(node, uniqueConstraints);
@@ -128,50 +167,14 @@ public class CypherFormatterUtils {
         writeNodeIds(out, properties);
         out.append("}");
     }
-
-    public static void getGroupedNodes(Writer out, TemplateCypher templateCypher, Node node, Map<String, Set<String>> uniqueConstraints, Map.Entry<Set<String>, Set<String>> key, boolean isLast) throws IOException {
-        ExportConfig exportConfig = templateCypher.getExportConfig();
-        AtomicInteger unwindCount = templateCypher.getUnwindCount();
-        AtomicInteger batchCount = templateCypher.getNodeBatchCount();
-        final AtomicInteger propertiesCount = templateCypher.getPropertyCount();
-        
-        writeBatchBegin(exportConfig, out, batchCount);
-        writeUnwindStart(exportConfig, out, unwindCount);
-        batchCount.incrementAndGet();
-        unwindCount.incrementAndGet();
-        Map<String, Object> props = node.getAllProperties();
-        // start element
-        out.append("{");
-
-        // id
-        Map<String, Object> idMap = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints);
-        writeNodeIds(out, idMap);
-
-        // properties
-        out.append(", ");
-        out.append("properties:");
-
-        propertiesCount.addAndGet(props.size());
-        props.keySet().removeAll(idMap.keySet());
-        writeProperties(out, props);
-
-        // end element
-        out.append("}");
-        if (isLast || isBatchMatch(exportConfig, batchCount) || isUnwindBatchMatch(exportConfig, unwindCount)) {
-            exportConfig.getCypherFormat().getFormatter().closeUnwindNodes(/*nodeClause, setClause, */uniqueConstraints, exportConfig, out, key, node);
-            writeBatchEnd(exportConfig, out, batchCount);
-            unwindCount.set(0);
-        } else {
-            out.append(", ");
-        }
-    }
+    
     private static void writeBatchEnd(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
         if (isBatchMatch(exportConfig, batchCount)) {
             out.append(exportConfig.getFormat().commit());
         }
     }
     
-    public static void writeProperties(Writer out, Map<String, Object> props) throws IOException {
+    private static void writeProperties(Writer out, Map<String, Object> props) throws IOException {
         out.append("{");
         if (!props.isEmpty()) {
             int size = props.size();

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -1,19 +1,31 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.cypher.TemplateCypher;
+import apoc.export.util.ExportConfig;
+import apoc.export.util.ExportFormat;
 import apoc.export.util.FormatUtils;
 import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
 import java.lang.reflect.Array;
 import java.time.temporal.Temporal;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static apoc.export.util.FormatUtils.getLabelsSorted;
 
@@ -30,6 +42,188 @@ public class CypherFormatterUtils {
 
     public final static String FUNCTION_TEMPLATE = "%s('%s')";
 
+    private static boolean isBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
+        return batchCount.get() % exportConfig.getBatchSize() == 0;
+    }
+
+    private static void writeBatchBegin(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
+        if (isBatchMatch(exportConfig, batchCount)) {
+            out.append(exportConfig.getFormat().begin());
+        }
+    }
+    
+	private static void writeUnwindStart(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
+		if (isUnwindBatchMatch(exportConfig, batchCount)) {
+			String start = (exportConfig.getFormat() == ExportFormat.CYPHER_SHELL
+					&& exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) ?
+					":param rows => [" : "UNWIND [";
+			out.append(start);
+		}
+	}
+
+    private static boolean isUnwindBatchMatch(ExportConfig exportConfig, AtomicInteger batchCount) {
+        return batchCount.get() % exportConfig.getUnwindBatchSize() == 0;
+    }
+
+    public static void getGroupedRels(/*String relationshipClause, String setClause, */Writer out, TemplateCypher templateCypher, Relationship rel, Map<String, Set<String>> uniqueConstraints, Map<String, Object> path, boolean isLast) throws IOException {
+        ExportConfig exportConfig = templateCypher.getExportConfig();
+        AtomicInteger unwindCount = templateCypher.getUnwindCount();
+        AtomicInteger batchCount = templateCypher.getRelBatchCount();
+        final AtomicInteger propertiesCount = templateCypher.getPropertyCount();
+
+        String start = "start";
+        String end = "end";
+
+        writeBatchBegin(exportConfig, out, batchCount);
+        writeUnwindStart(exportConfig, out, unwindCount);
+        batchCount.incrementAndGet();
+        unwindCount.incrementAndGet();
+        Map<String, Object> props = rel.getAllProperties();
+        // start element
+        out.append("{");
+
+        // start node
+        Node startNode = rel.getStartNode();
+        writeRelationshipNodeIds(uniqueConstraints, out, start, startNode);
+
+        out.append(", ");
+
+        // end node
+        Node endNode = rel.getEndNode();
+        writeRelationshipNodeIds(uniqueConstraints, out, end, endNode);
+
+        // properties
+        out.append(", ");
+        out.append("properties:");
+        writeProperties(out, props);
+        propertiesCount.addAndGet(props.size());
+
+        // end element
+        out.append("}");
+
+        if (isLast || isBatchMatch(exportConfig, batchCount) || isUnwindBatchMatch(exportConfig, unwindCount)) {
+            exportConfig.getCypherFormat().getFormatter().closeUnwindRelationships(uniqueConstraints, exportConfig, out, start, end, path, rel);
+            writeBatchEnd(exportConfig, out, batchCount);
+            unwindCount.set(0);
+        } else {
+            out.append(", ");
+        }
+    }
+    
+
+    private static void writeRelationshipNodeIds(Map<String, Set<String>> uniqueConstraints, Writer out, String key, Node node) throws IOException {
+        String uniqueConstrainedLabel = getUniqueConstrainedLabel(node, uniqueConstraints);
+        Set<String> props = getUniqueConstrainedProperties(uniqueConstraints, uniqueConstrainedLabel);
+        Map<String, Object> properties;
+        if (!props.contains(UNIQUE_ID_PROP)) {
+            String[] propsArray = props.toArray(new String[props.size()]);
+            properties = node.getProperties(propsArray);
+        } else {
+            // UNIQUE_ID_PROP is always the only member of the Set
+            properties = Util.map(UNIQUE_ID_PROP, node.getId());
+        }
+
+        out.append(key + ": ");
+        out.append("{");
+        writeNodeIds(out, properties);
+        out.append("}");
+    }
+
+    public static void getGroupedNodes(Writer out, TemplateCypher templateCypher, Node node, Map<String, Set<String>> uniqueConstraints, Map.Entry<Set<String>, Set<String>> key, boolean isLast) throws IOException {
+        ExportConfig exportConfig = templateCypher.getExportConfig();
+        AtomicInteger unwindCount = templateCypher.getUnwindCount();
+        AtomicInteger batchCount = templateCypher.getNodeBatchCount();
+        final AtomicInteger propertiesCount = templateCypher.getPropertyCount();
+        
+        writeBatchBegin(exportConfig, out, batchCount);
+        writeUnwindStart(exportConfig, out, unwindCount);
+        batchCount.incrementAndGet();
+        unwindCount.incrementAndGet();
+        Map<String, Object> props = node.getAllProperties();
+        // start element
+        out.append("{");
+
+        // id
+        Map<String, Object> idMap = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints);
+        writeNodeIds(out, idMap);
+
+        // properties
+        out.append(", ");
+        out.append("properties:");
+
+        propertiesCount.addAndGet(props.size());
+        props.keySet().removeAll(idMap.keySet());
+        writeProperties(out, props);
+
+        // end element
+        out.append("}");
+        if (isLast || isBatchMatch(exportConfig, batchCount) || isUnwindBatchMatch(exportConfig, unwindCount)) {
+            exportConfig.getCypherFormat().getFormatter().closeUnwindNodes(/*nodeClause, setClause, */uniqueConstraints, exportConfig, out, key, node);
+            writeBatchEnd(exportConfig, out, batchCount);
+            unwindCount.set(0);
+        } else {
+            out.append(", ");
+        }
+    }
+    private static void writeBatchEnd(ExportConfig exportConfig, Writer out, AtomicInteger batchCount) throws IOException {
+        if (isBatchMatch(exportConfig, batchCount)) {
+            out.append(exportConfig.getFormat().commit());
+        }
+    }
+    
+    public static void writeProperties(Writer out, Map<String, Object> props) throws IOException {
+        out.append("{");
+        if (!props.isEmpty()) {
+            int size = props.size();
+            for (Map.Entry<String, Object> es : props.entrySet()) {
+                --size;
+                out.append(Util.quote(es.getKey()));
+                out.append(":");
+                out.append(CypherFormatterUtils.toString(es.getValue()));
+                if (size > 0) {
+                    out.append(", ");
+                }
+            }
+        }
+        out.append("}");
+    }
+    
+    public static String getUniqueConstrainedLabel(Node node, Map<String, Set<String>> uniqueConstraints) {
+        return uniqueConstraints.entrySet().stream()
+                .filter(e -> node.hasLabel(Label.label(e.getKey())) && e.getValue().stream().anyMatch(k -> node.hasProperty(k)))
+                .map(e -> e.getKey())
+                .findFirst()
+                .orElse(UNIQUE_ID_LABEL);
+    }
+
+    public static Set<String> getUniqueConstrainedProperties(Map<String, Set<String>> uniqueConstraints, String uniqueConstrainedLabel) {
+        Set<String> props = uniqueConstraints.get(uniqueConstrainedLabel);
+        if (props == null || props.isEmpty()) {
+            props = Collections.singleton(UNIQUE_ID_PROP);
+        }
+        return props;
+    }
+
+    private static String formatNodeId(String key) {
+        if (CypherFormatterUtils.UNIQUE_ID_PROP.equals(key)) {
+            key = "_id";
+        }
+        return Util.quote(key);
+    }
+
+    private static void writeNodeIds(Writer out, Map<String, Object> properties) throws IOException {
+        int size = properties.size();
+        for (Map.Entry<String, Object> es : properties.entrySet()) {
+            --size;
+            out.append(formatNodeId(es.getKey()));
+            out.append(":");
+            out.append(CypherFormatterUtils.toString(es.getValue()));
+            if (size > 0) {
+                out.append(", ");
+            }
+        }
+    }
+    
     // ---- node id ----
 
     public static  String formatNodeLookup(String id, Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexNames) {

--- a/core/src/main/java/apoc/export/cypher/formatter/TemplateCypherHelpers.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/TemplateCypherHelpers.java
@@ -1,0 +1,187 @@
+package apoc.export.cypher.formatter;
+
+import apoc.export.cypher.TemplateCypher;
+import apoc.util.Util;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.internal.helpers.collection.Iterables;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static apoc.export.cypher.MultiStatementCypherSubGraphExporter.countArtificialUniques;
+import static apoc.export.cypher.MultiStatementCypherSubGraphExporter.toLabels;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_LABEL;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
+
+
+public enum TemplateCypherHelpers implements Helper<Object> {
+
+    getGroupedNodes {
+        @Override
+        public Object apply(final Object value, final Options options) throws IOException {
+            try(StringWriter writer = new StringWriter()) {
+                CypherFormatterUtils.getGroupedNodes(writer, (TemplateCypher) value, options.param(0), options.param(1), options.param(2), asBoolean(options, 3));
+                return writer.toString();
+            }
+        }
+    },
+
+
+    getGroupedRels {
+        @Override
+        public Object apply(final Object value, final Options options) throws IOException {
+            try(StringWriter writer = new StringWriter()) {
+                CypherFormatterUtils.getGroupedRels(writer, (TemplateCypher) value, options.param(0), options.param(1), options.param(2), asBoolean(options, 3));
+                return writer.toString();
+            }
+        }
+    },
+
+
+    initGroupedRels {
+        @Override
+        public Object apply(final Object value, final Options options) throws IOException {
+            TemplateCypher templateCypher = (TemplateCypher) value;
+            final int relListSize = ((List<Node>) options.param(0)).size();
+            templateCypher.incrementRelCount(relListSize);
+            return null;
+        }
+    },
+
+    initGroupedNodes {
+        @Override
+        public Object apply(final Object value, final Options options) throws IOException {
+            TemplateCypher templateCypher = (TemplateCypher) value;
+            final int nodeListSize = ((List<Node>) options.param(0)).size();
+            templateCypher.incrementNodeCount(nodeListSize);
+            return null;
+        }
+    },
+
+    modIsZero {
+        @Override
+        public Object apply(final Object value, final Options options) throws IOException {
+            return ((int) value) % (int) options.param(0) == 0;
+        }
+    },
+
+    toLong {
+        @Override
+        public Object apply(final Object value, final Options options) throws IOException {
+            return (long) (int) value;
+        }
+    },
+
+    forLoop {
+        @Override
+        public Object apply(final Object value, final Options options) throws IOException {
+            Options.Buffer buffer = options.buffer();
+            for(long i = 0; i < (long) value; i = i + (long) options.param(0)) {
+                buffer.append(options.fn());
+            }
+            return buffer;
+        }
+    },
+
+    statementRel {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            final Relationship rel = (Relationship) value;
+            
+            TemplateCypher templateCypher = options.param(0);
+            CypherFormatter cypherFormatter = templateCypher.getExportConfig().getCypherFormat().getFormatter();
+            final String cypher = cypherFormatter.statementForRelationship(rel, options.param(1), options.param(2));
+            if (Util.isNotNullOrEmpty(cypher)) {
+                templateCypher.getReporter().update(0, 1, Iterables.count(rel.getPropertyKeys()));
+                return cypher;
+            }
+            return null;
+        }
+    },
+
+
+    statementNode {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            final Node node = (Node) value;
+
+            TemplateCypher templateCypher = options.param(0);
+            CypherFormatter cypherFormatter = templateCypher.getExportConfig().getCypherFormat().getFormatter();
+            
+            templateCypher.incrementArtificialUniques(countArtificialUniques(node));
+            String cypher = cypherFormatter.statementForNode(node, options.param(1), options.param(2), options.param(3));
+
+            if (Util.isNotNullOrEmpty(cypher)) {
+                templateCypher.getReporter().update(1, 0, Iterables.count(node.getPropertyKeys()));
+                return cypher;
+            }
+            return null;
+        }
+    },
+
+    formatConstraint {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            final IndexDefinition constraint = (IndexDefinition) value;
+            final Iterable<String> props = constraint.getPropertyKeys();
+            final String label = Iterables.single(constraint.getLabels()).name();
+            return ((CypherFormatter) options.param(0)).statementForConstraint(label, props);
+        }
+    },
+
+    statementConstraintUnique {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            String statement = ((CypherFormatter) value).statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP));
+            if (options.param(0, false)) {
+                statement = statement.replaceAll("^CREATE", "DROP");
+            }
+            return statement;
+        }
+    },
+
+    statementForCleanup {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            return ((CypherFormatter) value).statementForCleanUp(options.param(0));
+        }
+    },
+
+    statementForNodeFullTextIndex {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            List<Label> labels = toLabels(options.param(1));
+            return ((CypherFormatter) value).statementForNodeFullTextIndex(options.param(0), labels, options.param(2));
+        }
+    },
+
+    statementForIndex {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            String tokenName = ((List<String>) options.param(0)).get(0);
+            return ((CypherFormatter) value).statementForIndex(tokenName, options.param(1));
+        }
+    },
+
+    keysString {
+        @Override
+        public Object apply(final Object value, final Options options) {
+            return StreamSupport.stream(((Iterable<String>) value).spliterator(), false)
+                    .map(key -> "node." + CypherFormatterUtils.quote(key))
+                    .collect(Collectors.joining(", "));
+        }
+    };
+
+    private static boolean asBoolean(Options options, int i) {
+        return !options.isFalsy(options.param(i));
+    }
+}

--- a/core/src/main/java/apoc/export/cypher/formatter/TemplateCypherHelpers.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/TemplateCypherHelpers.java
@@ -108,7 +108,6 @@ public enum TemplateCypherHelpers implements Helper<Object> {
         }
     },
 
-
     statementNode {
         @Override
         public Object apply(final Object value, final Options options) {
@@ -134,15 +133,17 @@ public enum TemplateCypherHelpers implements Helper<Object> {
             final IndexDefinition constraint = (IndexDefinition) value;
             final Iterable<String> props = constraint.getPropertyKeys();
             final String label = Iterables.single(constraint.getLabels()).name();
-            return ((CypherFormatter) options.param(0)).statementForConstraint(label, props);
+            return ((CypherFormatter) options.param(0)).statementForConstraint(label, props, options.param(1));
         }
     },
 
     statementConstraintUnique {
         @Override
         public Object apply(final Object value, final Options options) {
-            String statement = ((CypherFormatter) value).statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP));
-            if (options.param(0, false)) {
+            final boolean isDrop = options.param(0, false);
+            String statement = ((CypherFormatter) value).statementForConstraint(
+                    UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), isDrop ? false : options.param(1));
+            if (isDrop) {
                 statement = statement.replaceAll("^CREATE", "DROP");
             }
             return statement;
@@ -168,7 +169,7 @@ public enum TemplateCypherHelpers implements Helper<Object> {
         @Override
         public Object apply(final Object value, final Options options) {
             String tokenName = ((List<String>) options.param(0)).get(0);
-            return ((CypherFormatter) value).statementForIndex(tokenName, options.param(1));
+            return ((CypherFormatter) value).statementForIndex(tokenName, options.param(1), options.param(2));
         }
     },
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
@@ -1,12 +1,13 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.cypher.TemplateCypher;
 import apoc.export.util.ExportConfig;
-import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
-import java.io.PrintWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,12 +29,22 @@ public class UpdateAllCypherFormatter extends AbstractCypherFormatter implements
 	}
 
 	@Override
-	public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForNodes("MERGE ", "SET ", node, uniqueConstraints, exportConfig, out, reporter, db);
+	public void groupNodes(Iterable<Node> nodes, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher) {
+		super.groupNodes(nodes, uniqueConstraints, db, templateCypher);
 	}
 
 	@Override
-	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+	public void groupRelationships(Iterable<Relationship> relationships, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher) {
+		super.groupRelationships(relationships, uniqueConstraints, db, templateCypher);
+	}
+
+	@Override
+	public void closeUnwindNodes(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, Map.Entry<Set<String>, Set<String>> key, Node node) throws IOException {
+		closeUnwindNodes("MERGE ", "SET ", uniqueConstraints, exportConfig, out, key, node);
+	}
+
+	@Override
+	public void closeUnwindRelationships(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, String start, String end, Map<String, Object> path, Relationship relationship) throws IOException {
+		closeUnwindRelationships("MERGE ", "SET ", uniqueConstraints, exportConfig, out, start, end, path, relationship);
 	}
 }

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -1,12 +1,13 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.cypher.TemplateCypher;
 import apoc.export.util.ExportConfig;
-import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
-import java.io.PrintWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,13 +42,22 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists) {
 		return "";
 	}
-
+	
 	@Override
-	public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+	public void groupNodes(Iterable<Node> nodes, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher) {
 	}
 
 	@Override
-	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+	public void groupRelationships(Iterable<Relationship> relationships, Map<String, Set<String>> uniqueConstraints, GraphDatabaseService db, TemplateCypher templateCypher) {
+		super.groupRelationships(relationships, uniqueConstraints, db, templateCypher);
+	}
+
+	@Override
+	public void closeUnwindNodes(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, Map.Entry<Set<String>, Set<String>> key, Node node) {
+	}
+
+	@Override
+	public void closeUnwindRelationships(Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, Writer out, String start, String end, Map<String, Object> path, Relationship relationship) throws IOException {
+		closeUnwindRelationships("MERGE ", "SET ", uniqueConstraints, exportConfig, out, start, end, path, relationship);
 	}
 }

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -211,7 +211,8 @@ public class ExportConfig extends CompressionConfig {
         return sampling;
     }
     
-    public boolean ifNotExists() {
+    // changed in "isIfNotExists" to be recognized by handlebars
+    public boolean isIfNotExists() {
         return ifNotExists;
     }
 }

--- a/core/src/main/resources/cleanup.hbs
+++ b/core/src/main/resources/cleanup.hbs
@@ -5,6 +5,6 @@
         {{commit~}}
     {{~/forLoop~}}
     {{~begin~}}
-    {{~{statementConstraintUnique @root.exportConfig.cypherFormat.formatter true}~}}
+    {{~{statementConstraintUnique @root.exportConfig.cypherFormat.formatter true @root.exportConfig.ifNotExists}~}}
     {{commit~}}
 {{/gt}}

--- a/core/src/main/resources/cleanup.hbs
+++ b/core/src/main/resources/cleanup.hbs
@@ -1,0 +1,10 @@
+{{~#gt artificialUniques (toLong 0)~}}
+    {{~#forLoop artificialUniques (toLong exportConfig.batchSize)~}}
+        {{~begin~}}
+        {{~{statementForCleanup @root.exportConfig.cypherFormat.formatter exportConfig.batchSize}~}}
+        {{commit~}}
+    {{~/forLoop~}}
+    {{~begin~}}
+    {{~{statementConstraintUnique @root.exportConfig.cypherFormat.formatter true}~}}
+    {{commit~}}
+{{/gt}}

--- a/core/src/main/resources/nodes.hbs
+++ b/core/src/main/resources/nodes.hbs
@@ -1,0 +1,13 @@
+{{~#each nodes~}}
+    {{#if @first~}}{{~begin~}}{{~/if~}}
+    {{#and (gt @key 0) (modIsZero @key exportConfig.batchSize)}}{{~commit~}}{{~begin~}}{{~/and~}}
+    {{~{statementNode this @root uniqueConstraints indexedProperties indexNames}~}}
+    {{#if @last~}}{{~commit~}}{{~/if~}}
+{{~/each~}}
+{{~#each groupedNodes as |value key|~}}
+    {{~initGroupedNodes @root value~}}
+    {{~#each value as |valueNode keyNode|~}}
+        {{~{getGroupedNodes @root valueNode @root.uniqueConstraints key @last}~}}
+    {{~/each~}}
+    {{~#and @last (not nodeBatchMatch)~}}{{commit~}}{{~/and~}}
+{{~/each~}}

--- a/core/src/main/resources/relationships.hbs
+++ b/core/src/main/resources/relationships.hbs
@@ -1,0 +1,13 @@
+{{~#each relationships~}}
+    {{~#if @first~}}{{~begin~}}{{~/if~}}
+    {{~#and (gt @key 0) (modIsZero @key exportConfig.batchSize)}}{{~commit~}}{{~begin~}}{{~/and~}}
+    {{~{statementRel this @root uniqueConstraints indexedProperties}~}}
+    {{~#if @first~}}{{~commit~}}{{~/if}}
+{{~/each~}}
+{{~#each groupedRelationships as |value key|~}}
+    {{initGroupedRels @root value~}}
+    {{#each value as |valueRel keyRel|}}
+        {{~{getGroupedRels @root valueRel @root.uniqueConstraints key @last}~}}
+    {{~/each}}
+{{~#and @last (not relBatchMatch)~}}{{commit~}}{{~/and~}}
+{{~/each~}}

--- a/core/src/main/resources/schema.hbs
+++ b/core/src/main/resources/schema.hbs
@@ -1,0 +1,21 @@
+{{#unless indexesAndUniqueEmpty~}}
+    {{~begin~}}
+    {{~#each templateSchema.indexes~}}
+        {{#eq type "FULLTEXT"~}}
+        {{~{statementForNodeFullTextIndex @root.exportConfig.cypherFormat.formatter name labelsOrTypes properties}~}}
+        {{else}}
+        {{~{statementForIndex @root.exportConfig.cypherFormat.formatter labelsOrTypes properties}~}}
+        {{/eq~}}
+    {{~/each~}}
+    {{#each templateSchema.constraints~}}
+        {{~{formatConstraint this @root.exportConfig.cypherFormat.formatter}~}}
+    {{/each~}}
+    {{#gt artificialUniques (toLong 0)~}}
+        {{{statementConstraintUnique @root.exportConfig.cypherFormat.formatter}~}}
+    {{/gt~}}
+    {{commit~}}
+    {{#if templateSchema.withIndexes}}
+        {{~templateSchema.indexAwait~}}
+    {{/if}}
+    {{~templateSchema.schemaAwait~}}
+{{/unless~}}

--- a/core/src/main/resources/schema.hbs
+++ b/core/src/main/resources/schema.hbs
@@ -2,16 +2,16 @@
     {{~begin~}}
     {{~#each templateSchema.indexes~}}
         {{#eq type "FULLTEXT"~}}
-        {{~{statementForNodeFullTextIndex @root.exportConfig.cypherFormat.formatter name labelsOrTypes properties}~}}
+        {{~{statementForNodeFullTextIndex @root.exportConfig.cypherFormat.formatter name labelsOrTypes properties @root.exportConfig.ifNotExists}~}}
         {{else}}
-        {{~{statementForIndex @root.exportConfig.cypherFormat.formatter labelsOrTypes properties}~}}
+        {{~{statementForIndex @root.exportConfig.cypherFormat.formatter labelsOrTypes properties @root.exportConfig.ifNotExists}~}}
         {{/eq~}}
     {{~/each~}}
     {{#each templateSchema.constraints~}}
-        {{~{formatConstraint this @root.exportConfig.cypherFormat.formatter}~}}
+        {{~{formatConstraint this @root.exportConfig.cypherFormat.formatter @root.exportConfig.ifNotExists}~}}
     {{/each~}}
     {{#gt artificialUniques (toLong 0)~}}
-        {{{statementConstraintUnique @root.exportConfig.cypherFormat.formatter}~}}
+        {{{statementConstraintUnique @root.exportConfig.cypherFormat.formatter false @root.exportConfig.ifNotExists}~}}
     {{/gt~}}
     {{commit~}}
     {{#if templateSchema.withIndexes}}


### PR DESCRIPTION
Fixes 1260

Moved all template stuff in handlebars-implementation.
Added `TemplateCypher.java`
Added `CypherFormatterUtils.java`
