### PR TITLE
Issue 2252: Updates on a virtual node created from a real node should not update the original node

### DIFF
--- a/core/src/main/java/apoc/create/Create.java
+++ b/core/src/main/java/apoc/create/Create.java
@@ -159,7 +159,7 @@ public class Create {
     @UserFunction("apoc.create.virtual.fromNode")
     @Description("apoc.create.virtual.fromNode(node, [propertyNames]) returns a virtual node built from an existing node with only the requested properties")
     public Node virtualFromNodeFunction(@Name("node") Node node, @Name("propertyNames") List<String> propertyNames) {
-        return new VirtualNode(node, propertyNames);
+        return new VirtualNode(node, propertyNames, false);
     }
 
     @Procedure
@@ -236,7 +236,7 @@ public class Create {
     private PathResult createVirtualPath(Path path) {
         final Iterable<Relationship> relationships = path.relationships();
         final Node first = path.startNode();
-        VirtualPath virtualPath = new VirtualPath(new VirtualNode(first, Iterables.asList(first.getPropertyKeys())));
+        VirtualPath virtualPath = new VirtualPath(new VirtualNode(first, Iterables.asList(first.getPropertyKeys()), false));
         for (Relationship rel : relationships) {
             VirtualNode start = VirtualNode.from(rel.getStartNode());
             VirtualNode end = VirtualNode.from(rel.getEndNode());

--- a/core/src/main/java/apoc/create/Create.java
+++ b/core/src/main/java/apoc/create/Create.java
@@ -159,7 +159,7 @@ public class Create {
     @UserFunction("apoc.create.virtual.fromNode")
     @Description("apoc.create.virtual.fromNode(node, [propertyNames]) returns a virtual node built from an existing node with only the requested properties")
     public Node virtualFromNodeFunction(@Name("node") Node node, @Name("propertyNames") List<String> propertyNames) {
-        return new VirtualNode(node, propertyNames, false);
+        return new VirtualNode(node, propertyNames);
     }
 
     @Procedure
@@ -236,7 +236,7 @@ public class Create {
     private PathResult createVirtualPath(Path path) {
         final Iterable<Relationship> relationships = path.relationships();
         final Node first = path.startNode();
-        VirtualPath virtualPath = new VirtualPath(new VirtualNode(first, Iterables.asList(first.getPropertyKeys()), false));
+        VirtualPath virtualPath = new VirtualPath(new VirtualNode(first, Iterables.asList(first.getPropertyKeys())));
         for (Relationship rel : relationships) {
             VirtualNode start = VirtualNode.from(rel.getStartNode());
             VirtualNode end = VirtualNode.from(rel.getEndNode());

--- a/docs/asciidoc/modules/ROOT/pages/virtual/virtual-nodes-rels.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/virtual/virtual-nodes-rels.adoc
@@ -162,3 +162,10 @@ RETURN *;
 
 //update image once procedure is created
 //image::apoc.create.vPatternFullTwo.png[scaledwidth="100%"]
+
+[NOTE]
+====
+To update a virtual node you can use the xref::overview/apoc.create/apoc.create.setProperty.adoc[apoc.create.setProperty] or
+xref::overview/apoc.create/apoc.create.setProperties.adoc[apoc.create.setProperties],
+otherwise for a virtual relationships the xref::overview/apoc.create/apoc.create.setRelProperty.adoc[apoc.create.setRelProperty] or xref::overview/apoc.create/apoc.create.setRelProperties.adoc[apoc.create.setRelProperties]
+====

--- a/full/src/test/kotlin/apoc/nlp/NodeMatcher.kt
+++ b/full/src/test/kotlin/apoc/nlp/NodeMatcher.kt
@@ -7,6 +7,9 @@ import org.neo4j.graphdb.Node
 import java.util.stream.Collectors
 
 data class NodeMatcher(private val labels: List<Label>, private val properties: Map<String, Any>) : org.hamcrest.TypeSafeDiagnosingMatcher<Node>() {
+    constructor(node: Node) : this(node.labels.toList(), node.allProperties)
+//    constructor(node: Node) : this(emptyList(), emptyMap())
+    
     private val labelNames: List<String> = labels.stream().map { l -> l.name()}.collect(Collectors.toList())
 
     override fun describeTo(description: Description?) {

--- a/full/src/test/kotlin/apoc/nlp/NplUtils.kt
+++ b/full/src/test/kotlin/apoc/nlp/NplUtils.kt
@@ -1,0 +1,16 @@
+package apoc.nlp
+
+import apoc.result.VirtualNode
+import org.neo4j.graphdb.Node
+import org.neo4j.test.rule.DbmsRule
+
+object NplUtils {
+
+    fun commonNlpInit(neo4j: DbmsRule, query: String): Triple<Node, Node, NodeMatcher> =
+        neo4j.executeTransactionally(query, emptyMap()) {
+            val sourceNode = it.next()["a"] as Node
+            val nodeMatcher = NodeMatcher(sourceNode)
+            val virtualSourceNode = VirtualNode(sourceNode, sourceNode.propertyKeys.toList())
+            return@executeTransactionally Triple(sourceNode, virtualSourceNode, nodeMatcher)
+        }
+}

--- a/full/src/test/kotlin/apoc/nlp/aws/AWSProceduresAPITest.kt
+++ b/full/src/test/kotlin/apoc/nlp/aws/AWSProceduresAPITest.kt
@@ -1,6 +1,7 @@
 package apoc.nlp.aws
 
 import apoc.nlp.NodeMatcher
+import apoc.nlp.NplUtils.commonNlpInit
 import apoc.nlp.RelationshipMatcher
 import apoc.result.VirtualNode
 import apoc.util.TestUtil
@@ -162,12 +163,7 @@ class AWSProceduresAPITest {
     fun `should extract entity as virtual graph`() {
         neo4j.executeTransactionally("""CREATE (a:Article3 {id: 1234, body:${'$'}body})""", mapOf("body" to article1))
 
-        var sourceNode: Node? = null
-        var virtualSourceNode: Node? = null
-        neo4j.executeTransactionally("MATCH (a:Article3) RETURN a", emptyMap()) {
-            sourceNode = it.next()["a"] as Node
-            virtualSourceNode = VirtualNode(sourceNode, sourceNode!!.propertyKeys.toList())
-        }
+        val (sourceNode, virtualSourceNode, nodeMatcher) = commonNlpInit(neo4j, "MATCH (a:Article3) RETURN a")
 
         neo4j.executeTransactionally("""
                     MATCH (a:Article3)
@@ -189,7 +185,7 @@ class AWSProceduresAPITest {
 
                     assertEquals(8, nodes.size)
 
-                    assertThat(nodes, hasItem(sourceNode))
+                    assertThat(nodes, hasItem(nodeMatcher))
 
                     val orgLabels = listOf(Label { "Organization" }, Label { "Entity" })
                     val locationLabels = listOf(Label { "Location" }, Label { "Entity" })

--- a/full/src/test/kotlin/apoc/nlp/aws/AWSVirtualSentimentVirtualGraphTest.kt
+++ b/full/src/test/kotlin/apoc/nlp/aws/AWSVirtualSentimentVirtualGraphTest.kt
@@ -48,7 +48,8 @@ class AWSVirtualSentimentVirtualGraphTest {
 
         val nodes = virtualGraph.graph["nodes"] as Set<*>
         assertEquals(1, nodes.size)
-        assertThat(nodes, hasItem(sourceNode))
+        // we cannot assert initial NodeMatcher
+        // because the sentiment.graph return a virtual node with other properties (sentimentScore and sentiment)
         assertThat(nodes, hasItem(NodeMatcher(listOf(Label { "Person" }), mapOf("sentiment" to "Mixed", "sentimentScore" to 0.8F, "id" to 1234L))))
     }
 }

--- a/full/src/test/kotlin/apoc/nlp/azure/AzureProceduresAPITest.kt
+++ b/full/src/test/kotlin/apoc/nlp/azure/AzureProceduresAPITest.kt
@@ -1,6 +1,7 @@
 package apoc.nlp.azure
 
 import apoc.nlp.NodeMatcher
+import apoc.nlp.NplUtils.commonNlpInit
 import apoc.nlp.RelationshipMatcher
 import apoc.result.VirtualNode
 import apoc.util.TestUtil
@@ -120,13 +121,7 @@ class AzureProceduresAPITest {
         // given
         val text = "I had a wonderful trip to Seattle last week."
 
-        var sourceNode: Node? = null
-        var virtualSourceNode: Node? = null
-        neo4j.executeTransactionally("CREATE (a:Entity2{id: 'a', text: ${'$'}data}) RETURN a",
-                mapOf("data" to text))  {
-            sourceNode = it.next()["a"] as Node
-            virtualSourceNode = VirtualNode(sourceNode, sourceNode!!.propertyKeys.toList())
-        }
+        val (sourceNode, virtualSourceNode, nodeMatcher) = commonNlpInit(neo4j, "CREATE (a:Entity2{id: 'a', text: ${'$'}data}) RETURN a")
 
         // when
         neo4j.executeTransactionally("""MATCH (s:Entity2)
@@ -141,7 +136,7 @@ class AzureProceduresAPITest {
 
             Assert.assertEquals(3, nodes.size)
 
-            MatcherAssert.assertThat(nodes, Matchers.hasItem(sourceNode))
+            MatcherAssert.assertThat(nodes, Matchers.hasItem(nodeMatcher))
 
             val dateTimeLabels = listOf(Label { "DateTime" }, Label { "Entity" })
             val locationLabels = listOf(Label { "Location" }, Label { "Entity" })

--- a/full/src/test/kotlin/apoc/nlp/gcp/GCPProceduresAPITest.kt
+++ b/full/src/test/kotlin/apoc/nlp/gcp/GCPProceduresAPITest.kt
@@ -2,6 +2,7 @@ package apoc.nlp.gcp
 
 import apoc.nlp.MinimalPropertiesMatcher.Companion.hasAtLeast
 import apoc.nlp.NodeMatcher
+import apoc.nlp.NplUtils.commonNlpInit
 import apoc.nlp.RelationshipMatcher
 import apoc.result.VirtualNode
 import apoc.util.TestUtil
@@ -103,12 +104,7 @@ class GCPProceduresAPITest {
     fun `should extract entity as virtual graph`() {
         neo4j.executeTransactionally("""CREATE (a:Article3 {body:${'$'}body})""", mapOf("body" to body))
 
-        var sourceNode: Node? = null
-        var virtualSourceNode: Node? = null
-        neo4j.executeTransactionally("MATCH (a:Article3) RETURN a", emptyMap()) {
-            sourceNode = it.next()["a"] as Node
-            virtualSourceNode = VirtualNode(sourceNode, sourceNode!!.propertyKeys.toList())
-        }
+        val (sourceNode, virtualSourceNode, nodeMatcher) = commonNlpInit(neo4j, "MATCH (a:Article3) RETURN a")
 
         neo4j.executeTransactionally("""
                     MATCH (a:Article3)
@@ -128,7 +124,7 @@ class GCPProceduresAPITest {
 
                     Assert.assertEquals(17, nodes.size)
 
-                    assertThat(nodes, hasItem(sourceNode))
+                    assertThat(nodes, hasItem(nodeMatcher))
 
                     val orgLabels = listOf(Label { "Organization" }, Label { "Entity" })
                     val locationLabels = listOf(Label { "Location" }, Label { "Entity" })

--- a/full/src/test/kotlin/apoc/nlp/gcp/GCPProceduresAPIWithDummyClientTest.kt
+++ b/full/src/test/kotlin/apoc/nlp/gcp/GCPProceduresAPIWithDummyClientTest.kt
@@ -1,6 +1,7 @@
 package apoc.nlp.gcp
 
 import apoc.nlp.NodeMatcher
+import apoc.nlp.NplUtils.commonNlpInit
 import apoc.nlp.RelationshipMatcher
 import apoc.result.VirtualNode
 import apoc.util.TestUtil
@@ -100,12 +101,7 @@ class GCPProceduresAPIWithDummyClientTest {
     fun `batches should create multiple virtual graphs`() {
         neo4j.executeTransactionally("""CREATE (a:Article3 {id: 1234, body:${'$'}body})""", mapOf("body" to "test"))
 
-        var sourceNode: Node? = null
-        var virtualSourceNode: Node? = null
-        neo4j.executeTransactionally("MATCH (a:Article3) RETURN a", emptyMap()) {
-            sourceNode = it.next()["a"] as Node
-            virtualSourceNode = VirtualNode(sourceNode, sourceNode!!.propertyKeys.toList())
-        }
+        val (sourceNode, virtualSourceNode, nodeMatcher) = commonNlpInit(neo4j, "MATCH (a:Article3) RETURN a")
 
         neo4j.executeTransactionally("""
                     UNWIND range(1, 26) AS index
@@ -134,7 +130,7 @@ class GCPProceduresAPIWithDummyClientTest {
             val dummyLabels1 = listOf(Label { "ConsumerGood"}, Label {"Entity"})
             val dummyLabels2 = listOf(Label { "Location"}, Label {"Entity"})
 
-            assertThat(nodes, hasItem(sourceNode))
+            assertThat(nodes, hasItem(nodeMatcher))
             assertThat(nodes, hasItem(NodeMatcher(dummyLabels1, mapOf("text" to "token-1-index-0-batch-1", "type" to "CONSUMER_GOOD"))))
             assertThat(nodes, hasItem(NodeMatcher(dummyLabels2, mapOf("text" to "token-2-index-0-batch-1", "type" to "LOCATION"))))
 
@@ -209,12 +205,7 @@ class GCPProceduresAPIWithDummyClientTest {
     fun `classify batches should create multiple virtual graphs`() {
         neo4j.executeTransactionally("""CREATE (a:Article6 {id: 1234, body:${'$'}body})""", mapOf("body" to "test"))
 
-        var sourceNode: Node? = null
-        var virtualSourceNode: Node? = null
-        neo4j.executeTransactionally("MATCH (a:Article6) RETURN a", emptyMap()) {
-            sourceNode = it.next()["a"] as Node
-            virtualSourceNode = VirtualNode(sourceNode, sourceNode!!.propertyKeys.toList())
-        }
+        val (sourceNode, virtualSourceNode, nodeMatcher) = commonNlpInit(neo4j, "MATCH (a:Article6) RETURN a")
 
         neo4j.executeTransactionally("""
                     UNWIND range(1, 26) AS index
@@ -242,7 +233,7 @@ class GCPProceduresAPIWithDummyClientTest {
 
             val dummyLabels = listOf( Label {"Category"})
 
-            assertThat(nodes, hasItem(sourceNode))
+            assertThat(nodes, hasItem(nodeMatcher))
             assertThat(nodes, hasItem(NodeMatcher(dummyLabels, mapOf("text" to "category-1-index-0-batch-1"))))
             assertThat(nodes, hasItem(NodeMatcher(dummyLabels, mapOf("text" to "category-2-index-0-batch-1"))))
 
@@ -256,12 +247,7 @@ class GCPProceduresAPIWithDummyClientTest {
     fun `create virtual entity graph based on salience cut off`() {
         neo4j.executeTransactionally("""CREATE (a:Article7 {id: 1234, body:${'$'}body})""", mapOf("body" to "test"))
 
-        var sourceNode: Node? = null
-        var virtualSourceNode: Node? = null
-        neo4j.executeTransactionally("MATCH (a:Article7) RETURN a", emptyMap()) {
-            sourceNode = it.next()["a"] as Node
-            virtualSourceNode = VirtualNode(sourceNode, sourceNode!!.propertyKeys.toList())
-        }
+        val (sourceNode, virtualSourceNode, nodeMatcher) = commonNlpInit(neo4j, "MATCH (a:Article7) RETURN a")
 
         neo4j.executeTransactionally("""
                     MATCH (a:Article7) WITH a ORDER BY a.id
@@ -287,7 +273,7 @@ class GCPProceduresAPIWithDummyClientTest {
 
             val dummyLabels2 = listOf(Label { "Location"}, Label {"Entity"})
 
-            assertThat(nodes, hasItem(sourceNode))
+            assertThat(nodes, hasItem(nodeMatcher))
             assertThat(nodes, hasItem(NodeMatcher(dummyLabels2, mapOf("text" to "token-2-index-0-batch-0", "type" to "LOCATION"))))
 
             Assert.assertEquals(1, relationships.size)
@@ -299,12 +285,7 @@ class GCPProceduresAPIWithDummyClientTest {
     fun `create virtual category graph based on confidence cut off`() {
         neo4j.executeTransactionally("""CREATE (a:Article8 {id: 1234, body:${'$'}body})""", mapOf("body" to "test"))
 
-        var sourceNode: Node? = null
-        var virtualSourceNode: Node? = null
-        neo4j.executeTransactionally("MATCH (a:Article8) RETURN a", emptyMap()) {
-            sourceNode = it.next()["a"] as Node
-            virtualSourceNode = VirtualNode(sourceNode, sourceNode!!.propertyKeys.toList())
-        }
+        val (sourceNode, virtualSourceNode, nodeMatcher) = commonNlpInit(neo4j, "MATCH (a:Article8) RETURN a")
 
         neo4j.executeTransactionally("""
                     MATCH (a:Article8) WITH a ORDER BY a.id
@@ -328,7 +309,7 @@ class GCPProceduresAPIWithDummyClientTest {
 
             val dummyLabels = listOf( Label {"Category"})
 
-            assertThat(nodes, hasItem(sourceNode))
+            assertThat(nodes, hasItem(nodeMatcher))
             assertThat(nodes, hasItem(NodeMatcher(dummyLabels, mapOf("text" to "category-2-index-0-batch-0"))))
 
             Assert.assertEquals(1, relationships.size)


### PR DESCRIPTION
Issue 2252

- Added doc about update virtual entities

- Added test in nlp with `write: true` to check that there aren't regressions