### PR TITLE
Issue 2468: APOC uses Jackson version prior to 2.11 not compatible with latest spring-boot

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
 
     testCompile group: 'org.reflections', name: 'reflections', version: '0.9.11', { exclude group: 'com.google.guava', module: 'guava' }
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective
     testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.2.22.v20170606'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,6 @@ dependencies {
     }
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
     testCompile 'org.mock-server:mockserver-netty:3.10.8'
     testCompile 'org.mock-server:mockserver-client-java:3.10.8'
@@ -99,8 +98,7 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
-    testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'

--- a/extra-dependencies/gradle/wrapper/gradle-wrapper.properties
+++ b/extra-dependencies/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/extra-dependencies/nlp/build.gradle
+++ b/extra-dependencies/nlp/build.gradle
@@ -19,8 +19,8 @@ jar {
 
 dependencies {
     compile group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
-    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10'
 }
 
 

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id "org.sonarqube"
-    id "org.jetbrains.kotlin.jvm" version "1.3.71"
+    id "org.jetbrains.kotlin.jvm" version "1.6.10"
 }
 
 archivesBaseName = "apoc"
@@ -105,13 +105,12 @@ dependencies {
     testCompile group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE'
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
-    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10'
 
-    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
-    testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10'
 
     testCompile 'org.mock-server:mockserver-netty:3.10.8'
     testCompile 'org.mock-server:mockserver-client-java:3.10.8'
@@ -119,8 +118,6 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
-    testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'

--- a/full/src/main/kotlin/apoc/nlp/azure/AzureProcedures.kt
+++ b/full/src/main/kotlin/apoc/nlp/azure/AzureProcedures.kt
@@ -1,6 +1,7 @@
 package apoc.nlp.azure
 
 
+import apoc.Extended
 import apoc.nlp.NLPHelperFunctions
 import apoc.nlp.NLPHelperFunctions.convert
 import apoc.nlp.NLPHelperFunctions.getNodeProperty
@@ -14,6 +15,7 @@ import org.neo4j.logging.Log
 import org.neo4j.procedure.*
 import java.util.stream.Stream
 
+@Extended
 class AzureProcedures {
     @Context
     @JvmField

--- a/full/src/main/resources/extended.txt
+++ b/full/src/main/resources/extended.txt
@@ -96,6 +96,12 @@ apoc.nlp.aws.keyPhrases.graph
 apoc.nlp.aws.keyPhrases.stream
 apoc.nlp.aws.sentiment.graph
 apoc.nlp.aws.sentiment.stream
+apoc.nlp.azure.entities.graph, 
+apoc.nlp.azure.entities.stream, 
+apoc.nlp.azure.keyPhrases.graph, 
+apoc.nlp.azure.keyPhrases.stream, 
+apoc.nlp.azure.sentiment.graph, 
+apoc.nlp.azure.sentiment.stream,
 apoc.nlp.gcp.classify.graph
 apoc.nlp.gcp.classify.stream
 apoc.nlp.gcp.entities.graph

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
 
-    compile group: 'org.gradle', name: 'gradle-tooling-api', version: '6.0.1'
+    compile group: 'org.gradle', name: 'gradle-tooling-api', version: '6.1.1'
 
     def withoutServers = {
         exclude group: 'org.eclipse.jetty'

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -1,7 +1,7 @@
 description = 'APOC :: Test Utils'
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.12'
+    compile group: 'junit', name: 'junit', version: '4.13.2'
 
     compile group: 'org.neo4j', name: 'neo4j-common', version: neo4jVersionEffective, classifier: "tests"
     compile group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective // , classifier: "tests"


### PR DESCRIPTION
Issue 2468

The latest version (`2.13.1`) requires a  Kotlin update, and consequently gradle as well to `gradle-6.1.1`, otherwise we have a `The current Gradle version 6.0.1 is not compatible with the Kotlin Gradle plugin. Please use Gradle 6.1.1 or newer, or the previous version of the Kotlin plugin.` error


Removed `jackson-mapper-asl`, not used (old jackson-databind package)
Removed `jackson-databind` in full


This one resolves also the https://trello.com/c/PqAy4y8F/906-cves-for-apoc-4401-jackson issue. 

With `com.fasterxml.jackson.module` update, junit will be forced to 2.12 version, which cause a `Folder name cannot consist of multiple path components separated by a file separator. ` exception in LoadDirectoryTest.java (`temporaryFolder.newFolder(IMPORT_DIR + File.separator + SUBFOLDER_1)`). I could just replace it with `temporaryFolder.newFolder(IMPORT_DIR, SUBFOLDER_1); ` but, given that the `4.12` junit as a CVE (https://mvnrepository.com/artifact/junit/junit/4.12), I updated junit as well (to `4.13.2`)

For some reason, with Kotlin update the `AzureProcedures` is detected as "core" procedure (in `CoreExtendedTest`), because is absent the "`@Extended`" annotation. Before the update, the azure procs haven't listed in core procedures.
