### PR TITLE
Issue 2266: The apoc.periodic.truncate procedure doesn't provide a feedback if fails

### DIFF
--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -49,6 +49,7 @@ public class Periodic {
     @Description("apoc.periodic.truncate({config}) - removes all entities (and optionally indexes and constraints) from db using the apoc.periodic.iterate under the hood")
     public void truncate(@Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
 
+        config.put("throwsError", true);
         iterate("MATCH ()-[r]->() RETURN id(r) as id", "MATCH ()-[r]->() WHERE id(r) = id DELETE r", config);
         iterate("MATCH (n) RETURN id(n) as id", "MATCH (n) WHERE id(n) = id DELETE n", config);
 
@@ -274,7 +275,7 @@ public class Periodic {
                         Iterators.count(r); // XXX: consume all results
                         return r.getQueryStatistics();
                     },
-                    concurrency, failedParams);
+                    concurrency, failedParams, Util.toBoolean(config.get("throwsError")));
         }
     }
 

--- a/core/src/main/java/apoc/periodic/PeriodicUtils.java
+++ b/core/src/main/java/apoc/periodic/PeriodicUtils.java
@@ -59,7 +59,7 @@ public class PeriodicUtils {
             GraphDatabaseService db, TerminationGuard terminationGuard, Log log, Pools pools,
             int batchsize, boolean parallel, boolean iterateList, long retries,
             Iterator<Map<String, Object>> iterator, BiFunction<Transaction, Map<String, Object>, QueryStatistics> consumer,
-            int concurrency, int failedParams) {
+            int concurrency, int failedParams, boolean throwsError) {
 
         ExecutorService pool = parallel ? pools.getDefaultExecutorService() : pools.getSingleExecutorService();
         List<Future<Long>> futures = new ArrayList<>(concurrency);
@@ -103,8 +103,8 @@ public class PeriodicUtils {
 
         boolean wasTerminated = Util.transactionIsTerminated(terminationGuard);
         ToLongFunction<Future<Long>> toLongFunction = wasTerminated ?
-                f -> Util.getFutureOrCancel(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L) :
-                f -> Util.getFuture(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L);
+                f -> Util.getFutureOrCancel(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L, throwsError) :
+                f -> Util.getFuture(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L, throwsError);
         collector.incrementSuccesses(futures.stream().mapToLong(toLongFunction).sum());
 
         Util.logErrors("Error during iterate.commit:", collector.getBatchErrors(), log);

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -614,16 +614,21 @@ public class Util {
     }
 
     public static <T> T getFuture(Future<T> f, Map<String, Long> errorMessages, AtomicInteger errors, T errorValue) {
+        return getFuture(f, errorMessages, errors, errorValue, false);
+    }
+
+    public static <T> T getFuture(Future<T> f, Map<String, Long> errorMessages, AtomicInteger errors, T errorValue, boolean throwsError) {
         try {
             T t = f.get();
             return t;
         } catch (Exception e) {
+            throwPossibly(throwsError, e);
             errors.incrementAndGet();
             errorMessages.compute(e.getMessage(),(s, i) -> i == null ? 1 : i + 1);
             return errorValue;
         }
     }
-    public static <T> T getFutureOrCancel(Future<T> f, Map<String, Long> errorMessages, AtomicInteger errors, T errorValue) {
+    public static <T> T getFutureOrCancel(Future<T> f, Map<String, Long> errorMessages, AtomicInteger errors, T errorValue, boolean throwsError) {
         try {
             if (f.isDone()) return f.get();
             else {
@@ -631,10 +636,17 @@ public class Util {
                 errors.incrementAndGet();
             }
         } catch (Exception e) {
+            throwPossibly(throwsError, e);
             errors.incrementAndGet();
             errorMessages.compute(e.getMessage(),(s, i) -> i == null ? 1 : i + 1);
         }
         return errorValue;
+    }
+
+    private static void throwPossibly(boolean throwsError, Exception e) {
+        if (throwsError) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static boolean isSumOutOfRange(long... numbers) {

--- a/core/src/test/java/apoc/periodic/PeriodicTruncateTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTruncateTest.java
@@ -1,0 +1,42 @@
+package apoc.periodic;
+
+import apoc.util.TestUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.io.ByteUnit;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.stream.IntStream;
+
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertTrue;
+
+// created separated test to not affect PeriodicTest through dbms.memory.transaction.database_max_size=10M
+public class PeriodicTruncateTest {
+    
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.memory_transaction_database_max_size, ByteUnit.mebiBytes( 10 ));
+
+    @Before
+    public void initDb() {
+        TestUtil.registerProcedure(db, Periodic.class);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testShouldFailsWithTransactionMaxSize() {
+        IntStream.range(0, 5)
+                .forEach(i -> db.executeTransactionally("unwind range(0, 999) as range create (:Node)-[:REL]->(:Other)"));
+
+        try {
+            testCall(db, "call apoc.periodic.truncate", r -> {});
+        } catch (QueryExecutionException e) {
+            assertTrue(e.getMessage().contains("dbms.memory.transaction.database_max_size threshold reached"));
+            throw e;
+        }
+    }
+}

--- a/full/src/main/java/apoc/periodic/PeriodicExtended.java
+++ b/full/src/main/java/apoc/periodic/PeriodicExtended.java
@@ -77,7 +77,7 @@ public class PeriodicExtended {
                     PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
                             db, terminationGuard, log, pools,
                             (int) batchSize, false, false, 0,
-                            result, (tx, params) -> tx.execute(cypherAction, params).getQueryStatistics(), 50, -1);
+                            result, (tx, params) -> tx.execute(cypherAction, params).getQueryStatistics(), 50, -1, false);
                 final Object loopParam = value;
                 allResults = Stream.concat(allResults, oneResult.map(r -> r.inLoop(loopParam)));
             }
@@ -119,7 +119,7 @@ public class PeriodicExtended {
             return PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
                     db, terminationGuard, log, pools,
                     (int)batchSize, false, false, 0, result,
-                    (tx, p) -> tx.execute(cypherAction, p).getQueryStatistics(), 50, -1);
+                    (tx, p) -> tx.execute(cypherAction, p).getQueryStatistics(), 50, -1, false);
         }
     }
 


### PR DESCRIPTION
Issue 2266

Added config `throwError=true` in periodic.truncate to fail with errors