### PR TITLE
Issue 2325: Symmetric export-import for JSON documents

### DIFF
--- a/core/src/main/java/apoc/coll/Coll.java
+++ b/core/src/main/java/apoc/coll/Coll.java
@@ -384,7 +384,7 @@ public class Coll {
         return result.stream().map(ListResult::new);
     }
 
-    private Stream<List<Object>> partitionList(@Name("values") List list, @Name("batchSize") int batchSize) {
+    public static Stream<List<Object>> partitionList(@Name("values") List list, @Name("batchSize") int batchSize) {
         int total = list.size();
         int pages = total % batchSize == 0 ? total/batchSize : total/batchSize + 1;
         return IntStream.range(0, pages).parallel().boxed()

--- a/core/src/main/java/apoc/export/json/ImportJsonConfig.java
+++ b/core/src/main/java/apoc/export/json/ImportJsonConfig.java
@@ -18,6 +18,8 @@ public class ImportJsonConfig extends CompressionConfig {
 
     private final String importIdName;
 
+    private final boolean cleanup;
+
     public ImportJsonConfig(Map<String, Object> config) {
         super(config);
         config = config == null ? Collections.emptyMap() : config;
@@ -26,6 +28,7 @@ public class ImportJsonConfig extends CompressionConfig {
         this.unwindBatchSize = Util.toInteger(config.getOrDefault("unwindBatchSize", 5000));
         this.txBatchSize = Util.toInteger(config.getOrDefault("txBatchSize", 5000));
         this.importIdName = (String) config.getOrDefault("importIdName", "neo4jImportId");
+        this.cleanup = Util.toBoolean(config.get("cleanup"));
     }
 
     public String typeForNode(Collection<String> labels, String property) {
@@ -50,5 +53,9 @@ public class ImportJsonConfig extends CompressionConfig {
 
     public String getImportIdName() {
         return importIdName;
+    }
+
+    public boolean getCleanup() {
+        return cleanup;
     }
 }

--- a/core/src/main/java/apoc/export/json/JsonImporter.java
+++ b/core/src/main/java/apoc/export/json/JsonImporter.java
@@ -6,12 +6,12 @@ import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.Schema;
-import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.PointValue;
-import org.neo4j.values.storable.Values;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -31,10 +31,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static apoc.coll.Coll.partitionList;
+
 public class JsonImporter implements Closeable {
     private static final String UNWIND = "UNWIND $rows AS row ";
     private static final String CREATE_NODE = UNWIND +
-            "CREATE (n%s {%s: row.id}) SET n += row.properties";
+            "CREATE (n%1$s {%2$s: row.id}) SET n += row.properties RETURN n.%2$s as ids";
     private static final String CREATE_RELS = UNWIND +
             "MATCH (s%s {%s: row.start.id}) " +
             "MATCH (e%s {%2$s: row.end.id}) " +
@@ -47,6 +49,7 @@ public class JsonImporter implements Closeable {
     private final int txBatchSize;
     private final GraphDatabaseService db;
     private final Reporter reporter;
+    private final List<String> ids = new ArrayList<>();
 
     private String lastType;
     private List<String> lastLabels;
@@ -168,7 +171,7 @@ public class JsonImporter implements Closeable {
     }
 
     private void updateReporter(String type, Map<String, Object> properties) {
-        final int size = properties.size() + 1; // +1 is for the "neo4jImportId"
+        final int size = properties.size() + (importJsonConfig.getCleanup() ? 0 : 1); // +1 is for the "neo4jImportId"
         switch (type) {
             case "node":
                 reporter.update(1, 0, size);
@@ -321,7 +324,11 @@ public class JsonImporter implements Closeable {
                 throw new IllegalArgumentException("Current type not supported: " + type);
         }
         if (StringUtils.isNotBlank(query)) {
-            db.executeTransactionally(query, Collections.singletonMap("rows", resultList));
+            final Result result = db.executeTransactionally(query, Collections.singletonMap("rows", resultList), r -> r);
+            // add the ids to be used in clear()
+            if (type.equals("node")) {
+                ids.addAll(Iterators.asList(result.columnAs("ids")));
+            }
         }
     }
 
@@ -336,6 +343,7 @@ public class JsonImporter implements Closeable {
     public void close() throws IOException {
         flush();
         reporter.done();
+        clear();
     }
 
     private void flush() {
@@ -345,6 +353,14 @@ public class JsonImporter implements Closeable {
                 results.forEach(resultList -> write(tx, resultList));
             }
             paramList.clear();
+        }
+    }
+
+    public void clear() {
+        if (importJsonConfig.getCleanup()) { 
+            final String cleanQuery = String.format("UNWIND $i as id WITH id MATCH (n) WHERE n.%1$s = id REMOVE n.%1$s", importJsonConfig.getImportIdName());
+            partitionList(ids, importJsonConfig.getTxBatchSize())
+                    .forEach(i -> db.executeTransactionally(cleanQuery, Map.of("i", i )));
         }
     }
 }

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -65,19 +65,33 @@ public class ImportJsonTest {
     }
 
     @Test
+    public void shouldImportAllJsonWithClearIds() throws Exception {
+        importAllCommons(true, "neo4jImportId", "CALL apoc.import.json($file, $config)");
+    }
+
+    @Test
     public void shouldImportAllJson() throws Exception {
-        db.executeTransactionally("CREATE CONSTRAINT ON (n:User) assert n.neo4jImportId IS UNIQUE");
-        
+        importAllCommons(false, "neo4jImportId", "CALL apoc.import.json($file, null)");
+    }
+
+    @Test
+    public void shouldImportAllJsonWithClearIdsAndCustomId() throws Exception {
+        importAllCommons(true, "mySuperId", "CALL apoc.import.json($file, $config)");
+    }
+
+    private void importAllCommons(boolean isClear, String customId, String query) {
+        db.executeTransactionally(format("CREATE CONSTRAINT ON (n:User) assert n.%s IS UNIQUE", customId));
+
         // given
         String filename = "all.json";
 
         // when
-        TestUtil.testCall(db, "CALL apoc.import.json($file, null)",
-                map("file", filename),
-                (r) -> assertionsAllJsonProgressInfo(r, false)
+        TestUtil.testCall(db, query, 
+                map("file", filename, "config", map("cleanup", isClear, "importIdName", customId)),
+                (r) -> assertionsAllJsonProgressInfo(r, false, isClear)
         );
 
-        assertionsAllJsonDbResult();
+        assertionsAllJsonDbResult(isClear, customId);
     }
 
     @Test
@@ -272,18 +286,26 @@ public class ImportJsonTest {
     }
 
     private void assertionsAllJsonProgressInfo(Map<String, Object> r, boolean isBinary) {
+        assertionsAllJsonProgressInfo(r, isBinary, false);
+    }
+
+    private void assertionsAllJsonProgressInfo(Map<String, Object> r, boolean isBinary, boolean isClear) {
         // then
         Assert.assertEquals(isBinary ? null : "all.json", r.get("file"));
         Assert.assertEquals(isBinary ? "binary" : "file", r.get("source"));
         Assert.assertEquals("json", r.get("format"));
         Assert.assertEquals(3L, r.get("nodes"));
         Assert.assertEquals(1L, r.get("relationships"));
-        Assert.assertEquals(15L, r.get("properties"));
+        Assert.assertEquals(isClear ? 11L : 15L, r.get("properties"));
         Assert.assertEquals(4L, r.get("rows"));
         Assert.assertEquals(true, r.get("done"));
     }
 
     private void assertionsAllJsonDbResult() {
+        assertionsAllJsonDbResult(false, "neo4jImportId");
+    }
+
+    private void assertionsAllJsonDbResult(boolean isClear, String importId) {
         try(Transaction tx = db.beginTx()) {
             final long countNodes = tx.execute("MATCH (n:User) RETURN count(n) AS count")
                     .<Long>columnAs("count")
@@ -300,11 +322,12 @@ public class ImportJsonTest {
                     .next()
                     .getAllProperties();
 
-            Assert.assertEquals(9, props.size());
+            Assert.assertEquals(isClear ? 8 : 9, props.size());
             Assert.assertEquals("wgs-84", props.get("place.crs"));
             Assert.assertEquals(13.1D, props.get("place.latitude"));
             Assert.assertEquals(33.46789D, props.get("place.longitude"));
             Assert.assertFalse(props.containsKey("place"));
+            Assert.assertNotEquals(isClear, props.containsKey(importId));
         }
     }
 }

--- a/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
@@ -104,6 +104,7 @@ It supports the following config parameters:
 | unwindBatchSize | Long |  `5000` | the batch size of the unwind
 | txBatchSize | Long |  `5000` | the batch size of the transacttion
 | importIdName | String | `neo4jImportId` | the name of the property to be populated with the "id" field present into the json. For example a row `{"type":"node", "labels":["Language"], "id":"10"}`, with importIdName:`foo`, will create a node `(:User {foo: "10"})`
+| clear | boolean | false | Remove the "id" field (defined by the `importIdName` config)
 | nodePropertyMappings | Map | `{}` | The mapping label/property name/property type for Custom Neo4j types (point date).
 
 i.e. `{ User: { born: 'Point', dateOfBirth: 'Datetime' } }`
@@ -390,6 +391,7 @@ This procedure supports the following config parameters:
 | unwindBatchSize | `5000` | the batch size of the unwind
 | txBatchSize | `5000` | the batch size of the transacttion
 | importIdName | String | `neo4jImportId` | the name of the property to be populated with the "id" field present into the json. For example a row `{"type":"node", "labels":["Language"], "id":"10"}`, with importIdName:`foo`, will create a node `(:User {foo: "10"})`
+| clear | boolean | false | Remove the "id" field (defined by the `importIdName` config)
 | nodePropertyMappings | `{}` | The mapping label/property name/property type for Custom Neo4j types (point date). I.e. { User: { born: 'Point', dateOfBirth: 'Datetime' } }
 | relPropertyMappings | `{}` | The mapping rel type/property name/property type for Custom Neo4j types (point date). I.e. { KNOWS: { since: 'Datetime' } }
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
@@ -7,6 +7,7 @@ This procedure supports the following config parameters:
 | unwindBatchSize | Integer | `5000` | the batch size of the unwind
 | txBatchSize | Integer | `5000` | the batch size of the transacttion
 | importIdName | String | `neo4jImportId` | the name of the property to be populated with the "id" field present into the json. For example a row `{"type":"node", "labels":["Language"], "id":"10"}`, with importIdName:`foo`, will create a node `(:User {foo: "10"})`
+| clear | boolean | false | Remove the "id" field (defined by the `importIdName` config)
 | nodePropertyMappings | Map | `{}` | The mapping label/property name/property type for Custom Neo4j types (point date). I.e. { User: { born: 'Point', dateOfBirth: 'Datetime' } }
 | relPropertyMappings | Map | `{}` | The mapping rel type/property name/property type for Custom Neo4j types (point date). I.e. { KNOWS: { since: 'Datetime' } }
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)


### PR DESCRIPTION
Closed in favour of https://github.com/vga91/neo4j-apoc-procedures/pull/215 and https://github.com/vga91/neo4j-apoc-procedures/pull/214

Issue 2325

- added config to remove ids