### PR TITLE
Issue 2325: added prop filter

### DIFF
--- a/core/src/main/java/apoc/export/json/ImportJsonConfig.java
+++ b/core/src/main/java/apoc/export/json/ImportJsonConfig.java
@@ -6,9 +6,13 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class ImportJsonConfig extends CompressionConfig {
+    public static final String WILDCARD_PROPS = "_all";
+    private final Map<String, List<String>> nodePropFilter;
+    private final Map<String, List<String>> relPropFilter;
 
     private final Map<String, Map<String, String>> nodePropertyMappings;
     private final Map<String, Map<String, String>> relPropertyMappings;
@@ -26,6 +30,8 @@ public class ImportJsonConfig extends CompressionConfig {
         this.unwindBatchSize = Util.toInteger(config.getOrDefault("unwindBatchSize", 5000));
         this.txBatchSize = Util.toInteger(config.getOrDefault("txBatchSize", 5000));
         this.importIdName = (String) config.getOrDefault("importIdName", "neo4jImportId");
+        this.nodePropFilter = (Map<String, List<String>>) config.getOrDefault("nodePropFilter", Collections.emptyMap());
+        this.relPropFilter = (Map<String, List<String>>) config.getOrDefault("relPropFilter", Collections.emptyMap());
     }
 
     public String typeForNode(Collection<String> labels, String property) {
@@ -50,5 +56,13 @@ public class ImportJsonConfig extends CompressionConfig {
 
     public String getImportIdName() {
         return importIdName;
+    }
+
+    public Map<String, List<String>> getNodePropFilter() {
+        return nodePropFilter;
+    }
+
+    public Map<String, List<String>> getRelPropFilter() {
+        return relPropFilter;
     }
 }

--- a/core/src/main/java/apoc/export/json/JsonImporter.java
+++ b/core/src/main/java/apoc/export/json/JsonImporter.java
@@ -27,9 +27,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static apoc.export.json.ImportJsonConfig.WILDCARD_PROPS;
 
 public class JsonImporter implements Closeable {
     private static final String UNWIND = "UNWIND $rows AS row ";
@@ -70,18 +73,33 @@ public class JsonImporter implements Closeable {
 
         manageEntityType(type);
 
+        final List<String> labels;
+        final Map<String, List<String>> propFilter;
         switch (type) {
             case "node":
                 manageNode(param);
+                labels = lastLabels;
+                propFilter = importJsonConfig.getNodePropFilter();
                 break;
             case "relationship":
                 manageRelationship(param);
+                labels = Collections.singletonList((String) lastRelTypes.get("label"));
+                propFilter = importJsonConfig.getRelPropFilter();
                 break;
             default:
                 throw new IllegalArgumentException("Current type not supported: " + type);
         }
 
         final Map<String, Object> properties = (Map<String, Object>) param.getOrDefault("properties", Collections.emptyMap());
+
+        final List<String> defaultProps = propFilter.getOrDefault(WILDCARD_PROPS, Collections.emptyList());
+        
+        properties.keySet()
+                .removeIf(name -> {
+                    final Predicate<String> nameInPropFilter = (i) -> propFilter.getOrDefault(i, defaultProps).contains(name);
+                    return labels.stream().anyMatch(nameInPropFilter);
+                });
+
         updateReporter(type, properties);
         param.put("properties", convertProperties(type, properties, null));
 

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -7,15 +7,6 @@ import apoc.schema.Schemas;
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
-import com.google.common.collect.Iterables;
-import junit.framework.TestCase;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import apoc.util.Util;
-import com.google.common.collect.Iterables;
-import junit.framework.TestCase;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import apoc.util.Util;
-import com.google.common.collect.Iterables;
 import junit.framework.TestCase;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import apoc.util.Utils;
@@ -24,11 +15,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.spatial.Point;
+import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
@@ -41,15 +34,19 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
+import static apoc.export.json.ImportJsonConfig.WILDCARD_PROPS;
 import static apoc.export.json.JsonImporter.MISSING_CONSTRAINT_ERROR_MSG;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.CompressionConfig.COMPRESSION;
-import static apoc.export.json.JsonImporter.MISSING_CONSTRAINT_ERROR_MSG;
 import static apoc.util.MapUtil.map;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
@@ -210,6 +207,65 @@ public class ImportJsonTest {
     }
 
     @Test
+    public void shouldImportAllNodesAndRelsWithFilterAll() {
+        createConstraints(List.of("FirstLabel", "Stream", "User", "Game", "Team", "Language", "$User", "$Stream"));
+        assertEntities(0L, 0L);
+
+        String filename = "multiLabels.json";
+
+        TestUtil.testCall(db, "CALL apoc.import.json($file, $config)",
+                map("file", filename, 
+                        "config", map("nodePropFilter", map(WILDCARD_PROPS, List.of("name")),
+                                "relPropFilter", map(WILDCARD_PROPS, List.of("bffSince")))), 
+                r -> {
+                    assertEquals(NODES_BIG_JSON, r.get("nodes"));
+                    assertEquals(RELS_BIG_JSON, r.get("relationships"));
+                });
+
+        final Consumer<Node> nodeConsumer = node -> assertFalse(node.hasProperty("name"));
+        final Consumer<Relationship> relConsumer = rel -> assertFalse(rel.hasProperty("bffSince"));
+        assertEntities(NODES_BIG_JSON, RELS_BIG_JSON, nodeConsumer, relConsumer);
+    }
+    
+    @Test
+    public void shouldImportAllNodesAndRelsWithLabelAndRelTypeFilter() {
+        createConstraints(List.of("FirstLabel", "Stream", "User", "Game", "Team", "Language", "$User", "$Stream"));
+        assertEntities(0L, 0L);
+
+        String filename = "multiLabels.json";
+
+        TestUtil.testCall(db, "CALL apoc.import.json($file, $config)",
+                map("file", filename, 
+                        "config", map("nodePropFilter", map("Stream", List.of("name"), 
+                                        "$User", List.of("total_view_count", "url"), 
+                                        "$Stream", List.of("name", "id")), 
+                                "relPropFilter", map("REL_GAME_TO_LANG", List.of("since")))
+                ), r -> {
+                    assertEquals(NODES_BIG_JSON, r.get("nodes"));
+                    assertEquals(RELS_BIG_JSON, r.get("relationships"));
+                });
+
+        final Consumer<Node> nodeConsumer = node -> {
+            if (node.hasLabel(Label.label("Stream"))) {
+                final Set<String> actual = Iterables.asSet(node.getPropertyKeys());
+                assertEquals(Set.of("createdAt", "followers", "description", "id", "total_view_count", "url", "neo4jImportId"), actual);
+            }
+            if (node.hasLabel(Label.label("$User"))) {
+                final Set<String> actual = Iterables.asSet(node.getPropertyKeys());
+                assertEquals(Set.of("createdAt", "followers", "description", "neo4jImportId"), actual);
+            }
+        };
+        
+        final Consumer<Relationship> relConsumer = rel -> {
+            final boolean hasTypeRelGameToLang = rel.getType().name().equals("REL_GAME_TO_LANG");
+            assertEquals(!hasTypeRelGameToLang, rel.hasProperty("since"));
+            assertTrue(rel.hasProperty("bffSince"));
+        };
+
+        assertEntities(NODES_BIG_JSON, RELS_BIG_JSON, nodeConsumer, relConsumer);
+    }
+    
+    @Test
     public void shouldImportAllNodesAndRels() {
         createConstraints(List.of("FirstLabel", "Stream", "User", "Game", "Team", "Language", "$User", "$Stream"));
         assertEntities(0L, 0L);
@@ -262,9 +318,21 @@ public class ImportJsonTest {
     }
 
     private void assertEntities(long expectedNodes, long expectedRels) {
+        assertEntities(expectedNodes, expectedRels, null, null);
+    }
+
+    private void assertEntities(long expectedNodes, long expectedRels, Consumer<Node> nodeConsumer, Consumer<Relationship> relConsumer) {
         try (Transaction tx = db.beginTx()) {
-            assertEquals(expectedNodes, Iterables.size(tx.getAllNodes()));
-            assertEquals(expectedRels, Iterables.size(tx.getAllRelationships()));
+            final List<Node> nodeList = Iterables.asList(tx.getAllNodes());
+            final List<Relationship> relList = Iterables.asList((tx.getAllRelationships()));
+            assertEquals(expectedNodes, nodeList.size());
+            assertEquals(expectedRels, relList.size());
+            if (nodeConsumer != null) {
+                nodeList.forEach(nodeConsumer);
+            }
+            if (relConsumer != null) {
+                relList.forEach(relConsumer);
+            }
         }
     }
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
@@ -1,7 +1,7 @@
 This procedure supports the following config parameters:
 
 .Config parameters
-[opts=header]
+[opts=header, cols='1a,1a,1a,3a']
 |===
 | name | type |default | description
 | unwindBatchSize | Integer | `5000` | the batch size of the unwind
@@ -11,6 +11,13 @@ This procedure supports the following config parameters:
 | relPropertyMappings | Map | `{}` | The mapping rel type/property name/property type for Custom Neo4j types (point date). I.e. { KNOWS: { since: 'Datetime' } }
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)
 See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example]
+| nodePropFilter | Map<String, List<String>> | `{}` | A map with key the labels, and value the list of properties keys to filter during the import. 
+For example `{ User: ['name', 'surname'], Another: ['foo']}` will skip the properties name and surname of nodes with label User, the property foo of (:Another) nodes. +
+Note that if a node has multiple labels, in this example (:User:Another {}), will be filtered all properties of both labels, that is 'name', 'surname' and 'foo'. +
+We can also pass a key `_all` to filter properties of all nodes, for example `{_all: ['myProp']}`
+| relPropFilter | Map<String, List<String>> | `{}` | A map with key the rel-types, and value the list of properties keys to filter during the import.  
+For example `{ MY_REL: ['foo', 'baz'] }` will skip the properties name and surname of nodes with label User, the properties foo and baz of [:MY_REL] relationship. +
+We can also pass a key `_all` to filter properties of all relationships, for example `{_all: ['myProp']}`
 |===
 
 `nodePropertyMappings` and `relPropertyMappings` support the following Neo4j types:


### PR DESCRIPTION
Issue 2325

Added `nodePropFilter` and `relPropFilter`, 
with key the label / rel-type consistently with `nodePropertyMappings` and `relPropertyMappings`.

The values are the property keys to be filtered.