### PR TITLE
Issue 1900 and 2394: apoc.convert.toJson throws NullPointerException for null values in maps  4.4

### DIFF
--- a/core/src/main/java/apoc/convert/Json.java
+++ b/core/src/main/java/apoc/convert/Json.java
@@ -41,8 +41,9 @@ public class Json {
             case MAP:
                 return ((Map<String, Object>) value).entrySet()
                         .stream()
-                        .collect(Collectors.toMap(Map.Entry::getKey,
-                                e -> writeJsonResult(e.getValue())));
+                        .collect(HashMap::new, // workaround for https://bugs.openjdk.java.net/browse/JDK-8148463
+                                (mapAccumulator, entry) -> mapAccumulator.put(entry.getKey(), writeJsonResult(entry.getValue())), 
+                                HashMap::putAll);  
             default:
                 return value;
         }

--- a/core/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/core/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -29,7 +29,6 @@ import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static java.util.Arrays.asList;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 public class ConvertJsonTest {
@@ -140,6 +139,18 @@ public class ConvertJsonTest {
 	                Map<String, Object> valueAsMap = Util.readMap((String) row.get("value"));
 	                assertJsonNode(valueAsMap, "0", List.of("Test"), Map.of("foo", 7L));
                  });
+    }
+
+    @Test
+    public void testToJsonWithNullValues() {
+        testCall(db, "RETURN apoc.convert.toJson({a: null, b: 'myString', c: [1,'2',null]}) as value",
+                (row) -> {
+                    final Map<String, Object> value = Util.fromJson((String) row.get("value"), Map.class);
+                    assertNull(value.get("a"));
+                    assertEquals("myString", value.get("b"));
+                    final List<Object> expected = asList(1L, "2", null);
+                    assertEquals(expected, value.get("c"));
+                });
     }
 
     @Test


### PR DESCRIPTION
Issue 1900 and 2394, cherry pick (4.4, present in 4.3)