### PR TITLE
issue 2149: New lock procedures for mutual exclusion for relationships on nodes in 4.3.x

### DIFF
--- a/core/src/test/java/apoc/lock/LockTest.java
+++ b/core/src/test/java/apoc/lock/LockTest.java
@@ -5,7 +5,10 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.kernel.impl.locking.LockAcquisitionTimeoutException;
@@ -63,5 +66,68 @@ public class LockTest {
             tx.commit();
         }
 
+    }
+
+    @Test
+    public void shouldBlockRelationshipsWithSuperNode() throws Exception {
+        Node node;
+        Node node2;
+        try (Transaction tx = db.beginTx()) {
+            node = tx.createNode(Label.label("One"));
+            node2 = tx.createNode(Label.label("Two"));
+            final Relationship newRel = node.createRelationshipTo(node2, RelationshipType.withName("NEW_REL"));
+            newRel.setProperty("id", 1000);
+            tx.commit();
+        }
+
+        try (Transaction tx = db.beginTx()) {
+            
+            // we create a super node (:One)
+            final long single = Iterators.single(db.executeTransactionally(
+                    "UNWIND range(1, 499) as idx with idx MATCH (n:One) \n" +
+                            "CREATE (n)-[:NEW_REL {id: idx}]->(:Other {id: idx}) RETURN count(n) as count", 
+                    Collections.emptyMap(),
+                    r -> r.columnAs("count")));
+            assertEquals(499L, single);
+            
+            // block nodes and rel with prop id = 333
+            final Node n = Iterators.single(tx.execute("MATCH (n:One) CALL apoc.lock.read.nodes([n]) return n").columnAs("n"));
+            final Node n2 = Iterators.single(tx.execute("MATCH (n:Two) CALL apoc.lock.read.nodes([n]) return n").columnAs("n"));
+            final Relationship relationship = Iterators.single(tx.execute("MATCH (:One)-[r:NEW_REL {id: 333}]->(e) with r CALL apoc.lock.read.rels([r]) return r").columnAs("r"));
+            assertEquals(n, node);
+            assertEquals(n2, node2);
+            assertEquals(node, relationship.getStartNode());
+
+            final String deleteQuery = "MATCH (p:One)-[rel:NEW_REL]->(e:Two) DELETE rel";
+            checkLockForRelationships(tx, deleteQuery);
+
+            final String mergeQuery = "MATCH (p:One), (e:Two) MERGE (p)-[rel:NEW_REL {id: 999}]->(e)";
+            checkLockForRelationships(tx, mergeQuery);
+
+            final String createQuery = "MATCH (p:One), (e:Two) CREATE (p)-[rel:NEW_REL {id: 888}]->(e)";
+            checkLockForRelationships(tx, createQuery);
+
+            final String deleteBlockedRelQuery = "MATCH (:One)-[rel:NEW_REL {id: 333}]->() DELETE rel";
+            checkLockForRelationships(tx, deleteBlockedRelQuery);
+
+            final String removePropBlockedRelQuery = "MATCH (:One)-[rel:NEW_REL {id: 333}]->(e) remove rel.id ";
+            checkLockForRelationships(tx, removePropBlockedRelQuery);
+
+            tx.commit();
+        }
+    }
+
+    private void checkLockForRelationships(Transaction tx, String query) throws InterruptedException {
+        final Thread thread = new Thread(() -> {
+            try {
+                db.executeTransactionally(query);
+            } catch (LockAcquisitionTimeoutException ignored) {}
+        });
+        thread.start();
+        thread.join(5000L);
+
+        // the blocked thread didn't do any work, so we still have same rels
+        long count = Iterators.count(tx.execute("match (:One)-[r:NEW_REL]->() WHERE r.id IS NOT NULL return r").columnAs("r"));
+        assertEquals(500, count);
     }
 }


### PR DESCRIPTION
issue 2149

Forse mi sfugge lo scopo, ma mi sembra che non sia cambiato nulla per quanto riguarda la creazione/cancellazione delle relazione, anche in presenza di super nodi, come dice qui https://neo4j.com/developer-blog/relationship-chain-locks-dont-block-the-rock/?ref=social-blog. 
Ho messo un test per verificare che bloccando i nodi terminali, si blocca qualsiasi operazione tra i due
