### PR TITLE
Update packages to fix CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     compileOnly group: 'org.apache.poi', name: 'poi-ooxml', version: poiVersion
     testCompile group: 'org.apache.poi', name: 'poi-ooxml', version: poiVersion
 
-    compile 'org.jsoup:jsoup:1.11.3'
+    compile 'org.jsoup:jsoup:1.14.3'
 
     compile group: 'org.roaringbitmap', name: 'RoaringBitmap', version: '0.7.17'
 
@@ -164,7 +164,7 @@ dependencies {
     testCompile group: 'com.couchbase.client', name: 'java-client', version: '2.7.2'
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10.4'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10.8'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.2' 
     compileOnly group: 'org.ow2.asm', name: 'asm', version: '5.0.2'
     compile group: 'com.github.javafaker', name: 'javafaker', version: '0.10'

--- a/src/main/java/apoc/util/FileUtils.java
+++ b/src/main/java/apoc/util/FileUtils.java
@@ -7,7 +7,6 @@ import apoc.export.util.ExportConfig;
 import apoc.util.hdfs.HDFSUtils;
 import apoc.util.s3.S3URLConnection;
 import apoc.util.s3.S3UploadUtils;
-import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedOutputStream;
@@ -30,7 +29,6 @@ import java.util.Map;
 import static apoc.ApocConfiguration.getImportDir;
 import static apoc.ApocConfiguration.isImportFolderConfigured;
 import static apoc.util.Util.readHttpInputStream;
-import static org.apache.commons.httpclient.util.URIUtil.encodePath;
 
 /**
  * @author mh
@@ -165,13 +163,12 @@ public class FileUtils {
         return inputStreamFor(fileName, null, null);
     }
 
-    public static String changeFileUrlIfImportDirectoryConstrained(String urlNotEncoded) throws IOException {
-        final String url = encodeExceptQM(urlNotEncoded);
+    public static String changeFileUrlIfImportDirectoryConstrained(String url) throws IOException {
         if (isFile(url) && isImportUsingNeo4jConfig()) {
             if (!ApocConfiguration.isEnabled("import.file.allow_read_from_filesystem")) {
                 throw new RuntimeException(String.format(ERROR_READ_FROM_FS_NOT_ALLOWED, url));
             }
-            final Path resolvedPath = resolvePath(urlNotEncoded);
+            final Path resolvedPath = resolvePath(url);
             return resolvedPath
                     .normalize()
                     .toUri()
@@ -230,14 +227,6 @@ public class FileUtils {
                 return resolvedPath.normalize().startsWith(basePath);
             }
             return false;
-        }
-    }
-
-    private static String encodeExceptQM(String url) {
-        try {
-            return encodePath(url).replace("%3F", "?");
-        } catch (URIException e) {
-            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Update packages to fix CVEs

Ho rimosso `org.apache.commons.httpclient.URIException`
ed anche il metodo `encodeExceptQM` che comunque veniva usato ma in realtà poi veniva risolto il path con l'url non codificato, quindi non serve.
In alternativa aggiungendo `compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'` funziona, ma è un'aggiunta inutile.

Sulla 4.x mi funziona perché l'encodePath viene fatto con `jetty`, non con `httpclient`, ma anche lì si può rimuovere.

