### PR TITLE
Issue 2190: apoc.convert.toTree reorders paths

### DIFF
--- a/core/src/main/java/apoc/convert/ConvertConfig.java
+++ b/core/src/main/java/apoc/convert/ConvertConfig.java
@@ -1,5 +1,7 @@
 package apoc.convert;
 
+import apoc.util.Util;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -14,8 +16,10 @@ public class ConvertConfig {
 
     private Map<String, List<String>> nodes;
     private Map<String, List<String>> rels;
+    private final boolean preventSort;
 
     public ConvertConfig(Map<String,Object> config) {
+        this.preventSort = Util.toBoolean(config.get("preventSort"));
 
         this.nodes = (Map<String, List<String>>) config.getOrDefault("nodes", Collections.EMPTY_MAP);
         this.rels = (Map<String, List<String>>) config.getOrDefault("rels", Collections.EMPTY_MAP);
@@ -30,6 +34,10 @@ public class ConvertConfig {
 
     public Map<String, List<String>> getRels() {
         return rels;
+    }
+
+    public boolean isPreventSort() {
+        return preventSort;
     }
 
     private void validateListProperties(List<String> list) {

--- a/core/src/main/java/apoc/convert/Json.java
+++ b/core/src/main/java/apoc/convert/Json.java
@@ -8,6 +8,8 @@ import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.internal.helpers.collection.Iterables;
+import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.procedure.*;
 
 import java.io.IOException;
@@ -143,7 +145,13 @@ public class Json {
 
         Map<Long, Map<String, Object>> maps = new HashMap<>(paths.size() * 100);
 
-        paths.stream().sorted(Comparator.comparingInt(Path::length).reversed()).forEach(path -> {
+        for (Path path : paths) {
+            // to exclude closed paths
+            // so that we are sure not to pick, e.g. with `testToTreeIssue1685`, paths too short and therefore results too shallow
+            final Iterable<Node> iterable = path.nodes();
+            if (Iterables.count(iterable) != Iterables.asSet(iterable).size()) {
+                continue;
+            }
             Iterator<Entity> it = path.iterator();
             while (it.hasNext()) {
                 Node n = (Node) it.next();
@@ -167,7 +175,7 @@ public class Json {
                     }
                 }
             }
-        });
+        }
 
         return paths.stream()
                 .map(Path::startNode)

--- a/core/src/main/java/apoc/convert/Json.java
+++ b/core/src/main/java/apoc/convert/Json.java
@@ -145,13 +145,11 @@ public class Json {
 
         Map<Long, Map<String, Object>> maps = new HashMap<>(paths.size() * 100);
 
-        for (Path path : paths) {
-            // to exclude closed paths
-            // so that we are sure not to pick, e.g. with `testToTreeIssue1685`, paths too short and therefore results too shallow
-            final Iterable<Node> iterable = path.nodes();
-            if (Iterables.count(iterable) != Iterables.asSet(iterable).size()) {
-                continue;
-            }
+        Stream<Path> stream = paths.stream();
+        if (!conf.isPreventSort()) {
+            stream = stream.sorted(Comparator.comparingInt(Path::length).reversed());
+        }
+        stream.forEach(path -> {
             Iterator<Entity> it = path.iterator();
             while (it.hasNext()) {
                 Node n = (Node) it.next();
@@ -175,7 +173,7 @@ public class Json {
                     }
                 }
             }
-        }
+        });
 
         return paths.stream()
                 .map(Path::startNode)

--- a/core/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/core/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -339,7 +339,7 @@ public class ConvertJsonTest {
                     List<Object> actedInList = (List<Object>) root.get("acted_in");
                     assertEquals(7, actedInList.size());
                     List<Object> innerList = (List) ((Map<String, Object>) actedInList.get(1)).get("acted_in");
-                    assertEquals(5, ((Map<String, Object>) innerList.get(0)).size());
+                    assertEquals(6, ((Map<String, Object>) innerList.get(0)).size());
                 });
     }
     
@@ -365,7 +365,7 @@ public class ConvertJsonTest {
                         "WITH path, [r IN relationships(path) | r.order] AS orders\n" +
                         "ORDER BY orders\n" +
                         "WITH COLLECT(path) AS paths\n" +
-                        "CALL apoc.convert.toTree(paths) YIELD value AS tree\n" +
+                        "CALL apoc.convert.toTree(paths, true, {preventSort: true}) YIELD value AS tree\n" +
                         "RETURN tree",
                 (row) -> {
                     Map tree = (Map) row.get("tree");

--- a/core/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/core/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -339,8 +339,42 @@ public class ConvertJsonTest {
                     List<Object> actedInList = (List<Object>) root.get("acted_in");
                     assertEquals(7, actedInList.size());
                     List<Object> innerList = (List) ((Map<String, Object>) actedInList.get(1)).get("acted_in");
-                    assertEquals(6, ((Map<String, Object>) innerList.get(0)).size());
+                    assertEquals(5, ((Map<String, Object>) innerList.get(0)).size());
                 });
+    }
+    
+    @Test public void testToTreeIssue2190() {
+	    db.executeTransactionally("CREATE (root:TreeNode {name:'root'})\n" +
+                "CREATE (c0:TreeNode {name: 'c0'})\n" +
+                "CREATE (c1:TreeNode {name: 'c1'})\n" +
+                "CREATE (c2:TreeNode {name: 'c2'})\n" +
+                "CREATE (c00:TreeNode {name : 'c00'})\n" +
+                "CREATE (c01:TreeNode {name : 'c01'})\n" +
+                "CREATE (c10:TreeNode {name : 'c10'})\n" +
+                "CREATE (c100:TreeNode {name : 'c100'})\n" +
+                "CREATE (root)-[:CHILD {order: 0}]->(c0)\n" +
+                "CREATE (root)-[:CHILD {order: 1}]->(c1)\n" +
+                "CREATE (root)-[:CHILD { order: 2}]->(c2)\n" +
+                "CREATE (c0)-[:CHILD {order: 0}]->(c00)\n" +
+                "CREATE (c0)-[:CHILD {order: 1}]->(c01)\n" +
+                "CREATE (c1)-[:CHILD {order: 0}]->(c10)\n" +
+                "CREATE (c10)-[:CHILD {order: 0}]->(c100)");
+
+        testCall(db, "MATCH(root:TreeNode) WHERE root.name = \"root\"\n" +
+                        "MATCH path = (root)-[cl:CHILD*]->(c:TreeNode)\n" +
+                        "WITH path, [r IN relationships(path) | r.order] AS orders\n" +
+                        "ORDER BY orders\n" +
+                        "WITH COLLECT(path) AS paths\n" +
+                        "CALL apoc.convert.toTree(paths) YIELD value AS tree\n" +
+                        "RETURN tree",
+                (row) -> {
+                    Map tree = (Map) row.get("tree");
+                    final List<Map> child = (List<Map>) tree.get("child");
+                    final Object firstChildName = child.get(0).get("name");
+                    assertEquals("c0", firstChildName);
+                });
+                    
+	    db.executeTransactionally("MATCH (n:TreeNode) DETACH DELETE n");
     }
 
     @Test public void testToTree() throws Exception {

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.convert.toTree.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.convert.toTree.adoc
@@ -6,4 +6,5 @@ The procedure support the following config parameters:
 | name | type | default | description
 | nodes | Map<String, List<String>> | {}| properties to include for each node label e.g. `{Movie: ['title']}` or to exclude (e.g. `{Movie: ['-title']}`).
 | rels | Map<String, List<String>> | {} | properties to include for each relationship type e.g. `{`ACTED_IN`: ["roles"]}`  or to exclude (e.g. `{`ACTED_IN`: ["-roles"]}`).
+| preventSort | boolean | false | to prevents the sorting of the result implemented under the hood
 |===


### PR DESCRIPTION
Issue 2190

Added `preventSort` config
