### PR TITLE
Improve performance apoc.meta.stats 4.x

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -476,30 +476,25 @@ public class    Meta {
     private void collectStats(SubGraph subGraph, Collection<String> labelNames, Collection<String> relTypeNames, StatsCallback cb) {
         TokenRead tokenRead = kernelTx.tokenRead();
 
-        Map<String, Integer> labelMap = subGraph.labelsInUse(tokenRead, labelNames);
-        Map<String, Integer> typeMap = subGraph.relTypesInUse(tokenRead, relTypeNames);
-
-        Iterable<Label> labels = CollectionUtils.isNotEmpty(labelNames)
-                ? labelNames.stream().map(Label::label).collect(Collectors.toList()) : subGraph.getAllLabelsInUse();
-        Iterable<RelationshipType> types = CollectionUtils.isNotEmpty(relTypeNames)
-                ? relTypeNames.stream().map(RelationshipType::withName).collect(Collectors.toList()) : subGraph.getAllRelationshipTypesInUse();
+        Iterable<Label> labels = subGraph.labelsInUse(labelNames);
+        Iterable<RelationshipType> types = subGraph.relTypesInUse(relTypeNames);
 
         labels.forEach(label -> {
             long count = subGraph.countsForNode(label);
             if (count > 0) {
                 String name = label.name();
-                int id = labelMap.get(name);
+                int id = tokenRead.nodeLabel(name);
                 cb.label(id, name, count);
                 types.forEach(type -> {
                     long relCountOut = subGraph.countsForRelationship(label, type);
                     long relCountIn = subGraph.countsForRelationship(type, label);
-                    cb.rel(typeMap.get(type.name()), type.name(), id, name, relCountOut, relCountIn);
+                    cb.rel(tokenRead.relationshipType(type.name()), type.name(), id, name, relCountOut, relCountIn);
                 });
             }
         });
         types.forEach(type -> {
             String name = type.name();
-            int id = typeMap.get(name);
+            int id = tokenRead.relationshipType(name);
             cb.rel(id, name, subGraph.countsForRelationship(type));
         });
     }
@@ -1043,15 +1038,13 @@ public class    Meta {
     private Stream<GraphResult> metaGraph(SubGraph subGraph, Collection<String> labelNames, Collection<String> relTypeNames, boolean removeMissing, MetaConfig metaConfig) {
         TokenRead tokenRead = kernelTx.tokenRead();
 
-        Map<String, Integer> typeMap = subGraph.relTypesInUse(tokenRead, relTypeNames);
+        Iterable<RelationshipType> types = subGraph.relTypesInUse(relTypeNames);
         Iterable<Label> labels = CollectionUtils.isNotEmpty(labelNames)
                 ? labelNames.stream().map(Label::label).collect(Collectors.toList()) : subGraph.getAllLabelsInUse();
-        Iterable<RelationshipType> types = CollectionUtils.isNotEmpty(relTypeNames)
-                ? relTypeNames.stream().map(RelationshipType::withName).collect(Collectors.toList()) : subGraph.getAllRelationshipTypesInUse();
 
 
         Map<String, Node> vNodes = new TreeMap<>();
-        Map<Pattern, Relationship> vRels = new HashMap<>(typeMap.size() * 2);
+        Map<Pattern, Relationship> vRels = new HashMap<>((int) Iterables.count(types) * 2);
 
         labels.forEach(label -> {
             long count = subGraph.countsForNode(label);

--- a/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -14,17 +14,17 @@ import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import java.util.Iterator;
 import java.util.Optional;
 
+import static apoc.export.cypher.formatter.CypherFormatterUtils.cypherNode;
 import static org.neo4j.internal.kernel.api.TokenRead.ANY_LABEL;
+import static apoc.util.Util.quote;
 
 public class DatabaseSubGraph implements SubGraph
 {
     private final Transaction transaction;
-    private final KernelTransaction kernelTransaction;
 
     public DatabaseSubGraph( Transaction transaction )
     {
         this.transaction = transaction;
-        this.kernelTransaction = ((InternalTransaction) transaction).kernelTransaction();
     }
 
     public static SubGraph from( Transaction transaction )
@@ -89,13 +89,41 @@ public class DatabaseSubGraph implements SubGraph
 
     @Override
     public long countsForRelationship(Label start, RelationshipType type, Label end) {
-        final TokenRead tokenRead = kernelTransaction.tokenRead();
-        final int startId = getLabelId(start, tokenRead);
-        final int relId = tokenRead.relationshipType(type.name());
-        final int endId = getLabelId(end, tokenRead);
-        
-        return kernelTransaction.dataRead()
-                .countsForRelationship(startId, relId, endId);
+        // even if `MATCH ()-[r]->(:Label) RETURN count(r)` and `MATCH (:Label)-[r]->() RETURN count(r)` leverage on `RelationshipCountFromCountStore`
+        // we count entities via the `TokenRead`, because it's much faster
+        // and we fallback to query via count store if transaction is not an InternalTransaction
+        if (transaction instanceof InternalTransaction) {
+            final KernelTransaction kernelTransaction = ((InternalTransaction) transaction).kernelTransaction();
+            final TokenRead tokenRead = kernelTransaction.tokenRead();
+            final int startId = getLabelId(start, tokenRead);
+            final int relId = tokenRead.relationshipType(type.name());
+            final int endId = getLabelId(end, tokenRead);
+
+            return kernelTransaction.dataRead()
+                    .countsForRelationship(startId, relId, endId);
+        }
+        String startNode = cypherNode(start);
+        String endNode = cypherNode(end);
+        String relationship = String.format("[r:%s]", quote(type.name()));
+        return transaction.execute(String.format("MATCH %s-%s->%s RETURN count(r) AS count", startNode, relationship, endNode))
+                .<Long>columnAs("count")
+                .next();
+    }
+
+    @Override
+    public long countsForNode(Label label) {
+        // even if `MATCH (n:Label) RETURN count(n)` leverage on `NodeCountFromCountStore`
+        // we count entities via the `TokenRead`, because it's much faster
+        // and we fallback to query via count store if transaction is not an InternalTransaction
+        if (transaction instanceof InternalTransaction) {
+            final KernelTransaction kernelTransaction = ((InternalTransaction) transaction).kernelTransaction();
+            final int labelId = getLabelId(label, kernelTransaction.tokenRead());
+            return kernelTransaction.dataRead()
+                    .countsForNode(labelId);
+        }
+        return transaction.execute(String.format("MATCH (n:%s) RETURN count(n) AS count", quote(label.name())))
+                .<Long>columnAs("count")
+                .next();
     }
 
     private Integer getLabelId(Label start, TokenRead tokenRead) {
@@ -103,13 +131,6 @@ public class DatabaseSubGraph implements SubGraph
                 .map(Label::name)
                 .map(tokenRead::nodeLabel)
                 .orElse(ANY_LABEL);
-    }
-
-    @Override
-    public long countsForNode(Label label) {
-        final int labelId = kernelTransaction.tokenRead().nodeLabel(label.name());
-        return kernelTransaction.dataRead()
-                .countsForNode(labelId);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -7,19 +7,24 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.internal.kernel.api.TokenRead;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 
 import java.util.Iterator;
+import java.util.Optional;
 
-import static apoc.export.cypher.formatter.CypherFormatterUtils.cypherNode;
-import static apoc.util.Util.quote;
+import static org.neo4j.internal.kernel.api.TokenRead.ANY_LABEL;
 
 public class DatabaseSubGraph implements SubGraph
 {
     private final Transaction transaction;
+    private final KernelTransaction kernelTransaction;
 
     public DatabaseSubGraph( Transaction transaction )
     {
         this.transaction = transaction;
+        this.kernelTransaction = ((InternalTransaction) transaction).kernelTransaction();
     }
 
     public static SubGraph from( Transaction transaction )
@@ -84,19 +89,27 @@ public class DatabaseSubGraph implements SubGraph
 
     @Override
     public long countsForRelationship(Label start, RelationshipType type, Label end) {
-        String startNode = cypherNode(start);
-        String endNode = cypherNode(end);
-        String relationship = String.format("[r:%s]", quote(type.name()));
-        return transaction.execute(String.format("MATCH %s-%s->%s RETURN count(r) AS count", startNode, relationship, endNode))
-                .<Long>columnAs("count")
-                .next();
+        final TokenRead tokenRead = kernelTransaction.tokenRead();
+        final int startId = getLabelId(start, tokenRead);
+        final int relId = tokenRead.relationshipType(type.name());
+        final int endId = getLabelId(end, tokenRead);
+        
+        return kernelTransaction.dataRead()
+                .countsForRelationship(startId, relId, endId);
+    }
+
+    private Integer getLabelId(Label start, TokenRead tokenRead) {
+        return Optional.ofNullable(start)
+                .map(Label::name)
+                .map(tokenRead::nodeLabel)
+                .orElse(ANY_LABEL);
     }
 
     @Override
     public long countsForNode(Label label) {
-        return transaction.execute(String.format("MATCH (n:%s) RETURN count(n) AS count", quote(label.name())))
-                .<Long>columnAs("count")
-                .next();
+        final int labelId = kernelTransaction.tokenRead().nodeLabel(label.name());
+        return kernelTransaction.dataRead()
+                .countsForNode(labelId);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
@@ -12,10 +12,10 @@ import org.neo4j.internal.kernel.api.TokenRead;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toMap;
 
 public interface SubGraph
 {
@@ -41,24 +41,20 @@ public interface SubGraph
 
     Iterator<Node> findNodes(Label label);
 
-    default Map<String, Integer> relTypesInUse(TokenRead ops, Collection<String> relTypeNames) {
+    default List<RelationshipType> relTypesInUse(Collection<String> relTypeNames) {
         Stream<RelationshipType> stream = Iterables.stream(this.getAllRelationshipTypesInUse());
         if (CollectionUtils.isNotEmpty(relTypeNames)) {
             stream = stream.filter(rel -> relTypeNames.contains(rel.name()));
         }
-        return stream
-                .map(RelationshipType::name)
-                .collect(toMap(t -> t, ops::relationshipType));
+        return stream.collect(Collectors.toList());
     }
 
-    default Map<String, Integer> labelsInUse(TokenRead ops, Collection<String> labelNames) {
+    default List<Label> labelsInUse(Collection<String> labelNames) {
         Stream<Label> stream = Iterables.stream(this.getAllLabelsInUse());
         if (CollectionUtils.isNotEmpty(labelNames)) {
             stream = stream.filter(rel -> labelNames.contains(rel.name()));
         }
-        return stream
-                .map(Label::name)
-                .collect(toMap(t -> t, ops::nodeLabel));
+        return stream.collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
Improve performance apoc.meta.stats 4.x

Rispetto alla 3.5, il calo di prestazioni è dovuto ai metodi `countsForNode` e `countsForRelationship`,
che attualmente nella 4.x sono calcolati tramite query cypher utilizzando la classe `DatabaseSubGraph.java`
mentre nella 3.x tramite il `org.neo4j.internal.kernel.api.TokenRead` (senza l'utilizzo della `DatabaseSubGraph`)
che è decisamente più prestante.

Quindi qui ho implementato il `TokenRead` nella `DatabaseSubGraph.java` per il conteggio delle entità.
In alternativa, se non si vuole toccare il SubGraph, si potrebbe banalmente sostituire il metodo `collectStats(..)` con quello che c'è nel 3.5, però visto la classe Meta è fatta nella 4.x tutta con i `subGraph` forse è meglio lasciarla così?
