### PR TITLE
issue 2347: Update POI versions

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/import/xls.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/xls.adoc
@@ -12,14 +12,14 @@ That's why we decided not to include it into the apoc jar, but make it an option
 Please download these jars and put them into your `plugins` directory:
 
 .For XLS files:
-* https://repo1.maven.org/maven2/org/apache/poi/poi/3.17/poi-3.17.jar[poi-3.17.jar^]
+* https://repo1.maven.org/maven2/org/apache/poi/poi/5.1.0/poi-5.1.0.jar[poi-5.1.0.jar^]
 
 .Additional for XLSX files:
-* https://repo1.maven.org/maven2/org/apache/commons/commons-collections4/4.1/commons-collections4-4.1.jar[commons-collections4-4.1.jar^]
-* https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml/3.17/poi-ooxml-3.17.jar[poi-ooxml-3.17.jar^]
-* https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml-schemas/3.17/poi-ooxml-schemas-3.17.jar[poi-ooxml-schemas-3.17.jar^]
-* https://repo1.maven.org/maven2/org/apache/xmlbeans/xmlbeans/2.6.0/xmlbeans-2.6.0.jar[xmlbeans-2.6.0.jar^]
-* https://repo1.maven.org/maven2/com/github/virtuald/curvesapi/1.04/curvesapi-1.04.jar[curvesapi-1.04.jar^]
+* https://repo1.maven.org/maven2/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar[commons-collections4-4.4.jar^]
+* https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml/5.1.0/poi-ooxml-5.1.0.jar[poi-ooxml-5.1.0.jar^]
+* https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml-lite/5.1.0/poi-ooxml-lite-5.1.0.jar[poi-ooxml-lite-5.1.0.jar^]
+* https://repo1.maven.org/maven2/org/apache/xmlbeans/xmlbeans/5.0.2/xmlbeans-5.0.2.jar[xmlbeans-5.0.2.jar^]
+* https://repo1.maven.org/maven2/com/github/virtuald/curvesapi/1.06/curvesapi-1.06.jar[curvesapi-1.06.jar^]
 
 == Usage
 

--- a/extra-dependencies/xls/build.gradle
+++ b/extra-dependencies/xls/build.gradle
@@ -18,10 +18,12 @@ jar {
 }
 
 dependencies {
-    compile group: 'org.apache.poi', name: 'poi', version: '3.17'
-    compile group: 'org.apache.poi', name: 'poi-ooxml', version: '3.17'
-    compile group: 'org.apache.poi', name: 'poi-ooxml-schemas', version: '3.17'
-    compile group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '2.6.0'
-    compile group: 'com.github.virtuald', name: 'curvesapi', version: '1.04'
+    compile group: 'org.apache.poi', name: 'poi', version: '5.1.0'
+    compile group: 'org.apache.poi', name: 'poi-ooxml-lite', version: '5.1.0'
+    compile group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0' , {
+        exclude group: 'org.apache.commons', module: 'commons-compress' 
+    }
+    compile group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.0.2'
+    compile group: 'com.github.virtuald', name: 'curvesapi', version: '1.06'
     compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 }

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -59,10 +59,10 @@ dependencies {
     // compileOnly "org.antlr:antlr4-runtime:4.7.2"
     // testCompile "org.antlr:antlr4-runtime:4.7.2"
 
-    compileOnly "org.apache.poi:poi:3.17"
-    testCompile "org.apache.poi:poi:3.17"
-    compileOnly "org.apache.poi:poi-ooxml:3.17"
-    testCompile "org.apache.poi:poi-ooxml:3.17"
+    compileOnly "org.apache.poi:poi:5.1.0"
+    testCompile "org.apache.poi:poi:5.1.0"
+    compileOnly "org.apache.poi:poi-ooxml:5.1.0"
+    testCompile "org.apache.poi:poi-ooxml:5.1.0"
 
     compile 'org.jsoup:jsoup:1.14.3'
 

--- a/full/src/main/java/apoc/load/LoadXls.java
+++ b/full/src/main/java/apoc/load/LoadXls.java
@@ -276,7 +276,7 @@ public class LoadXls {
         for (int i = selection.left; i < selection.right; i++) {
             Cell cell = row.getCell(i);
             if (cell == null) continue;
-            result[i-selection.left] = getValue(cell, cell.getCellTypeEnum());
+            result[i-selection.left] = getValue(cell, cell.getCellType());
         }
         return result;
 
@@ -297,7 +297,7 @@ public class LoadXls {
                 if (value == Math.floor(value)) return (long) value;
                 return value;
             case STRING: return cell.getStringCellValue();
-            case FORMULA: return getValue(cell,cell.getCachedFormulaResultTypeEnum());
+            case FORMULA: return getValue(cell,cell.getCachedFormulaResultType());
             case BOOLEAN: return cell.getBooleanCellValue();
             case _NONE: return null;
             case BLANK: return null;

--- a/full/src/test/java/apoc/export/csv/ExportXlsTest.java
+++ b/full/src/test/java/apoc/export/csv/ExportXlsTest.java
@@ -4,7 +4,6 @@ import apoc.ApocSettings;
 import apoc.export.xls.ExportXls;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
-import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -214,7 +213,7 @@ public class ExportXlsTest {
                 assertEquals(expected, actual);
             }
             tx.commit();
-        } catch (IOException|InvalidFormatException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -226,7 +225,7 @@ public class ExportXlsTest {
             int numberOfSheets = wb.getNumberOfSheets();
             assertEquals(sheets, numberOfSheets);
 
-        } catch (IOException|InvalidFormatException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/full/src/test/java/apoc/load/LoadFullSecurityTest.java
+++ b/full/src/test/java/apoc/load/LoadFullSecurityTest.java
@@ -21,6 +21,7 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -56,7 +57,7 @@ public class LoadFullSecurityTest {
     }
 
     private static final Map<String, Class<?>> ALLOWED_EXCEPTIONS = Map.of(
-            "xls", InvalidFormatException.class);
+            "xls", IOException.class);
 
     private static final Map<String, List<String>> APOC_PROCEDURE_WITH_ARGUMENTS = Map.of(
             "xls", List.of("($fileName, '', {})"),


### PR DESCRIPTION
issue 2347

From [documentation](https://poi.apache.org/components/):
```
poi-ooxml requires poi-ooxml-lite. 
This is a substantially smaller version of the poi-ooxml-full jar (ooxml-schemas-1.4.jar for POI 4.0.0, ooxml-schemas-1.3.jar for POI 3.14 or to POI 3.17, ooxml-schemas-1.1.jar for POI 3.7 up to POI 3.13, ooxml-schemas-1.0.jar for POI 3.5 and 3.6). The larger ooxml-schemas jar is normally only required for development. 
Similarly, the ooxml-security jar, which contains all of the classes relating to encryption and signing, is normally only required for development. A subset of its contents are in poi-ooxml-schemas. 
This JAR is ooxml-security-1.1.jar for POI 3.14 onwards and ooxml-security-1.0.jar prior to that.
```

So, I added `poi-ooxml-lite` and removed `poi-ooxml-schemas` (which is a subset of `-lite`)



Changed `LoadFullSecurityTest.ALLOWED_EXCEPTION` because `Workbook.create()` now throws IOException, not InvalidFormatException anymore