### PR TITLE
issue 2159: apoc.load.ldap add support spaces in a DN when loading credential information from conf

### DIFF
--- a/core/src/test/java/apoc/cypher/CypherTest.java
+++ b/core/src/test/java/apoc/cypher/CypherTest.java
@@ -63,7 +63,7 @@ public class CypherTest {
 
     @BeforeClass
     public static void setUp() {
-        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, false);
         TestUtil.registerProcedure(db, Cypher.class, Utils.class, CypherFunctions.class, Timeboxed.class, Strings.class);
     }
 

--- a/core/src/test/java/apoc/cypher/CypherTest.java
+++ b/core/src/test/java/apoc/cypher/CypherTest.java
@@ -63,7 +63,7 @@ public class CypherTest {
 
     @BeforeClass
     public static void setUp() {
-        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, false);
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, Cypher.class, Utils.class, CypherFunctions.class, Timeboxed.class, Strings.class);
     }
 

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     compileOnly "org.apache.poi:poi-ooxml:3.17"
     testCompile "org.apache.poi:poi-ooxml:3.17"
 
+    testCompile group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.8.1'
+    
     compile 'org.jsoup:jsoup:1.11.3'
 
     compile group: 'org.roaringbitmap', name: 'RoaringBitmap', version: '0.7.17'

