### PR TITLE
Issue 1674: Manage utf8 file with BOM properly

### DIFF
--- a/core/src/main/java/apoc/export/util/CountingInputStream.java
+++ b/core/src/main/java/apoc/export/util/CountingInputStream.java
@@ -1,5 +1,7 @@
 package apoc.export.util;
 
+import org.apache.commons.io.input.BOMInputStream;
+
 import java.io.*;
 
 /**
@@ -13,12 +15,17 @@ public class CountingInputStream extends FilterInputStream implements SizeCounte
     private long newLines;
 
     public CountingInputStream(File file) throws FileNotFoundException {
-        super(new BufferedInputStream(new FileInputStream(file), BUFFER_SIZE));
+        super(toBufferedStream(new FileInputStream(file)));
         this.total = file.length();
     }
     public CountingInputStream(InputStream stream, long total) throws FileNotFoundException {
-        super(new BufferedInputStream(stream, BUFFER_SIZE));
+        super(toBufferedStream(stream));
         this.total = total;
+    }
+
+    private static BufferedInputStream toBufferedStream(InputStream stream) {
+        final BOMInputStream bomInputStream = new BOMInputStream(stream);
+        return new BufferedInputStream(bomInputStream, BUFFER_SIZE);
     }
 
     @Override

--- a/core/src/main/java/apoc/export/util/CountingReader.java
+++ b/core/src/main/java/apoc/export/util/CountingReader.java
@@ -1,8 +1,6 @@
 package apoc.export.util;
 
 import java.io.*;
-import java.util.Collection;
-import java.util.Set;
 
 /**
  * @author mh
@@ -13,7 +11,6 @@ public class CountingReader extends FilterReader implements SizeCounter {
     private final long total;
     private long count=0;
     private long newLines;
-    private Set<Character> invalidChars = Set.of('\uFEFF');
 
     public CountingReader(File file) throws FileNotFoundException {
         super(new BufferedReader(new FileReader(file), BUFFER_SIZE));
@@ -28,20 +25,10 @@ public class CountingReader extends FilterReader implements SizeCounter {
     public int read(char[] cbuf, int off, int len) throws IOException {
         int read = super.read(cbuf, off, len);
         count+=read;
-
-        if (read == -1) {
-            return -1;
+        for (int i=off;i<off+len;i++) {
+            if (cbuf[i] == '\n') newLines++;
         }
-        int validIdx = off - 1;
-        for (int i=off;i<off+read;i++) {
-            if (invalidChars.contains(cbuf[i])) {
-                continue;
-            }
-            validIdx++;
-            cbuf[validIdx] = cbuf[i];
-            if (cbuf[validIdx] == '\n') newLines++;
-        }
-        return validIdx - off + 1;
+        return read;
     }
 
     @Override
@@ -74,13 +61,5 @@ public class CountingReader extends FilterReader implements SizeCounter {
     public long getPercent() {
         if (total <= 0) return 0;
         return count*100 / total;
-    }
-
-    public Set<Character> getInvalidChars() {
-        return invalidChars;
-    }
-
-    public void addInvalidChars(Collection<Character> invalidChars) {
-        this.invalidChars.addAll(invalidChars);
     }
 }

--- a/core/src/main/java/apoc/export/util/CountingReader.java
+++ b/core/src/main/java/apoc/export/util/CountingReader.java
@@ -1,6 +1,8 @@
 package apoc.export.util;
 
 import java.io.*;
+import java.util.Collection;
+import java.util.Set;
 
 /**
  * @author mh
@@ -11,6 +13,7 @@ public class CountingReader extends FilterReader implements SizeCounter {
     private final long total;
     private long count=0;
     private long newLines;
+    private Set<Character> invalidChars = Set.of('\uFEFF');
 
     public CountingReader(File file) throws FileNotFoundException {
         super(new BufferedReader(new FileReader(file), BUFFER_SIZE));
@@ -25,10 +28,20 @@ public class CountingReader extends FilterReader implements SizeCounter {
     public int read(char[] cbuf, int off, int len) throws IOException {
         int read = super.read(cbuf, off, len);
         count+=read;
-        for (int i=off;i<off+len;i++) {
-            if (cbuf[i] == '\n') newLines++;
+
+        if (read == -1) {
+            return -1;
         }
-        return read;
+        int validIdx = off - 1;
+        for (int i=off;i<off+read;i++) {
+            if (invalidChars.contains(cbuf[i])) {
+                continue;
+            }
+            validIdx++;
+            cbuf[validIdx] = cbuf[i];
+            if (cbuf[validIdx] == '\n') newLines++;
+        }
+        return validIdx - off + 1;
     }
 
     @Override
@@ -61,5 +74,13 @@ public class CountingReader extends FilterReader implements SizeCounter {
     public long getPercent() {
         if (total <= 0) return 0;
         return count*100 / total;
+    }
+
+    public Set<Character> getInvalidChars() {
+        return invalidChars;
+    }
+
+    public void addInvalidChars(Collection<Character> invalidChars) {
+        this.invalidChars.addAll(invalidChars);
     }
 }

--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -220,6 +220,19 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertEquals(asList("Selina", asList("Cola")), r.next().get("list"));
                 });
     }
+    
+    @Test
+    public void testLoadCsvWithBom() {
+        String url = "taxonomy.csv";
+        testCall(db, "CALL apoc.load.csv($url) YIELD map return map['smth1'] as first, map['ceva'] as second",
+                map("url",url),
+                (row) -> {
+                    final Object first = row.get("first");
+                    final Object second = row.get("second");
+                    assertEquals("Taxonomy", first);
+                    assertEquals("1", second);
+                });
+    }
 
     @Test public void testMapping() throws Exception {
         String url = "test-mapping.csv";

--- a/full/src/test/resources/taxonomy.csv
+++ b/full/src/test/resources/taxonomy.csv
@@ -1,0 +1,2 @@
+﻿ceva,Tree Level,Tree Path,Id,Code,Description,Long Description,smth,smth1,Active,Code Valid from,Node Valid from,Node Valid to
+1,1,(Root Code),31102727,Something,SomethingElse,,Something,Taxonomy,A,31/01/2020,,


### PR DESCRIPTION
Issue 1674

----

Ho provato a modificare la `dea64a5cb232398c1e39e958cd66d55c7956337f` 
cambiando quel `cbuf[validIdx] = cbuf[i];` (che quindi sposta uno alla volta gli elementi dell'array cbuf)
con un qualcosa che invece assegnasse un nuovo array buffer e rileggesse la porzione di caratteri 
o che mettesse `\0` invece del bom char.

Ma in entrambi i casi non va, perché se assegno un nuovo array poi il `BufferedReader` sottobanco si prende l'array iniziale (`cb`) e lo ripiazza nel'array finale --> `System.arraycopy(cb, nextChar, cbuf, off, n);`.

Invece il `\0` non funziona, perché il carattere nullo è diverso da "carattere vuoto".

Ho optato per mettere un `BOMInputStream`, però così è decisamente una soluzione poco generale e se poi c'è bisogno eventualmente di filtrare altri caratteri si è punto e a capo.