### PR TITLE
Issue 2336: Error when restoring a backup with cypher-shell (≤ 4.2)

### DIFF
--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -572,6 +572,8 @@ public class ExportCypherTest {
         Map<String, Object> config = map("awaitForIndexes", 3000);
         String expected = String.format(":begin%n" +
                 "CALL db.index.fulltext.createNodeIndex('MyCoolNodeFulltextIndex',['TempNode','TempNode2'],['value']);%n" +
+                ":commit%n" +
+                ":begin%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 ":commit%n" +
                 "CALL db.awaitIndexes(3000);%n" +


### PR DESCRIPTION
Issue 2336 ≤ 4.2

the `db.index.fulltext.*` statements must be placed in a `:begin` - `:commit` block without others schema operations.
Otherwise cypher shell throws ` Tried to execute Schema modification after executing Write query`


This is not needed for neo4j ≥ 4.3, see #186