### PR TITLE
Issue 2403: Incoherent behaviours when some header cells are empty when using apoc.load.xls 

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/import/xls.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/xls.adoc
@@ -39,6 +39,8 @@ The `{config}` parameter is a map
 | <type> | Default `String`, The type of the conversion requested (`STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `NULL`, `LIST`, `DATE`, `DATE_TIME`, `LOCAL_DATE`, `LOCAL_DATE_TIME`, `LOCAL_TIME`, `TIME`)
 | dateFormat: <format> | Convert the Date into String (only String is allowed)
 | dateParse: [<formats>] | Convert the String into Date (Array of strings are allowed)
+| header | indicates if file has a header (default: true)
+| skipNullHeader | To map header value as empty string in case of column header without value (default: false, that is, it will fail with error `java.lang.IllegalStateException: Header at position N doesn't have a value`) 
 |===
 
 [NOTE]

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.xls.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.xls.adoc
@@ -6,7 +6,8 @@ The procedure support the following config parameters:
 | name | type | default | description
 | skip | boolean | none | skip result rows
 | limit | Long | none | limit result rows
-| header | booelan | true | indicates if file has a header
+| header | boolean | true | indicates if file has a header
+| skipNullHeader | boolean | false | To map header value as empty string in case of column header without value, otherwise it will fail with error `java.lang.IllegalStateException: Header at position N doesn't have a value`)
 | sep | String | ',' | separator character or 'TAB'
 | quoteChar | String | '"' | the char to use for quoted elements
 | arraySep | String |  ';' | array separator

--- a/full/src/main/java/apoc/load/LoadXls.java
+++ b/full/src/main/java/apoc/load/LoadXls.java
@@ -108,6 +108,7 @@ public class LoadXls {
             char arraySep = separator(config, "arraySep", DEFAULT_ARRAY_SEP);
             long skip = longValue(config, "skip", 0L);
             boolean hasHeader = booleanValue(config, "header", true);
+            boolean skipNullHeader = booleanValue(config, "skipNullHeader", false);
             long limit = longValue(config, "limit", Long.MAX_VALUE);
 
             List<String> ignore = value(config, "ignore", emptyList());
@@ -122,7 +123,7 @@ public class LoadXls {
             Row firstRow = sheet.getRow(selection.top);
             selection.updateHorizontal(firstRow.getFirstCellNum(), firstRow.getLastCellNum());
 
-            String[] header = getHeader(hasHeader, firstRow,selection, ignore, mappings);
+            String[] header = getHeader(hasHeader, skipNullHeader, firstRow,selection, ignore, mappings);
             boolean checkIgnore = !ignore.isEmpty() || mappings.values().stream().anyMatch( m -> m.ignore);
             return StreamSupport.stream(new XLSSpliterator(sheet, selection, header, url, skip, limit, checkIgnore,mappings, nullValues), false);
         } catch (Exception e) {
@@ -225,15 +226,23 @@ public class LoadXls {
         return strings.toArray(new String[strings.size()]);
     }
 
-    private String[] getHeader(boolean hasHeader, Row header, Selection selection, List<String> ignore, Map<String, Mapping> mapping) throws IOException {
+    private String[] getHeader(boolean hasHeader, boolean skipNullHeader, Row header, Selection selection, List<String> ignore, Map<String, Mapping> mapping) throws IOException {
         if (!hasHeader) return null;
 
         String[] result = new String[selection.right - selection.left];
         for (int i = selection.left; i < selection.right; i++) {
             Cell cell = header.getCell(i);
-            if (cell == null) throw new IllegalStateException("Header at position "+i+" doesn't have a value");
-            String value = cell.getStringCellValue();
-            result[i- selection.left] = ignore.contains(value) || mapping.getOrDefault(value, Mapping.EMPTY).ignore ? null : value;
+            final String s = "Header at position " + i + " doesn't have a value";
+            result[i- selection.left] = Optional.ofNullable(cell)
+                    .map(Cell::getStringCellValue)
+                    .or(() -> {
+                        if (skipNullHeader) {
+                            return Optional.of("");
+                        }
+                        throw new IllegalStateException(s);
+                    })
+                    .filter(value -> !ignore.contains(value) && !mapping.getOrDefault(value, Mapping.EMPTY).ignore)
+                    .orElse(null);
         }
         return result;
     }

--- a/full/src/test/java/apoc/load/LoadXlsTest.java
+++ b/full/src/test/java/apoc/load/LoadXlsTest.java
@@ -77,6 +77,18 @@ public class LoadXlsTest {
 
         assertEquals(2L, (long)query.apply("temp",false));
     }
+    
+    @Test
+    public void testLoadBrokenHeaderWithSkipNullHeaderTrue() throws Exception {
+        testResult(db, "CALL apoc.load.xls($url, 'temp', $config)",
+                map("url", brokenHeader,
+                        "config", map("header", true, "skipNullHeader", true)),
+                (r) -> {
+                    assertRow(r,0L, "A", 1L, "B", 2L, "C", 3L, "D", 4L, "", 5L, "F", 6L);
+                    assertFalse("Should not have another row",r.hasNext());
+                });
+    }
+
     @Test public void testLoadXlsMany() throws Exception {
         testResult(db, "CALL apoc.load.xls($url,'Many',{mapping:{Float:{type:'float'}, Array:{type:'int',array:true,arraySep:';'}}})", map("url",loadTest), // 'file:load_test.xlsx'
                 (r) -> {


### PR DESCRIPTION
Issue 2403: skip column if header is "broken"

Small xls adoc fixes (header config)