### PR TITLE
Issue 1948: Multi Char string not useable for splitting values in apoc.load.csv

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -73,7 +73,7 @@ public class CsvEntityLoader {
                                             new AbstractMap.SimpleEntry<>("type", f.getType()),
                                             new AbstractMap.SimpleEntry<>("array", f.isArray())
                                     ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
-                            return new Mapping(f.getName(), mappingMap, clc.getArrayDelimiter(), false);
+                            return new Mapping(f.getName(), mappingMap, clc.getArrayDelimiter(), false, Collections.emptyList());
                         }
                 )
         );
@@ -186,7 +186,7 @@ public class CsvEntityLoader {
                                             new AbstractMap.SimpleEntry<>("array", f.isArray())
                                     ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
 
-                            return new Mapping(f.getName(), mappingMap, clc.getArrayDelimiter(), false);
+                            return new Mapping(f.getName(), mappingMap, clc.getArrayDelimiter(), false, Collections.emptyList());
                         }
                 )
         );

--- a/core/src/main/java/apoc/load/Mapping.java
+++ b/core/src/main/java/apoc/load/Mapping.java
@@ -13,19 +13,21 @@ import static apoc.util.Util.parseCharFromConfig;
 import static java.util.Collections.emptyList;
 
 public class Mapping {
-    public static final Mapping EMPTY = new Mapping("", Collections.emptyMap(), LoadCsvConfig.DEFAULT_ARRAY_SEP, false);
+    public static final Mapping EMPTY = new Mapping("", Collections.emptyMap(), LoadCsvConfig.DEFAULT_ARRAY_SEP, false, Collections.emptyList());
     final String name;
     final Collection<String> nullValues;
     final Meta.Types type;
     final boolean array;
     final boolean ignore;
     final char arraySep;
+    private final List<String> ignoreArray;
     private final Pattern arrayPattern;
 
-    public Mapping(String name, Map<String, Object> mapping, char arraySep, boolean ignore) {
+    public Mapping(String name, Map<String, Object> mapping, char arraySep, boolean ignore, List<String> ignoreArray) {
         this.name = mapping.getOrDefault("name", name).toString();
         this.array = (Boolean) mapping.getOrDefault("array", false);
         this.ignore = (Boolean) mapping.getOrDefault("ignore", ignore);
+        this.ignoreArray = (List<String>) mapping.getOrDefault("ignoreArray", ignoreArray);
         this.nullValues = (Collection<String>) mapping.getOrDefault("nullValues", emptyList());
         this.arraySep = parseCharFromConfig(mapping, "arraySep", arraySep);
         this.type = Meta.Types.from(mapping.getOrDefault("type", "STRING").toString());
@@ -47,7 +49,9 @@ public class Mapping {
         String[] values = arrayPattern.split(value);
         List<Object> result = new ArrayList<>(values.length);
         for (String v : values) {
-            result.add(convertType(v));
+            if (!ignoreArray.contains(v)) {
+                result.add(convertType(v));
+            }
         }
         return result;
     }

--- a/core/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/core/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -29,6 +29,7 @@ public class LoadCsvConfig {
     private EnumSet<Results> results;
 
     private List<String> ignore;
+    private List<String> ignoreArray;
     private List<String> nullValues;
     private Map<String, Map<String, Object>> mapping;
     private Map<String, Mapping> mappings;
@@ -55,17 +56,18 @@ public class LoadCsvConfig {
         }
 
         ignore = (List<String>) config.getOrDefault("ignore", emptyList());
+        ignoreArray = (List<String>) config.getOrDefault("ignoreArray", emptyList());
         nullValues = (List<String>) config.getOrDefault("nullValues", emptyList());
         mapping = (Map<String, Map<String, Object>>) config.getOrDefault("mapping", Collections.emptyMap());
-        mappings = createMapping(mapping, arraySep, ignore);
+        mappings = createMapping(mapping, arraySep, ignore, ignoreArray);
     }
 
-    private Map<String, Mapping> createMapping(Map<String, Map<String, Object>> mapping, char arraySep, List<String> ignore) {
+    private Map<String, Mapping> createMapping(Map<String, Map<String, Object>> mapping, char arraySep, List<String> ignore, List<String> ignoreArray) {
         if (mapping.isEmpty()) return Collections.emptyMap();
         HashMap<String, Mapping> result = new HashMap<>(mapping.size());
         for (Map.Entry<String, Map<String, Object>> entry : mapping.entrySet()) {
             String name = entry.getKey();
-            result.put(name, new Mapping(name, entry.getValue(), arraySep, ignore.contains(name)));
+            result.put(name, new Mapping(name, entry.getValue(), arraySep, ignore.contains(name), ignoreArray));
         }
         return result;
     }

--- a/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
@@ -78,6 +78,7 @@ Besides the file you can pass in a config map:
 | quoteChar | '"' | the char to use for quoted elements
 | arraySep | ';' | array separator
 | ignore | [] | which columns to ignore
+| ignoreArray | [] | which values to ignore in case of array value 
 | nullValues | [] | which values to treat as null, e.g. `['na',false]`
 | mapping | {} | per field mapping, entry key is field name, .e.g `{years:{....}` see below
 | failOnError | boolean | true | fail if error encountered while parsing CSV
@@ -92,6 +93,7 @@ Besides the file you can pass in a config map:
 | arraySep | ';' | separator for array
 | name | none | rename field
 | ignore | false | ignore/remove this field
+| ignoreArray | [] | which values of this field to ignore in case of array value
 | nullValues | [] | which values to treat as null, e.g. `['na',false]`
 |===
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.csv.adoc
@@ -27,3 +27,43 @@ RETURN *;
 | 1      | ["Rana", "12", "Tea;Milk"] | {name: "Rana", age: "12", beverage: "Tea;Milk"}
 | 2      | ["Selina", "19", "Cola"]   | {name: "Selina", age: "19", beverage: "Cola"}
 |===
+
+The library currently doesn't support multi-char separator. 
+As a workaround, we can use ignore and/or ignoreArray, in case of separator with equals chars.
+For example, with this csv:
+
+.multichar.csv
+----
+Foo;;Bar;;Baz
+One;;Two;;Three
+Is||Splitted;;1;;
+----
+
+we can add a config `ignoreArray: ['']` and `ignore: ['']` and a single char separator, 
+so that we ignore empty strings created between the two `|` and between the two `;`.
+That is:
+[source, cypher]
+----
+CALL apoc.load.csv("file.csv", {ignore:[""], ignoreArray:[""], 
+  mapping: {Foo: {array: true, arraySep: "|"}},
+  results: ["map","list", "stringMap", "strings"]})
+YIELD lineNo, list, map RETURN *
+----
+
+.Results
+[opts="header",cols="1,2,2"]
+|===
+| lineNo | list | map
+| 0      | [["One"], "Two", "Three"]     | {"Bar": "Two", "Baz": "Three", "Foo": ["One"]}
+| 1      | [["Is", "Splitted"], "1", ""] | {"Bar": "1", "Baz": "", "Foo": ["Is", "Splitted"]}
+|===
+
+instead without `ignore` and `ignoreArray` config we receive:
+
+.Results
+[opts="header",cols="1,2,2"]
+|===
+| lineNo | list | map
+| 0      | [["One"], "", "Two", "", "Three"]     | {"": "", "Bar": "Two", "Baz": "Three", "Foo": ["One"]}
+| 1      | [["Is", "", "Splitted"], "", "1", "", ""] | {"": "", "Bar": "1", "Baz": "", "Foo": ["Is", "", "Splitted"]}
+|===

--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -6,6 +6,7 @@ import apoc.util.Util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.*;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
@@ -119,11 +120,25 @@ RETURN m.col_1,m.col_2,m.col_3
     }
 
     static void assertRow(Result r, long lineNo, Object...data) {
+        assertRow(r, StringUtils.EMPTY, lineNo, data);
+    }
+
+    static void assertRow(Result r, String joinArray, long lineNo, Object...data) {
         Map<String, Object> row = r.next();
         Map<String, Object> map = map(data);
         assertEquals(map, row.get("map"));
         Map<Object, Object> stringMap = new LinkedHashMap<>(map.size());
-        map.forEach((k,v) -> stringMap.put(k,v == null ? null : v.toString()));
+        map.forEach((k,v) -> {
+            final Object stringValue;
+            if (v == null) {
+                stringValue = null;
+            } else {
+                stringValue = v instanceof Collection 
+                        ? StringUtils.join((Collection) map.get("Foo"), joinArray) 
+                        : v.toString();
+            }
+            stringMap.put(k, stringValue);
+        });
         assertEquals(stringMap, row.get("stringMap"));
         assertEquals(new ArrayList<>(map.values()), row.get("list"));
         assertEquals(new ArrayList<>(stringMap.values()), row.get("strings"));
@@ -163,6 +178,32 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertRow(r, 0L,"name", "Rana", "age","11");
                     assertEquals(false, r.hasNext());
                 });
+    }
+
+
+    @Test 
+    public void testLoadIgnoreArray() {
+        URL url = getUrlFileName("test-multi-char.csv");
+        testResult(db, "CALL apoc.load.csv($url, $conf)", 
+                map("url",url.toString(), 
+                        "conf", map("results", List.of("map","list", "stringMap", "strings"),
+                                "ignore", List.of(""), "ignoreArray", List.of(""), "sep", ";",
+                                "mapping", map("Foo", map("array", true, "arraySep", "|"))) ),
+                this::assertionsIgnoreArray);
+        
+        // same as above with ignoreArray in {mapping}
+        testResult(db, "CALL apoc.load.csv($url, $conf)", 
+                map("url",url.toString(), 
+                        "conf", map("results", List.of("map","list", "stringMap", "strings"),
+                                "ignore", List.of(""), "sep", ";",
+                                "mapping", map("Foo", map("ignoreArray", List.of(""), "array", true, "arraySep", "|"))) ),
+                this::assertionsIgnoreArray);
+    }
+
+    private void assertionsIgnoreArray(Result r) {
+        assertRow(r, 0L, "Foo", List.of("One"), "Bar", "Two", "Baz", "Three");
+        assertRow(r, "||", 1L, "Foo", List.of("Is", "Splitted"), "Bar", "1", "Baz", "");
+        assertFalse(r.hasNext());
     }
 
     @Test public void testLoadCsvNoHeader() throws Exception {

--- a/full/src/test/resources/test-multi-char.csv
+++ b/full/src/test/resources/test-multi-char.csv
@@ -1,0 +1,3 @@
+Foo;;Bar;;Baz
+One;;Two;;Three
+Is||Splitted;;1;;


### PR DESCRIPTION
Issue 1948
Aggiunto esempio per spiegare come usare separatore multi carattere.
Aggiunto config per ignorare elementi di un array

C'è un https://mvnrepository.com/artifact/org.openrefine.dependencies/opencsv-multichar,
ma anche se dovrebbe essere una fork ha alcuni comportamenti diversi e sembra dal codice più scarno del progetto originale.