--- a/full/src/main/java/apoc/load/LoadLdap.java
+++ b/full/src/main/java/apoc/load/LoadLdap.java
@@ -29,7 +29,7 @@ public class LoadLdap {
     public static Map<String, Object> getConnectionMap(Object conn) {
         if (conn instanceof String) {
             //String value = "ldap.forumsys.com cn=read-only-admin,dc=example,dc=com password";
-            String value = apocConfig().getString("apoc.loadldap" + conn.toString() + ".config");
+            String value = apocConfig().getString("apoc.loadldap." + conn.toString() + ".config");
             // format <ldaphost:port> <logindn> <loginpw>
             if (value == null) throw new RuntimeException("No apoc.loadldap."+conn+".config ldap access configuration specified");
             Map<String, Object> config = new HashMap<>();

--- a/full/src/test/java/apoc/load/LoadLdapCommonTest.java
+++ b/full/src/test/java/apoc/load/LoadLdapCommonTest.java
@@ -1,0 +1,33 @@
+package apoc.load;
+
+import org.zapodot.junit.ldap.EmbeddedLdapRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class LoadLdapCommonTest {
+    private static final int LDAP_PORT = 12345;
+    
+    static final String LDAP_HOST = "127.0.0.1:" + LDAP_PORT;
+    static final String LDAP_PASSWORD = "myPassword";
+    static final Map<String, String> SEARCH_MAP = Map.of("searchBase", "dc=example1,dc=com", "searchScope", "SCOPE_SUB", "searchFilter", "(&(objectClass=*domain))");
+
+    
+    static EmbeddedLdapRule buildLdapRule(String loginDn) {
+        return EmbeddedLdapRuleBuilder
+                .newInstance()
+                .usingDomainDsn("dc=example1,dc=com")
+                .importingLdifs("example.ldif")
+                .usingBindDSN(loginDn)
+                .usingBindCredentials(LDAP_PASSWORD)
+                .bindingToPort(LDAP_PORT)
+                .build();
+    }
+
+    static void ldapAssertions(Map<String, Object> r) {
+        assertEquals("ou=Users,dc=example1,dc=com", r.get("dn"));
+        assertEquals("foobar", r.get("uniqueMember"));
+    }
+}

--- a/full/src/test/java/apoc/load/LoadLdapStaticTest.java
+++ b/full/src/test/java/apoc/load/LoadLdapStaticTest.java
@@ -1,0 +1,50 @@
+package apoc.load;
+
+import apoc.cache.Static;
+import apoc.util.TestUtil;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRule;
+
+import java.util.Map;
+
+import static apoc.ApocConfig.apocConfig;
+import static apoc.load.LoadLdapCommonTest.LDAP_HOST;
+import static apoc.load.LoadLdapCommonTest.LDAP_PASSWORD;
+import static apoc.load.LoadLdapCommonTest.SEARCH_MAP;
+import static apoc.load.LoadLdapCommonTest.buildLdapRule;
+import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.singletonList;
+
+public class LoadLdapStaticTest {
+    private static final String LOGIN_DN_WITH_SPACES = "CN=testuser,OU=System users,OU=Users,dc=example,dc=com";
+
+    @Rule
+    public EmbeddedLdapRule embeddedLdapRule = buildLdapRule(LOGIN_DN_WITH_SPACES);
+
+    @BeforeClass
+    public static void setUp() {
+        apocConfig().setProperty("apoc.static.ldap.host", LDAP_HOST);
+        apocConfig().setProperty("apoc.static.ldap.loginDn", LOGIN_DN_WITH_SPACES);
+        apocConfig().setProperty("apoc.static.ldap.password", LDAP_PASSWORD);
+        TestUtil.registerProcedure(db, LoadLdap.class, Static.class);
+    }
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.procedure_unrestricted, singletonList("apoc.*"));
+
+
+    @Test
+    public void testLoadLdapProcedureWithStatics() {
+        testCall(db, "CALL apoc.load.ldap({ldapHost : apoc.static.get('ldap.host'), loginDN : apoc.static.get('ldap.loginDn'), loginPW : apoc.static.get('ldap.password')}, $searchMap)\n" +
+                        "YIELD entry RETURN entry.dn as dn,  entry.uniqueMember as uniqueMember",
+                Map.of("searchMap", SEARCH_MAP),
+                LoadLdapCommonTest::ldapAssertions);
+    }
+}

--- a/full/src/test/java/apoc/load/LoadLdapTest.java
+++ b/full/src/test/java/apoc/load/LoadLdapTest.java
@@ -1,17 +1,59 @@
 package apoc.load;
 
 
+import apoc.util.TestUtil;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPSearchResults;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRule;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import static apoc.ApocConfig.apocConfig;
+import static apoc.load.LoadLdapCommonTest.LDAP_HOST;
+import static apoc.load.LoadLdapCommonTest.LDAP_PASSWORD;
+import static apoc.load.LoadLdapCommonTest.SEARCH_MAP;
+import static apoc.load.LoadLdapCommonTest.buildLdapRule;
+import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
 
 public class LoadLdapTest {
+    private static final String LOGIN_DN = "CN=testuser,OU=Systemusers,OU=Users,dc=example,dc=com";
+    private static final String LDAP_KEY = "myldap";
+
+    @Rule
+    public EmbeddedLdapRule embeddedLdapRule = buildLdapRule(LOGIN_DN);
+    
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+    
+    @BeforeClass
+    public static void setUp() {
+        apocConfig().setProperty("apoc.loadldap." + LDAP_KEY + ".config", String.format("%s %s %s", LDAP_HOST, LOGIN_DN, LDAP_PASSWORD));
+        TestUtil.registerProcedure(db, LoadLdap.class);
+    }
+    
+    @Test
+    public void testLoadLdapProcedureWithAuthKeyString() {
+        testCall(db, "CALL apoc.load.ldap($key, $searchMap) YIELD entry RETURN entry.dn as dn,  entry.uniqueMember as uniqueMember",
+                Map.of("key", LDAP_KEY, "searchMap", SEARCH_MAP), 
+                LoadLdapCommonTest::ldapAssertions);
+    }
+
+    @Test
+    public void testLoadLdapProcedureWithAuthMap() {
+        testCall(db, "CALL apoc.load.ldap($conn, $searchMap) YIELD entry RETURN entry.dn as dn,  entry.uniqueMember as uniqueMember",
+                Map.of("conn", Map.of("ldapHost", LDAP_HOST, "loginDN", LOGIN_DN, "loginPW", LDAP_PASSWORD), 
+                        "searchMap", SEARCH_MAP),
+                LoadLdapCommonTest::ldapAssertions);
+    }
 
     @Test
     public void testLoadLDAP() throws Exception {

--- a/full/src/test/resources/example.ldif
+++ b/full/src/test/resources/example.ldif
@@ -1,0 +1,10 @@
+dn: dc=example1,dc=com
+objectClass: domain
+objectClass: top
+dc: example
+uniqueMember: foobar
+ 
+dn: ou=Users,dc=example1,dc=com
+objectClass: organizationalUnit
+objectClass: top
+ou: Users


### PR DESCRIPTION
- Added test case to cover issue 2159 case
- Fixed bug with `apoc.static.ldap` key (in `LoadLdap.java`)