### PR TITLE
Issue 2269: apoc.load procedures don't work anymore with urls containing %

### DIFF
--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -7,7 +7,6 @@ import apoc.util.hdfs.HDFSUtils;
 import apoc.util.s3.S3URLConnection;
 import apoc.util.s3.S3UploadUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.configuration.GraphDatabaseSettings;
 
@@ -32,7 +31,6 @@ import static apoc.ApocConfig.APOC_IMPORT_FILE_ALLOW__READ__FROM__FILESYSTEM;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.util.Util.ERROR_BYTES_OR_STRING;
 import static apoc.util.Util.readHttpInputStream;
-import static org.eclipse.jetty.util.URIUtil.encodePath;
 
 /**
  * @author mh
@@ -174,13 +172,12 @@ public class FileUtils {
         return inputStreamFor(fileName, null, null, CompressionAlgo.NONE.name());
     }
 
-    public static String changeFileUrlIfImportDirectoryConstrained(String urlNotEncoded) throws IOException {
-        final String url = encodeExceptQM(urlNotEncoded);
+    public static String changeFileUrlIfImportDirectoryConstrained(String url) throws IOException {
         if (isFile(url) && isImportUsingNeo4jConfig()) {
             if (!apocConfig().getBoolean(APOC_IMPORT_FILE_ALLOW__READ__FROM__FILESYSTEM)) {
                 throw new RuntimeException(String.format(ERROR_READ_FROM_FS_NOT_ALLOWED, url));
             }
-            final Path resolvedPath = resolvePath(urlNotEncoded);
+            final Path resolvedPath = resolvePath(url);
             return resolvedPath
                     .normalize()
                     .toUri()
@@ -353,11 +350,6 @@ public class FileUtils {
         return Paths.get(URI.create(urlDir));
     }
 
-    // to exclude cases like 'testload.tar.gz?raw=true'
-    private static String encodeExceptQM(String url) {
-        return encodePath(url).replace("%3F", "?");
-    }
-    
     public static CountingInputStream getInputStreamFromBinary(byte[] urlOrBinary, String compressionAlgo) {
         return CompressionAlgo.valueOf(compressionAlgo).toInputStream(urlOrBinary);
     }


### PR DESCRIPTION
Issue 2269

Tested in Neo4j Browser.
`LoadS3Test` with minio doesn't work due to `Unable to calculate MD5 hash: src/test/resources/ma%25p.json (No such file or directory)` with `%` char.