### PR TITLE
issue 1152 - 2247: APOC trigger: deletedNodes does not return info of the Node (properties, labels) only the id in before phase

### DIFF
--- a/core/src/main/java/apoc/result/VirtualRelationship.java
+++ b/core/src/main/java/apoc/result/VirtualRelationship.java
@@ -28,6 +28,11 @@ public class VirtualRelationship implements Relationship {
     private final long id;
     private final Map<String, Object> props = new HashMap<>();
 
+    public VirtualRelationship(Node startNode, Node endNode, RelationshipType type, Map<String, Object> props) {
+        this(startNode, endNode, type);
+        this.props.putAll(props);
+    }
+
     public VirtualRelationship(Node startNode, Node endNode, RelationshipType type) {
         validateNodes(startNode, endNode);
         this.id = MIN_ID.getAndDecrement();

--- a/core/src/main/java/apoc/trigger/TriggerHandler.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandler.java
@@ -206,7 +206,7 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     @Override
     public Void beforeCommit(TransactionData txData, Transaction transaction, GraphDatabaseService databaseService) {
         if (hasPhase(Phase.before)) {
-            executeTriggers(transaction, txData, Phase.before, true);
+            executeTriggers(transaction, txData, Phase.before);
         }
         return null;
     }
@@ -215,7 +215,7 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     public void afterCommit(TransactionData txData, Void state, GraphDatabaseService databaseService) {
         if (hasPhase(Phase.after)) {
             try (Transaction tx = db.beginTx()) {
-                executeTriggers(tx, txData, Phase.after, false);
+                executeTriggers(tx, txData, Phase.after);
                 tx.commit();
             }
         }
@@ -236,7 +236,7 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     public void afterRollback(TransactionData txData, Void state, GraphDatabaseService databaseService) {
         if (hasPhase(Phase.rollback)) {
             try (Transaction tx = db.beginTx()) {
-                executeTriggers(tx, txData, Phase.rollback, false);
+                executeTriggers(tx, txData, Phase.rollback);
                 tx.commit();
             }
         }
@@ -248,8 +248,8 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
                 .anyMatch(selector -> when(selector, phase));
     }
 
-    private void executeTriggers(Transaction tx, TransactionData txData, Phase phase, boolean rebindDeleted) {
-        executeTriggers(tx, TriggerMetadata.from(txData, rebindDeleted), phase);
+    private void executeTriggers(Transaction tx, TransactionData txData, Phase phase) {
+        executeTriggers(tx, TriggerMetadata.from(txData, false), phase);
     }
 
     private void executeTriggers(Transaction tx, TriggerMetadata triggerMetadata, Phase phase) {

--- a/core/src/main/java/apoc/trigger/TriggerHandler.java
+++ b/core/src/main/java/apoc/trigger/TriggerHandler.java
@@ -206,7 +206,7 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     @Override
     public Void beforeCommit(TransactionData txData, Transaction transaction, GraphDatabaseService databaseService) {
         if (hasPhase(Phase.before)) {
-            executeTriggers(transaction, txData, Phase.before);
+            executeTriggers(transaction, txData, Phase.before, true);
         }
         return null;
     }
@@ -215,7 +215,7 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     public void afterCommit(TransactionData txData, Void state, GraphDatabaseService databaseService) {
         if (hasPhase(Phase.after)) {
             try (Transaction tx = db.beginTx()) {
-                executeTriggers(tx, txData, Phase.after);
+                executeTriggers(tx, txData, Phase.after, false);
                 tx.commit();
             }
         }
@@ -236,7 +236,7 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
     public void afterRollback(TransactionData txData, Void state, GraphDatabaseService databaseService) {
         if (hasPhase(Phase.rollback)) {
             try (Transaction tx = db.beginTx()) {
-                executeTriggers(tx, txData, Phase.rollback);
+                executeTriggers(tx, txData, Phase.rollback, false);
                 tx.commit();
             }
         }
@@ -248,8 +248,8 @@ public class TriggerHandler extends LifecycleAdapter implements TransactionEvent
                 .anyMatch(selector -> when(selector, phase));
     }
 
-    private void executeTriggers(Transaction tx, TransactionData txData, Phase phase) {
-        executeTriggers(tx, TriggerMetadata.from(txData, false), phase);
+    private void executeTriggers(Transaction tx, TransactionData txData, Phase phase, boolean rebindDeleted) {
+        executeTriggers(tx, TriggerMetadata.from(txData, rebindDeleted), phase);
     }
 
     private void executeTriggers(Transaction tx, TriggerMetadata triggerMetadata, Phase phase) {

--- a/core/src/main/java/apoc/trigger/TriggerMetadata.java
+++ b/core/src/main/java/apoc/trigger/TriggerMetadata.java
@@ -100,11 +100,11 @@ public class TriggerMetadata {
                                 .map(LabelEntry::label)
                                 .toArray(Label[]::new);
                         final Map<String, Object> props = getProps(txData.removedNodeProperties(), node);
-                        return new VirtualNode(node.getId(), labels, props);
+                        return new VirtualNode(labels, props);
                     } else {
                         Relationship rel = (Relationship) e;
                         final Map<String, Object> props = getProps(txData.removedRelationshipProperties(), rel);
-                        return new VirtualRelationship(rel.getId(), rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
+                        return new VirtualRelationship(rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
                     }
                 })
                 .collect(Collectors.toList());
@@ -121,10 +121,7 @@ public class TriggerMetadata {
         final List<Relationship> createdRelationships = Util.rebind(this.createdRelationships, tx);
 //        final List<Node> deletedNodes = Util.rebind(this.deletedNodes, tx);
 //        final List<Relationship> deletedRelationships = Util.rebind(this.deletedRelationships, tx);
-        final Map<String, List<Node>> removedLabels = rebindMap(this.removedLabels, tx);
         final Map<String, List<Node>> assignedLabels = rebindMap(this.assignedLabels, tx);
-        final Map<String, List<PropertyEntryContainer<Node>>> removedNodeProperties = rebindPropertyEntryContainer(this.removedNodeProperties, tx);
-        final Map<String, List<PropertyEntryContainer<Relationship>>> removedRelationshipProperties = rebindPropertyEntryContainer(this.removedRelationshipProperties, tx);
         final Map<String, List<PropertyEntryContainer<Node>>> assignedNodeProperties = rebindPropertyEntryContainer(this.assignedNodeProperties, tx);
         final Map<String, List<PropertyEntryContainer<Relationship>>> assignedRelationshipProperties = rebindPropertyEntryContainer(this.assignedRelationshipProperties, tx);
         return new TriggerMetadata(transactionId, commitTime, createdNodes, createdRelationships, deletedNodes, deletedRelationships,

--- a/core/src/main/java/apoc/trigger/TriggerMetadata.java
+++ b/core/src/main/java/apoc/trigger/TriggerMetadata.java
@@ -92,10 +92,11 @@ public class TriggerMetadata {
 
     private static <T extends Entity> List<T> rebindDeleted(List<T> entities, TransactionData txData) {
         return (List<T>) entities.stream()
-                .map(e -> { 
+                .map(e -> {
                     if (e instanceof Node) {
                         Node node = (Node) e;
-                        final Label[] labels = Iterables.stream(Iterables.filter(label -> label.node().equals(node), txData.removedLabels()))
+                        final Label[] labels = Iterables.stream(txData.removedLabels())
+                                .filter(label -> label.node().equals(node))
                                 .map(LabelEntry::label)
                                 .toArray(Label[]::new);
                         final Map<String, Object> props = getProps(txData.removedNodeProperties(), node);
@@ -109,8 +110,9 @@ public class TriggerMetadata {
                 .collect(Collectors.toList());
     }
 
-    private static <T extends Entity> Map<String, Object> getProps(Iterable<PropertyEntry<T>> i, T e) {
-        return Iterables.stream(Iterables.filter(label -> label.entity().equals(e), i))
+    private static <T extends Entity> Map<String, Object> getProps(Iterable<PropertyEntry<T>> propertyEntries, T entity) {
+        return Iterables.stream(propertyEntries)
+                .filter(label -> label.entity().equals(entity))
                 .collect(Collectors.toMap(PropertyEntry::key, PropertyEntry::previouslyCommittedValue));
     }
 

--- a/core/src/main/java/apoc/trigger/TriggerMetadata.java
+++ b/core/src/main/java/apoc/trigger/TriggerMetadata.java
@@ -77,8 +77,8 @@ public class TriggerMetadata {
         }
         List<Node> createdNodes = Convert.convertToList(txData.createdNodes());
         List<Relationship> createdRelationships = Convert.convertToList(txData.createdRelationships());
-        List<Node> deletedNodes = rebindDeleted ? rebindDeleted(Convert.convertToList(txData.deletedNodes())) : Convert.convertToList(txData.deletedNodes());
-        List<Relationship> deletedRelationships = rebindDeleted ? rebindDeleted(Convert.convertToList(txData.deletedRelationships())) : Convert.convertToList(txData.deletedRelationships());
+        List<Node> deletedNodes = rebindDeleted ? rebindDeleted(Convert.convertToList(txData.deletedNodes()), txData) : Convert.convertToList(txData.deletedNodes());
+        List<Relationship> deletedRelationships = rebindDeleted ? rebindDeleted(Convert.convertToList(txData.deletedRelationships()), txData) : Convert.convertToList(txData.deletedRelationships());
         Map<String, List<Node>> removedLabels = aggregateLabels(txData.removedLabels());
         Map<String, List<Node>> assignedLabels = aggregateLabels(txData.assignedLabels());
         final Map<String, List<PropertyEntryContainer<Node>>> removedNodeProperties = aggregatePropertyKeys(txData.removedNodeProperties(), true);
@@ -90,19 +90,28 @@ public class TriggerMetadata {
                 assignedRelationshipProperties, txData.metaData());
     }
 
-    private static <T extends Entity> List<T> rebindDeleted(List<T> entities) {
+    private static <T extends Entity> List<T> rebindDeleted(List<T> entities, TransactionData txData) {
         return (List<T>) entities.stream()
-                .map(e -> {
+                .map(e -> { 
                     if (e instanceof Node) {
                         Node node = (Node) e;
-                        Label[] labels = Iterables.asArray(Label.class, node.getLabels());
-                        return new VirtualNode(labels, e.getAllProperties());
+                        final Label[] labels = Iterables.stream(Iterables.filter(label -> label.node().equals(node), txData.removedLabels()))
+                                .map(LabelEntry::label)
+                                .toArray(Label[]::new);
+                        final Map<String, Object> props = getProps(txData.removedNodeProperties(), node);
+                        return new VirtualNode(node.getId(), labels, props);
                     } else {
                         Relationship rel = (Relationship) e;
-                        return new VirtualRelationship(rel.getStartNode(), rel.getEndNode(), rel.getType());
+                        final Map<String, Object> props = getProps(txData.removedRelationshipProperties(), rel);
+                        return new VirtualRelationship(rel.getId(), rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
                     }
                 })
                 .collect(Collectors.toList());
+    }
+
+    private static <T extends Entity> Map<String, Object> getProps(Iterable<PropertyEntry<T>> i, T e) {
+        return Iterables.stream(Iterables.filter(label -> label.entity().equals(e), i))
+                .collect(Collectors.toMap(PropertyEntry::key, PropertyEntry::previouslyCommittedValue));
     }
 
     public TriggerMetadata rebind(Transaction tx) {

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -1,7 +1,5 @@
 package apoc.trigger;
 
-import apoc.create.Create;
-import apoc.nodes.Nodes;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -16,14 +14,12 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocSettings.apoc_trigger_enabled;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestricted;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 
 /**
@@ -34,7 +30,6 @@ public class TriggerTest {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
-            .withSetting(procedure_unrestricted, List.of("apoc.*"))
             .withSetting(apoc_trigger_enabled, true);  // need to use settings here, apocConfig().setProperty in `setUp` is too late
 
     private long start;
@@ -42,7 +37,7 @@ public class TriggerTest {
     @Before
     public void setUp() throws Exception {
         start = System.currentTimeMillis();
-        TestUtil.registerProcedure(db, Trigger.class, Nodes.class, Create.class);
+        TestUtil.registerProcedure(db, Trigger.class);
     }
 
     @Test
@@ -71,52 +66,13 @@ public class TriggerTest {
     }
 
     @Test
-    public void testIssue1152()  {
-        final Long id = db.executeTransactionally("CREATE (n:To:Delete {prop1: 'val1', prop2: 'val2'}) RETURN id(n) as id", Collections.emptyMap(), 
-                r -> r.<Long>columnAs("id").next());
-        
-        // we check that we can execute write operation (through virtualNode functions)
-        db.executeTransactionally("call apoc.trigger.add('ugone', " +
-                "\"UNWIND $deletedNodes as deletedNode CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode " +
-                "CALL apoc.create.addLabels(r, apoc.node.labels(deletedNode)) yield node with node, deletedNode " +
-                "set node+=apoc.any.properties(deletedNode)\" ,{phase:'before'})");
-        db.executeTransactionally("MATCH (f:To:Delete) DELETE f");
-        
-        TestUtil.testCall(db, "MATCH (n:Report:To:Delete) RETURN n", (row) -> {
-            final Node n = (Node) row.get("n");
-            assertEquals("val1", n.getProperty("prop1"));
-            assertEquals("val2", n.getProperty("prop2"));
-            assertEquals(id, n.getProperty("id"));
-        });
-    }
-
-    @Test
     public void testIssue2247() {
         db.executeTransactionally("CREATE (n:ToBeDeleted)");
         db.executeTransactionally("CALL apoc.trigger.add('myTrig', 'RETURN 1', {phase: 'afterAsync'})");
-        
-        db.executeTransactionally("MATCH (n:ToBeDeleted) DELETE n");
-        
-        db.executeTransactionally("CALL apoc.trigger.remove('myTrig')");
-    }
 
-    @Test
-    public void testDeletedRelationshipWithBefore()  {
-        final Long id = db.executeTransactionally("CREATE (:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End) RETURN id(r) as id", Collections.emptyMap(), 
-                r -> r.<Long>columnAs("id").next());
-        
-        db.executeTransactionally("call apoc.trigger.add('ugone', " +
-                "\"UNWIND $deletedRelationships as deletedRel CREATE (r:Report {id: id(deletedRel), type: apoc.rel.type(deletedRel)}) WITH r, deletedRel " +
-                "set r+=apoc.any.properties(deletedRel)\" ,{phase:'before'})");
-        db.executeTransactionally("MATCH (:Start)-[r:MY_TYPE]->(:End) DELETE r");
-        
-        TestUtil.testCall(db, "MATCH (n:Report) RETURN n", (row) -> {
-            final Node n = (Node) row.get("n");
-            assertEquals("MY_TYPE", n.getProperty("type"));
-            assertEquals("val1", n.getProperty("prop1"));
-            assertEquals("val2", n.getProperty("prop2"));
-            assertEquals(id, n.getProperty("id"));
-        });
+        db.executeTransactionally("MATCH (n:ToBeDeleted) DELETE n");
+
+        db.executeTransactionally("CALL apoc.trigger.remove('myTrig')");
     }
 
     @Test

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -1,5 +1,6 @@
 package apoc.trigger;
 
+import apoc.nodes.Nodes;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -7,6 +8,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.coreapi.TransactionImpl;
@@ -14,12 +16,14 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocSettings.apoc_trigger_enabled;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestricted;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 
 /**
@@ -30,6 +34,7 @@ public class TriggerTest {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(procedure_unrestricted, List.of("apoc*"))
             .withSetting(apoc_trigger_enabled, true);  // need to use settings here, apocConfig().setProperty in `setUp` is too late
 
     private long start;
@@ -37,7 +42,7 @@ public class TriggerTest {
     @Before
     public void setUp() throws Exception {
         start = System.currentTimeMillis();
-        TestUtil.registerProcedure(db, Trigger.class);
+        TestUtil.registerProcedure(db, Trigger.class, Nodes.class);
     }
 
     @Test
@@ -252,20 +257,73 @@ public class TriggerTest {
     }
 
     @Test
-    public void testDeleteRelationshipsAsync() throws Exception {
-        db.executeTransactionally("CREATE (a:A {name: \"A\"})-[:R1]->(z:Z {name: \"Z\"}), (a)-[:R2]->(z)");
-        db.executeTransactionally("CALL apoc.trigger.add('trigger-after-async', 'UNWIND $deletedRelationships AS r\n" +
+    public void testDeleteRelationshipsAsync() {
+        db.executeTransactionally("CREATE (a:A {name: \"A\"})-[:R1 {omega: 3}]->(z:Z {name: \"Z\"}), (a)-[:R2 {alpha: 1}]->(z)");
+        final String query = "UNWIND $deletedRelationships AS r\n" +
                 "MATCH (a)-[r1:R1]->(z)\n" +
-                "SET r1.triggerAfterAsync = size($deletedRelationships) > 0, r1.size = size($deletedRelationships), r1.deleted = type(r) RETURN *', {phase: 'afterAsync'})");
-        db.executeTransactionally("MATCH (a:A {name: \"A\"})-[r:R2]->(z:Z {name: \"Z\"})\n" +
-                "DELETE r");
+                "SET a.alpha = apoc.any.property(r, \"alpha\"), r1.triggerAfterAsync = size($deletedRelationships) > 0, r1.size = size($deletedRelationships), r1.deleted = type(r) RETURN *";
+        db.executeTransactionally("CALL apoc.trigger.add('trigger-after-async-1', $query, {phase: 'afterAsync'})",
+                map("query", query));
+
+        // delete rel
+        commonDeleteAfterAsync("MATCH (a:A {name: 'A'})-[r:R2]->(z:Z {name: 'Z'}) DELETE r");
+    }
+
+    @Test
+    public void testDeleteRelationshipsAsyncWithCreationInQuery() {
+        db.executeTransactionally("CREATE (a:A {name: \"A\"})-[:R1 {omega: 3}]->(z:Z {name: \"Z\"}), (a)-[:R2 {alpha: 1}]->(z)");
+        final String query = "UNWIND $deletedRelationships AS r\n" +
+                "CREATE (a:A)-[r1:R1 {omega: 3}]->(z)\n" +
+                "SET a.alpha = apoc.any.property(r, \"alpha\"), r1.triggerAfterAsync = size($deletedRelationships) > 0, r1.size = size($deletedRelationships), r1.deleted = type(r) RETURN *";
+        db.executeTransactionally("CALL apoc.trigger.add('trigger-after-async-2', $query, {phase: 'afterAsync'})",
+                map("query", query));
+
+        // delete rel
+        commonDeleteAfterAsync("MATCH (a:A {name: 'A'})-[r:R2]->(z:Z {name: 'Z'}) DELETE r");
+    }
+
+    @Test
+    public void testDeleteNodesAsync() {
+        db.executeTransactionally("CREATE (a:A {name: 'A'})-[:R1 {omega: 3}]->(z:Z {name: 'Z'}), (:R2:Other {alpha: 1})");
+        final String query = "UNWIND $deletedNodes AS n\n" +
+                "MATCH (a)-[r1:R1]->(z)\n" +
+                "SET a.alpha = apoc.any.property(n, \"alpha\"), r1.triggerAfterAsync = size($deletedNodes) > 0, r1.size = size($deletedNodes), r1.deleted = apoc.node.labels(n)[0] RETURN *";
+        
+        db.executeTransactionally("CALL apoc.trigger.add('trigger-after-async-3', $query, {phase: 'afterAsync'})", 
+                map("query", query));
+
+        // delete node
+        commonDeleteAfterAsync("MATCH (n:R2) DELETE n");
+    }
+
+    @Test
+    public void testDeleteNodesAsyncWithCreationQuery() {
+        db.executeTransactionally("CREATE (:R2:Other {alpha: 1})");
+        final String query = "UNWIND $deletedNodes AS n\n" +
+                "CREATE (a:A)-[r1:R1 {omega: 3}]->(z:Z)\n" +
+                "SET a.alpha = apoc.any.property(n, \"alpha\"), r1.triggerAfterAsync = size($deletedNodes) > 0, r1.size = size($deletedNodes), r1.deleted = apoc.node.labels(n)[0] RETURN *";
+        
+        db.executeTransactionally("CALL apoc.trigger.add('trigger-after-async-4', $query, {phase: 'afterAsync'})", 
+                map("query", query));
+
+        // delete node
+        commonDeleteAfterAsync("MATCH (n:R2) DELETE n");
+    }
+    
+    private void commonDeleteAfterAsync(String deleteQuery) {
+        db.executeTransactionally(deleteQuery);
+        
+        final Map<String, Object> expectedProps = Map.of("deleted", "R2",
+                "triggerAfterAsync", true,
+                "size", 1L,
+                "omega", 3L);
 
         org.neo4j.test.assertion.Assert.assertEventually(() ->
-                        db.executeTransactionally("MATCH ()-[r:R1]->() RETURN r", Map.of(),
+                        db.executeTransactionally("MATCH (a:A {alpha: 1})-[r:R1]->() RETURN r", Map.of(),
                                 result -> {
-                                    final Relationship r = result.<Relationship>columnAs("r").next();
-                                    return (boolean) r.getProperty("triggerAfterAsync", false)
-                                            && r.getProperty("deleted", "").equals("R2");
+                                    final ResourceIterator<Relationship> relIterator = result.columnAs("r");
+                                    return relIterator.hasNext()
+                                            && relIterator.next().getAllProperties().equals(expectedProps);
                                 })
                 , (value) -> value, 30L, TimeUnit.SECONDS);
     }

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -91,6 +91,16 @@ public class TriggerTest {
     }
 
     @Test
+    public void testIssue2247() {
+        db.executeTransactionally("CREATE (n:ToBeDeleted)");
+        db.executeTransactionally("CALL apoc.trigger.add('myTrig', 'RETURN 1', {phase: 'afterAsync'})");
+        
+        db.executeTransactionally("MATCH (n:ToBeDeleted) DELETE n");
+        
+        db.executeTransactionally("CALL apoc.trigger.remove('myTrig')");
+    }
+
+    @Test
     public void testDeletedRelationshipWithBefore()  {
         final Long id = db.executeTransactionally("CREATE (:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End) RETURN id(r) as id", Collections.emptyMap(), 
                 r -> r.<Long>columnAs("id").next());

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -1,5 +1,7 @@
 package apoc.trigger;
 
+import apoc.create.Create;
+import apoc.nodes.Nodes;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,12 +16,14 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocSettings.apoc_trigger_enabled;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestricted;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 
 /**
@@ -30,6 +34,7 @@ public class TriggerTest {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(procedure_unrestricted, List.of("apoc.*"))
             .withSetting(apoc_trigger_enabled, true);  // need to use settings here, apocConfig().setProperty in `setUp` is too late
 
     private long start;
@@ -37,7 +42,7 @@ public class TriggerTest {
     @Before
     public void setUp() throws Exception {
         start = System.currentTimeMillis();
-        TestUtil.registerProcedure(db, Trigger.class);
+        TestUtil.registerProcedure(db, Trigger.class, Nodes.class, Create.class);
     }
 
     @Test
@@ -62,6 +67,45 @@ public class TriggerTest {
         db.executeTransactionally("MATCH (f:Foo) DELETE f");
         TestUtil.testCall(db, "MATCH (c:Counter) RETURN c.count as count", (row) -> {
             assertEquals(1L, row.get("count"));
+        });
+    }
+
+    @Test
+    public void testIssue1152()  {
+        final Long id = db.executeTransactionally("CREATE (n:To:Delete {prop1: 'val1', prop2: 'val2'}) RETURN id(n) as id", Collections.emptyMap(), 
+                r -> r.<Long>columnAs("id").next());
+        
+        // we check that we can execute write operation (through virtualNode functions)
+        db.executeTransactionally("call apoc.trigger.add('ugone', " +
+                "\"UNWIND $deletedNodes as deletedNode CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode " +
+                "CALL apoc.create.addLabels(r, apoc.node.labels(deletedNode)) yield node with node, deletedNode " +
+                "set node+=apoc.any.properties(deletedNode)\" ,{phase:'before'})");
+        db.executeTransactionally("MATCH (f:To:Delete) DELETE f");
+        
+        TestUtil.testCall(db, "MATCH (n:Report:To:Delete) RETURN n", (row) -> {
+            final Node n = (Node) row.get("n");
+            assertEquals("val1", n.getProperty("prop1"));
+            assertEquals("val2", n.getProperty("prop2"));
+            assertEquals(id, n.getProperty("id"));
+        });
+    }
+
+    @Test
+    public void testDeletedRelationshipWithBefore()  {
+        final Long id = db.executeTransactionally("CREATE (:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End) RETURN id(r) as id", Collections.emptyMap(), 
+                r -> r.<Long>columnAs("id").next());
+        
+        db.executeTransactionally("call apoc.trigger.add('ugone', " +
+                "\"UNWIND $deletedRelationships as deletedRel CREATE (r:Report {id: id(deletedRel), type: apoc.rel.type(deletedRel)}) WITH r, deletedRel " +
+                "set r+=apoc.any.properties(deletedRel)\" ,{phase:'before'})");
+        db.executeTransactionally("MATCH (:Start)-[r:MY_TYPE]->(:End) DELETE r");
+        
+        TestUtil.testCall(db, "MATCH (n:Report) RETURN n", (row) -> {
+            final Node n = (Node) row.get("n");
+            assertEquals("MY_TYPE", n.getProperty("type"));
+            assertEquals("val1", n.getProperty("prop1"));
+            assertEquals("val2", n.getProperty("prop2"));
+            assertEquals(id, n.getProperty("id"));
         });
     }
 

--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -317,6 +317,34 @@ CALL apoc.trigger.add('timeParams','UNWIND $createdNodes AS n SET n.time = $time
 ----
 
 
+
+[NOTE]
+====
+To retrieve information about nodes and relations, we leverage on xref::virtual/virtual-nodes-rels.adoc[virtual nodes and relationships],
+so (except for internal entity `id`), you can use `apoc.any.properties`, `apoc.rel.type` and `apoc.node.labels` to get entity info. 
+====
+
+For example, with a node `(:To:Delete {prop1: 'val1', prop2: 'val2'})` we can execute:
+[source,cypher]
+----
+CALL apoc.trigger.add('myTrigger', 
+"UNWIND $deletedNodes as deletedNode CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode 
+CALL apoc.create.addLabels(r, apoc.node.labels(deletedNode)) yield node with node, deletedNode 
+set node+=apoc.any.properties(deletedNode)" ,
+{phase:'before'})
+----
+to create a node `Report` with the same properties (plus the id) and with additional label retrieved by the deleted node.
+
+Instead with a rel `(:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End)` we can execute:
+[source,cypher]
+----
+CALL apoc.trigger.add('myTrigger', 
+"UNWIND $deletedRelationships as deletedRel CREATE (r:Report {id: id(deletedRel), type: apoc.rel.type(deletedRel)}) 
+WITH r, deletedRelset r+=apoc.any.properties(deletedRel)" ,
+{phase:'before'})
+----
+to create a node `Report` with the same properties (plus the id and rel-type as additional properties).
+
 .Other examples
 [source,cypher]
 ----

--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -61,6 +61,8 @@ You can use these helper functions to extract nodes or relationships by label/re
 |===
 | apoc.trigger.nodesByLabel($assignedLabels/$assignedNodeProperties,'Label') | function to filter entries by label, to be used within a trigger statement with `$assignedLabels` and `$removedLabels`
 | apoc.trigger.propertiesByKey($assignedNodeProperties,'key') | function to filter propertyEntries by property-key, to be used within a trigger statement with $assignedNode/RelationshipProperties and $removedNode/RelationshipProperties. Returns [{old,[new],key,node,relationship}]
+| apoc.trigger.rebuildNode(node, $removedLabels, $removedNodeProperties) | function to rebuild a node as a virtual, to be used in triggers with a not 'afterAsync' phase
+| apoc.trigger.rebuildRelationship(rel, $removedRelationshipProperties) | function to rebuild a relationship as a virtual, to be used in triggers with a not 'afterAsync' phase
 |===
 
 
@@ -316,34 +318,47 @@ We can pass as a 4th parameter, a `{params: {parameterMaps}}` to insert addition
 CALL apoc.trigger.add('timeParams','UNWIND $createdNodes AS n SET n.time = $time', {}, {params: {time: timestamp()}});
 ----
 
+.Handle deleted entities
 
+If we to create a 'before' or 'after' trigger query, with `$deletedRelationships` or `$deletedNodes`,
+and then we want to retrieve entities information like labels and/or properties,
+we cannot use the 'classic' cypher functions `labels()` and `properties()`,
+but we can leverage on xref::virtual/virtual-nodes-rels.adoc[virtual nodes and relationships],
+via the functions `apoc.trigger.rebuildNode(node, $removedLabels, $removedNodeProperties)` and `apoc.trigger.rebuildRelationship(rel, $removedRelationshipProperties)`.
 
-[NOTE]
-====
-To retrieve information about nodes and relations, we leverage on xref::virtual/virtual-nodes-rels.adoc[virtual nodes and relationships],
-so (except for internal entity `id`), you can use `apoc.any.properties`, `apoc.rel.type` and `apoc.node.labels` to get entity info. 
-====
+So that, we can retrieve information about nodes and relations, 
+using the `apoc.any.properties`, and the `apoc.node.labels` functions.
 
-For example, with a node `(:To:Delete {prop1: 'val1', prop2: 'val2'})` we can execute:
+For example, if we want to create a new node with the same properties (plus the id) and with an additional label retrieved for each deleted node, we can execute:
+
 [source,cypher]
 ----
 CALL apoc.trigger.add('myTrigger', 
-"UNWIND $deletedNodes as deletedNode CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode 
+"UNWIND $deletedNodes as deletedNode 
+WITH apoc.trigger.rebuildNode(deletedNode, $removedLabels, $removedNodeProperties) AS deletedNode 
+CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode 
 CALL apoc.create.addLabels(r, apoc.node.labels(deletedNode)) yield node with node, deletedNode 
 set node+=apoc.any.properties(deletedNode)" ,
 {phase:'before'})
 ----
-to create a node `Report` with the same properties (plus the id) and with additional label retrieved by the deleted node.
 
-Instead with a rel `(:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End)` we can execute:
+Or also, if we want to  create a node `Report` with the same properties (plus the id and rel-type as additional properties) for each deleted relationship, we can execute:
+
 [source,cypher]
 ----
 CALL apoc.trigger.add('myTrigger', 
-"UNWIND $deletedRelationships as deletedRel CREATE (r:Report {id: id(deletedRel), type: apoc.rel.type(deletedRel)}) 
+"UNWIND $deletedRelationships as deletedRel 
+WITH apoc.trigger.rebuildRelationship(deletedRel, $removedRelationshipProperties) AS deletedRel 
+CREATE (r:Report {id: id(deletedRel), type: apoc.rel.type(deletedRel)}) 
 WITH r, deletedRelset r+=apoc.any.properties(deletedRel)" ,
 {phase:'before'})
 ----
-to create a node `Report` with the same properties (plus the id and rel-type as additional properties).
+
+[NOTE]
+====
+By using phase 'afterAsync', we don't need to execute `apoc.trigger.rebuildNode` and `apoc.trigger.rebuildRelationship`,
+because using this one, the rebuild of entities is executed automatically under the hood.
+====
 
 .Other examples
 [source,cypher]

--- a/full/src/main/java/apoc/trigger/TriggerExtended.java
+++ b/full/src/main/java/apoc/trigger/TriggerExtended.java
@@ -3,12 +3,16 @@ package apoc.trigger;
 import apoc.Description;
 import apoc.Extended;
 import apoc.coll.SetBackedList;
+import apoc.result.VirtualNode;
+import apoc.result.VirtualRelationship;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.procedure.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -101,5 +105,42 @@ TriggerExtended {
             }
         }
         return new TriggerInfo(name, null, null, false, false);
+    }
+    
+    @UserFunction
+    @Description("apoc.trigger.rebuildNode(node, $removedLabels, $removedNodeProperties) | function to rebuild a node as a virtual, to be used in triggers with a not 'afterAsync' phase")
+    public Node rebuildNode(@Name("id") Node node, @Name("removedLabels") Map<String, List<Node>> removedLabels, @Name("removedNodeProperties") Map<String, List<Map>> removedNodeProperties) {
+
+        final long id = node.getId();
+        final Label[] labels = removedLabels.entrySet().stream()
+                .filter(i -> i.getValue().stream().anyMatch(l -> l.getId() == id))
+                .map(e -> Label.label(e.getKey()))
+                .toArray(Label[]::new);
+
+        final Map<String, Object> props = removedNodeProperties.entrySet().stream()
+                .map(i -> i.getValue().stream()
+                        .filter(l -> ((Node) l.get("node")).getId() == id)
+                        .findAny()
+                        .map(v -> new AbstractMap.SimpleEntry<>(i.getKey(), v.get("old"))))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+
+        return new VirtualNode(id, labels, props);
+    }
+    
+    @UserFunction
+    @Description("apoc.trigger.rebuildRelationship(rel, $removedRelationshipProperties) | function to rebuild a relationship as a virtual, to be used in triggers with a not 'afterAsync' phase")
+    public Relationship rebuildRelationship(@Name("id") Relationship rel, @Name("removedRelationshipProperties") Map<String, List<Map>> removedRelationshipProperties) {
+        final Map<String, Object> props = removedRelationshipProperties.entrySet().stream()
+                .map(i -> i.getValue().stream()
+                        .filter(l -> ((Relationship) l.get("relationship")).getId() == rel.getId())
+                        .findAny()
+                        .map(v -> new AbstractMap.SimpleEntry<>(i.getKey(), v.get("old"))))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+        
+        return new VirtualRelationship(rel.getId(), rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
     }
 }

--- a/full/src/main/java/apoc/trigger/TriggerExtended.java
+++ b/full/src/main/java/apoc/trigger/TriggerExtended.java
@@ -126,7 +126,7 @@ TriggerExtended {
                 .map(Optional::get)
                 .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
 
-        return new VirtualNode(id, labels, props);
+        return new VirtualNode(labels, props);
     }
     
     @UserFunction
@@ -141,6 +141,6 @@ TriggerExtended {
                 .map(Optional::get)
                 .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
         
-        return new VirtualRelationship(rel.getId(), rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
+        return new VirtualRelationship(rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
     }
 }

--- a/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
@@ -1,5 +1,7 @@
 package apoc.trigger;
 
+import apoc.create.Create;
+import apoc.nodes.Nodes;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -10,10 +12,13 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocSettings.apoc_trigger_enabled;
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestricted;
 
 /**
  * @author mh
@@ -22,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 public class TriggerExtendedTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(procedure_unrestricted, List.of("apoc*"))
             .withSetting(apoc_trigger_enabled, true);  // need to use settings here, apocConfig().setProperty in `setUp` is too late
 
     private long start;
@@ -29,7 +35,7 @@ public class TriggerExtendedTest {
     @Before
     public void setUp() throws Exception {
         start = System.currentTimeMillis();
-        TestUtil.registerProcedure(db, Trigger.class, TriggerExtended.class);
+        TestUtil.registerProcedure(db, Trigger.class, TriggerExtended.class, Nodes.class, Create.class);
     }
 
     @Test
@@ -80,4 +86,61 @@ public class TriggerExtendedTest {
                 (value) -> value == 2L, 30, TimeUnit.SECONDS);
     }
 
+    @Test
+    public void testIssue1152() {
+        final long id = TestUtil.singleResultFirstColumn(db, 
+                "CREATE (n:To:Delete {prop1: 'val1', prop2: 'val2'}) RETURN id(n) as id");
+        
+        testIssue1152Common(id, "before");
+        testIssue1152Common(id, "after");
+    }
+
+    private void testIssue1152Common(long id, String phase) {
+        // we check also that we can execute write operation (through virtualNode functions, e.g. apoc.create.addLabels)
+        final String query = "UNWIND $deletedNodes as deletedNode " +
+                "WITH apoc.trigger.rebuildNode(deletedNode, $removedLabels, $removedNodeProperties) AS deletedNode " +
+                "CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode " +
+                "CALL apoc.create.addLabels(r, apoc.node.labels(deletedNode)) yield node with node, deletedNode " +
+                "set node+=apoc.any.properties(deletedNode)";
+        
+        db.executeTransactionally("call apoc.trigger.add('issue1152', $query , {phase: $phase})",
+                Map.of("query", query, "phase", phase));
+
+        db.executeTransactionally("MATCH (f:To:Delete) DELETE f");
+
+        TestUtil.testCall(db, "MATCH (n:Report:To:Delete) RETURN n", (row) -> {
+            final Node n = (Node) row.get("n");
+            assertEquals("val1", n.getProperty("prop1"));
+            assertEquals("val2", n.getProperty("prop2"));
+            assertEquals(id, n.getProperty("id"));
+        });
+    }
+
+    @Test
+    public void testRetrievePropsDeletedRelationship() {
+        final long id = TestUtil.singleResultFirstColumn(db, 
+                "CREATE (:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End) RETURN id(r) as id");
+
+        testRetrievePropsDeletedRelationshipCommon(id, "before");
+        testRetrievePropsDeletedRelationshipCommon(id, "after");
+    }
+
+    private void testRetrievePropsDeletedRelationshipCommon(long id, String phase) {
+        final String query = "UNWIND $deletedRelationships as deletedRel " +
+                "WITH apoc.trigger.rebuildRelationship(deletedRel, $removedRelationshipProperties) AS deletedRel " +
+                "CREATE (r:Report {id: id(deletedRel), type: type(deletedRel)}) WITH r, deletedRel " +
+                "set r+=apoc.any.properties(deletedRel)";
+
+        db.executeTransactionally("call apoc.trigger.add('deleteRelationshipsBefore', $query , {phase: $phase})",
+                Map.of("query", query, "phase", phase));
+        db.executeTransactionally("MATCH (:Start)-[r:MY_TYPE]->(:End) DELETE r");
+
+        TestUtil.testCall(db, "MATCH (n:Report) RETURN n", (row) -> {
+            final Node n = (Node) row.get("n");
+            assertEquals("MY_TYPE", n.getProperty("type"));
+            assertEquals("val1", n.getProperty("prop1"));
+            assertEquals("val2", n.getProperty("prop2"));
+            assertEquals(id, n.getProperty("id"));
+        });
+    }
 }

--- a/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
@@ -6,6 +6,7 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.test.rule.DbmsRule;
@@ -14,6 +15,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocSettings.apoc_trigger_enabled;
@@ -88,14 +90,13 @@ public class TriggerExtendedTest {
 
     @Test
     public void testIssue1152() {
-        final long id = TestUtil.singleResultFirstColumn(db, 
-                "CREATE (n:To:Delete {prop1: 'val1', prop2: 'val2'}) RETURN id(n) as id");
+        db.executeTransactionally("CREATE (n:To:Delete {prop1: 'val1', prop2: 'val2'}) RETURN id(n) as id");
         
-        testIssue1152Common(id, "before");
-        testIssue1152Common(id, "after");
+        testIssue1152Common("before");
+        testIssue1152Common("after");
     }
 
-    private void testIssue1152Common(long id, String phase) {
+    private void testIssue1152Common(String phase) {
         // we check also that we can execute write operation (through virtualNode functions, e.g. apoc.create.addLabels)
         final String query = "UNWIND $deletedNodes as deletedNode " +
                 "WITH apoc.trigger.rebuildNode(deletedNode, $removedLabels, $removedNodeProperties) AS deletedNode " +
@@ -112,35 +113,47 @@ public class TriggerExtendedTest {
             final Node n = (Node) row.get("n");
             assertEquals("val1", n.getProperty("prop1"));
             assertEquals("val2", n.getProperty("prop2"));
-            assertEquals(id, n.getProperty("id"));
         });
     }
 
     @Test
     public void testRetrievePropsDeletedRelationship() {
-        final long id = TestUtil.singleResultFirstColumn(db, 
-                "CREATE (:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End) RETURN id(r) as id");
-
-        testRetrievePropsDeletedRelationshipCommon(id, "before");
-        testRetrievePropsDeletedRelationshipCommon(id, "after");
-    }
-
-    private void testRetrievePropsDeletedRelationshipCommon(long id, String phase) {
+        db.executeTransactionally("CREATE (s:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(e:End), (s)-[:REMAINING_REL]->(e)");
+        
         final String query = "UNWIND $deletedRelationships as deletedRel " +
                 "WITH apoc.trigger.rebuildRelationship(deletedRel, $removedRelationshipProperties) AS deletedRel " +
-                "CREATE (r:Report {id: id(deletedRel), type: type(deletedRel)}) WITH r, deletedRel " +
+                "MATCH (s)-[r:REMAINING_REL]->(e) WITH r, deletedRel " +
+                "set r+=apoc.any.properties(deletedRel), r.type= type(deletedRel)";
+
+        final String assertionQuery = "MATCH (:Start)-[n:REMAINING_REL]->(:End) RETURN n";
+        testRetrievePropsDeletedRelationshipCommon("before", query, assertionQuery);
+        testRetrievePropsDeletedRelationshipCommon("after", query, assertionQuery);
+    }
+
+    @Test
+    public void testRetrievePropsDeletedRelationshipWithQueryCreation() {
+        db.executeTransactionally("CREATE (:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End)");
+        
+        final String query = "UNWIND $deletedRelationships as deletedRel " +
+                "WITH apoc.trigger.rebuildRelationship(deletedRel, $removedRelationshipProperties) AS deletedRel " +
+                "CREATE (r:Report {type: type(deletedRel)}) WITH r, deletedRel " +
                 "set r+=apoc.any.properties(deletedRel)";
 
-        db.executeTransactionally("call apoc.trigger.add('deleteRelationshipsBefore', $query , {phase: $phase})",
-                Map.of("query", query, "phase", phase));
+        final String assertionQuery = "MATCH (n:Report) RETURN n";
+        testRetrievePropsDeletedRelationshipCommon("before", query, assertionQuery);
+        testRetrievePropsDeletedRelationshipCommon("after", query, assertionQuery);
+    }
+
+    private void testRetrievePropsDeletedRelationshipCommon(String phase, String triggerQuery, String assertionQuery) {
+        db.executeTransactionally("call apoc.trigger.add('myTrigger', $query , {phase: $phase})",
+                Map.of("name", UUID.randomUUID().toString(), "query", triggerQuery, "phase", phase));
         db.executeTransactionally("MATCH (:Start)-[r:MY_TYPE]->(:End) DELETE r");
 
-        TestUtil.testCall(db, "MATCH (n:Report) RETURN n", (row) -> {
-            final Node n = (Node) row.get("n");
+        TestUtil.testCall(db, assertionQuery, (row) -> {
+            final Entity n = (Entity) row.get("n");
             assertEquals("MY_TYPE", n.getProperty("type"));
             assertEquals("val1", n.getProperty("prop1"));
             assertEquals("val2", n.getProperty("prop2"));
-            assertEquals(id, n.getProperty("id"));
         });
     }
 }


### PR DESCRIPTION

issue 2247

Changed TriggerMetadata.rebindDeleted(), not to leverage on `node.getLabels()`, `node.getAllProperties()`, `rel.getAllProperties()` (these fail),
 but respectively on `txData.removedLabels()`, `txData.removedNodeProperties()` and `txData.removedRelationshipProperties()`.
- added tests in `TriggerTest.java`


issue 1152


- added `apoc.trigger.rebuildNode` and `apoc.trigger.rebuildRelationship`  to retrieve labels and props entity infos with phase 'before' and 'after' (via `apoc.any.properties` and `apoc.node.labels` functions), similarly to `TriggerMetadata.rebindDeleted()` function (which is called only with phase 'afterAsync')
- added docs
- added tests in `TriggerExtendedTest.java`