### PR TITLE
Fix enterprise test 4.4

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -81,6 +81,8 @@ public class ApocConfig extends LifecycleAdapter {
             plugin_dir,
             logical_logs_location,
             transaction_logs_root_path,
+            run_directory,
+            lib_directory,
             neo4j_home
     ));
     private static final String DEFAULT_PATH = ".";

--- a/full/src/main/java/apoc/metrics/Metrics.java
+++ b/full/src/main/java/apoc/metrics/Metrics.java
@@ -43,7 +43,7 @@ public class Metrics {
         public static StoragePair fromDirectorySetting(String dir) {
             if (dir == null) return null;
 
-            String configLocation = apocConfig().getString("apoc." + dir, null);
+            String configLocation = apocConfig().getString(dir, null);
             if (configLocation == null) return null;
 
             File f = new File(configLocation);


### PR DESCRIPTION
Fixes enterprise tests 4.4

`MetricsTest` --> Issue 1829 (not cherry-picked in 4.4)

`SchemasEnterpriseFeaturesTest.java` 
- Added `filter(isRelConstraint)` and `filter(isNodeConstraint)` to avoid Exceptions in case of constraints of both types.
- Added `@Before` with drop schema, coherently with SchemasTest
- Changed `List` to `Set` in `testKeptNodeKeyAndUniqueConstraintIfExistsAndDropExistingIsFalse` test, not to consider order 