### PR TITLE
Fixes 1064 and 1380 (cherry-picks): Add procedure to compare graphs

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,6 @@ dependencies {
     }
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
     testCompile 'org.mock-server:mockserver-netty:3.10.8'
     testCompile 'org.mock-server:mockserver-client-java:3.10.8'
@@ -99,7 +98,6 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
-    testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'

--- a/core/src/main/java/apoc/diff/Diff.java
+++ b/core/src/main/java/apoc/diff/Diff.java
@@ -50,7 +50,7 @@ public class Diff {
         return inCommon;
     }
 
-    private Map<String, Map<String, Object>> getPropertiesDiffering(Map<String, Object> left, Map<String, Object> right) {
+    public static Map<String, Map<String, Object>> getPropertiesDiffering(Map<String, Object> left, Map<String, Object> right) {
         Map<String, Map<String, Object>> different = new HashMap<>();
         Map<String, Object> keyPairs = new HashMap<>();
         keyPairs.putAll(left);

--- a/core/src/main/java/apoc/export/util/MapSubGraph.java
+++ b/core/src/main/java/apoc/export/util/MapSubGraph.java
@@ -1,0 +1,236 @@
+package apoc.export.util;
+
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.graphdb.schema.ConstraintType;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.graphdb.schema.IndexSetting;
+import org.neo4j.graphdb.schema.IndexType;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+
+public class MapSubGraph implements SubGraph {
+
+    public static class MapIndexDefinition implements IndexDefinition {
+        private final Label label;
+        private final Collection<Label> labels;
+        private final Collection<String> properties;
+        private final String type;
+
+        public MapIndexDefinition(Map<String, Object> map) {
+            Collection<String> labels = (Collection<String>) map.get("labels");
+            Collection<String> properties = (Collection<String>) map.get("properties");
+            String type = (String) map.get("type");
+            this.labels = labels.stream().map(Label::label).collect(Collectors.toList());
+            this.label = this.labels.iterator().next();
+            this.properties = properties;
+            this.type = type;
+        }
+        @Override
+        public Iterable<Label> getLabels() {
+            return labels;
+        }
+
+        @Override
+        public Iterable<RelationshipType> getRelationshipTypes() {
+            throw new UnsupportedOperationException("Method not implemented");
+        }
+
+        @Override
+        public Iterable<String> getPropertyKeys() {
+            return properties;
+        }
+
+        @Override
+        public IndexType getIndexType() {
+            return null;
+        }
+
+        @Override
+        public void drop() {}
+
+        @Override
+        public boolean isConstraintIndex() {
+            return false;
+        }
+
+        @Override
+        public boolean isNodeIndex() {
+            return true;
+        }
+
+        @Override
+        public boolean isRelationshipIndex() {
+            return false;
+        }
+
+        @Override
+        public boolean isMultiTokenIndex() {
+            return false;
+        }
+
+        @Override
+        public boolean isCompositeIndex() {
+            return properties.size() > 1;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public Map<IndexSetting, Object> getIndexConfiguration() {
+            return null;
+        }
+    }
+
+    public static class MapConstraintDefinition implements ConstraintDefinition {
+        private final Label label;
+        private final Collection<Label> labels;
+        private final Collection<String> properties;
+
+        public MapConstraintDefinition(Map<String, Object> map) {
+            Collection<String> labels = (Collection<String>) map.get("labels");
+            Collection<String> properties = (Collection<String>) map.get("properties");
+            this.labels = labels.stream().map(Label::label).collect(Collectors.toList());
+            this.label = this.labels.iterator().next();
+            this.properties = properties;
+        }
+
+
+        @Override
+        public Label getLabel() {
+            return label;
+        }
+
+        @Override
+        public RelationshipType getRelationshipType() {
+            throw new UnsupportedOperationException("Method not implemented");
+        }
+
+        @Override
+        public Iterable<String> getPropertyKeys() {
+            return properties;
+        }
+
+        @Override
+        public void drop() {}
+
+        @Override
+        public ConstraintType getConstraintType() {
+            return properties.size() == 1 ? ConstraintType.UNIQUENESS : ConstraintType.NODE_KEY;
+        }
+
+        @Override
+        public boolean isConstraintType(ConstraintType type) {
+            return getConstraintType().equals(type);
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+
+    private final Collection<Node> nodes;
+    private final Collection<Relationship> rels;
+    private final Set<String> labels;
+    private final Collection<IndexDefinition> indexes;
+    private final Collection<ConstraintDefinition> constraints;
+
+    public MapSubGraph(Map<String, Object> map) {
+        this.nodes = (Collection<Node>) map.getOrDefault("nodes", Collections.emptyList());
+        this.labels = this.nodes.stream()
+                .flatMap(node -> StreamSupport.stream(node.getLabels().spliterator(), true)
+                .map(Label::name))
+                .collect(Collectors.toSet());
+        Collection<Relationship> rels = (Collection<Relationship>) map.getOrDefault("relationships", Collections.emptyList());
+        this.rels = new HashSet<>(rels);
+        Collection<Map<String, Object>> schema = (Collection<Map<String, Object>>) map.getOrDefault("schema", Collections.emptyList());
+        this.indexes = schema.stream().map(MapIndexDefinition::new).collect(Collectors.toList());
+        this.constraints = schema.stream().map(MapConstraintDefinition::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public Iterable<Node> getNodes() {
+        return nodes;
+    }
+
+    @Override
+    public Iterable<Relationship> getRelationships() {
+        return rels;
+    }
+
+    @Override
+    public boolean contains(Relationship relationship) {
+        return rels.contains(relationship);
+    }
+
+    @Override
+    public Iterable<IndexDefinition> getIndexes() {
+        return indexes;
+    }
+
+    @Override
+    public Iterable<ConstraintDefinition> getConstraints() {
+        return constraints;
+    }
+
+    @Override
+    public Iterable<ConstraintDefinition> getConstraints(Label label) {
+        return null;
+    }
+
+    @Override
+    public Iterable<ConstraintDefinition> getConstraints(RelationshipType type) {
+        return null;
+    }
+
+    @Override
+    public Iterable<IndexDefinition> getIndexes(Label label) {
+        return null;
+    }
+
+    @Override
+    public Iterable<IndexDefinition> getIndexes(RelationshipType label) {
+        return null;
+    }
+
+    @Override
+    public Iterable<RelationshipType> getAllRelationshipTypesInUse() {
+        return null;
+    }
+
+    @Override
+    public Iterable<Label> getAllLabelsInUse() {
+        return null;
+    }
+
+    @Override
+    public Iterator<Node> findNodes(Label label) {
+        return null;
+    }
+
+    @Override
+    public long countsForRelationship(Label start, RelationshipType type, Label end) {
+        return 0;
+    }
+
+    @Override
+    public long countsForNode(Label label) {
+        return 0;
+    }
+}

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -105,7 +105,6 @@ dependencies {
     testCompile group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE'
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
     compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
@@ -119,7 +118,6 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
-    testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'

--- a/full/src/main/java/apoc/bolt/Bolt.java
+++ b/full/src/main/java/apoc/bolt/Bolt.java
@@ -1,6 +1,7 @@
 package apoc.bolt;
 
 import apoc.Extended;
+import apoc.meta.Meta;
 import apoc.result.RowResult;
 import apoc.result.VirtualNode;
 import apoc.result.VirtualRelationship;
@@ -35,7 +36,9 @@ import org.neo4j.procedure.Procedure;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -44,6 +47,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static apoc.util.MapUtil.map;
 
@@ -70,7 +74,7 @@ public class Bolt {
                         SummaryCounters counters = statementResult.consume().counters();
                         return Stream.of(new RowResult(toMap(counters)));
                     } else
-                        return getRowResultStream(boltConfig.isVirtual(), session, params, statement);
+                        return getRowResultStream(boltConfig, session, params, statement);
                 }));
     }
 
@@ -81,11 +85,6 @@ public class Bolt {
 
     private <T> Stream<T> withSession(Driver driver, SessionConfig sessionConfig, Function<Session, Stream<T>> function) {
         Session session = driver.session(sessionConfig);
-        return function.apply(session).onClose(() -> session.close());
-    }
-
-    private <T> Stream<T> withSession(Driver driver, Function<Session, Stream<T>> function) {
-        Session session = driver.session();
         return function.apply(session).onClose(() -> session.close());
     }
 
@@ -109,7 +108,7 @@ public class Bolt {
                         String withColumns = "WITH " + localResult.columns().stream()
                                 .map(c -> "$" + c + " AS " + c)
                                 .collect(Collectors.joining(", ")) + "\n";
-                        Map<Long, Object> nodesCache = new HashMap<>();
+                        Map<Long, VirtualNode> nodesCache = new HashMap<>();
                         List<RowResult> response = new ArrayList<>();
                         while (localResult.hasNext()) {
                             final Result statementResult;
@@ -127,7 +126,7 @@ public class Bolt {
                             } else {
                                 response.addAll(
                                         statementResult.stream()
-                                                .map(record -> buildRowResult(record, nodesCache, boltConfig.isVirtual()))
+                                                .flatMap(record -> buildRowResult(session, record, nodesCache, boltConfig))
                                                 .collect(Collectors.toList())
                                 );
                             }
@@ -145,59 +144,114 @@ public class Bolt {
         return load(url, statement, params, configuration);
     }
 
-    private RowResult buildRowResult(Record record, Map<Long,Object> nodesCache, boolean virtual) {
-        return new RowResult(record.asMap(value -> {
-            Object entity = value.asObject();
-            if (entity instanceof Node) return toNode(entity, virtual, nodesCache);
-            if (entity instanceof Relationship) return toRelationship(entity, virtual, nodesCache);
-            if (entity instanceof Path) return toPath(entity, virtual, nodesCache);
-            return entity;
-        }));
+    private Stream<RowResult> buildRowResult(Session session, Record record, Map<Long,VirtualNode> nodesCache, BoltConfig config) {
+        return withTransaction(session, tx -> Stream.of(buildRowResult(tx, record, nodesCache, config)));
     }
 
-    private Stream<RowResult> getRowResultStream(boolean virtual, Session session, Map<String, Object> params, String statement) {
-        Map<Long, Object> nodesCache = new HashMap<>();
+    private RowResult buildRowResult(Transaction tx, Record record, Map<Long,VirtualNode> nodesCache, BoltConfig config) {
+        return new RowResult(record.asMap(value -> convert(tx, value, config, nodesCache)));
+    }
+
+    private Object convert(Transaction tx, Object entity, BoltConfig config, Map<Long, VirtualNode> nodesCache) {
+        if (entity instanceof Value) return convert(tx, ((Value) entity).asObject(), config, nodesCache);
+        if (entity instanceof Node) return toNode(entity, config, nodesCache);
+        if (entity instanceof Relationship) return toRelationship(tx, entity, config, nodesCache);
+        if (entity instanceof Path) return toPath(tx, entity, config, nodesCache);
+        if (entity instanceof Collection) return toCollection(tx, (Collection) entity, config, nodesCache);
+        if (entity instanceof Map) return toMap(tx, (Map<String, Object>) entity, config, nodesCache);
+        return entity;
+    }
+
+    private Object toMap(Transaction tx, Map<String, Object> entity, BoltConfig config, Map<Long, VirtualNode> nodeCache) {
+        return entity.entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleEntry(entry.getKey(), convert(tx, entry.getValue(), config, nodeCache)))
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+    }
+
+    private Object toCollection(Transaction tx, Collection entity, BoltConfig config, Map<Long, VirtualNode> nodeCache) {
+        return entity.stream()
+                .map(elem -> convert(tx, elem, config, nodeCache))
+                .collect(Collectors.toList());
+    }
+
+    private Stream<RowResult> getRowResultStream(BoltConfig config, Session session, Map<String, Object> params, String statement) {
+        Map<Long, VirtualNode> nodesCache = new HashMap<>();
 
         return withTransaction(session, tx -> {
             ClosedAwareDelegatingIterator<Record> iterator = new ClosedAwareDelegatingIterator(tx.run(statement, params));
-            return Iterators.stream(iterator).map(record -> buildRowResult(record, nodesCache, virtual));
+            return Iterators.stream(iterator).map(record -> buildRowResult(tx, record, nodesCache, config));
         });
     }
 
-    private Object toNode(Object value, boolean virtual, Map<Long, Object> nodesCache) {
-        Value internalValue = ((InternalEntity) value).asValue();
-        Node node = internalValue.asNode();
-        if (virtual) {
-            List<Label> labels = new ArrayList<>();
-            node.labels().forEach(l -> labels.add(Label.label(l)));
-            VirtualNode virtualNode = new VirtualNode(node.id(), labels.toArray(new Label[0]), node.asMap());
+    private Object toNode(Object value, BoltConfig config, Map<Long, VirtualNode> nodesCache) {
+        Node node;
+        if (value instanceof Value) {
+            node = ((InternalEntity) value).asValue().asNode();
+        } else if (value instanceof Node) {
+            node = (Node) value;
+        } else {
+            throw getUnsupportedConversionException(value);
+        }
+        if (config.isVirtual()) {
+            VirtualNode virtualNode = new VirtualNode(node.id(), getLabelsAsArray(node), node.asMap());
             nodesCache.put(node.id(), virtualNode);
             return virtualNode;
         } else
-            return Util.map("entityType", internalValue.type().name(), "labels", node.labels(), "id", node.id(), "properties", node.asMap());
+            return Util.map("entityType", Meta.Types.NODE.name(), "labels", node.labels(), "id", node.id(), "properties", node.asMap());
     }
 
-    private Object toRelationship(Object value, boolean virtual, Map<Long, Object> nodesCache) {
-        Value internalValue = ((InternalEntity) value).asValue();
-        Relationship relationship = internalValue.asRelationship();
-        if (virtual) {
-            VirtualNode start = (VirtualNode) nodesCache.getOrDefault(relationship.startNodeId(), new VirtualNode(relationship.startNodeId()));
-            VirtualNode end = (VirtualNode) nodesCache.getOrDefault(relationship.endNodeId(), new VirtualNode(relationship.endNodeId()));
-            VirtualRelationship virtualRelationship = new VirtualRelationship(relationship.id(), start, end, RelationshipType.withName(relationship.type()), relationship.asMap());
-            return virtualRelationship;
+    private Object toRelationship(Transaction tx, Object value, BoltConfig config, Map<Long, VirtualNode> nodesCache) {
+        Relationship rel;
+        if (value instanceof Value) {
+            rel = ((InternalEntity) value).asValue().asRelationship();
+        } else if (value instanceof Relationship) {
+            rel = (Relationship) value;
+        } else {
+            throw getUnsupportedConversionException(value);
+        }
+        if (config.isVirtual()) {
+            VirtualNode start;
+            VirtualNode end;
+            final long startId = rel.startNodeId();
+            final long endId = rel.endNodeId();
+            if (config.isWithRelationshipNodeProperties()) {
+                final Function<Long, VirtualNode> retrieveNode = (id) -> {
+                    final Node node = tx.run("MATCH (n) WHERE id(n) = $id RETURN n", Map.of("id", id))
+                            .single()
+                            .get("n")
+                            .asNode();
+                    return new VirtualNode(node.id(), getLabelsAsArray(node), node.asMap());
+                };
+                start = nodesCache.computeIfAbsent(startId, retrieveNode);
+                end = nodesCache.computeIfAbsent(endId, retrieveNode);
+            } else {
+                start = nodesCache.getOrDefault(startId, new VirtualNode(startId));
+                end = nodesCache.getOrDefault(endId, new VirtualNode(endId));
+            }
+            return new VirtualRelationship(rel.id(), start, end, RelationshipType.withName(rel.type()), rel.asMap());
         } else
-            return Util.map("entityType", internalValue.type().name(), "type", relationship.type(), "id", relationship.id(), "start", relationship.startNodeId(), "end", relationship.endNodeId(), "properties", relationship.asMap());
+            return Util.map("entityType", Meta.Types.RELATIONSHIP.name(), "type", rel.type(), "id", rel.id(), "start", rel.startNodeId(), "end", rel.endNodeId(), "properties", rel.asMap());
     }
 
-    private Object toPath(Object value, boolean virtual, Map<Long, Object> nodesCache) {
+    private Object toPath(Transaction tx, Object value, BoltConfig config, Map<Long, VirtualNode> nodesCache) {
         List<Object> entityList = new LinkedList<>();
         Value internalValue = ((InternalPath) value).asValue();
         internalValue.asPath().forEach(p -> {
-            entityList.add(toNode(p.start(), virtual, nodesCache));
-            entityList.add(toRelationship(p.relationship(), virtual, nodesCache));
-            entityList.add(toNode(p.end(), virtual, nodesCache));
+            entityList.add(toNode(p.start(), config, nodesCache));
+            entityList.add(toRelationship(tx, p.relationship(), config, nodesCache));
+            entityList.add(toNode(p.end(), config, nodesCache));
         });
         return entityList;
+    }
+
+    private Label[] getLabelsAsArray(Node node) {
+        return StreamSupport.stream(node.labels().spliterator(), false)
+                .map(Label::label)
+                .toArray(Label[]::new);
+    }
+
+    private ClassCastException getUnsupportedConversionException(Object value) {
+        return new ClassCastException("Conversion from class " + value.getClass().getName() + " not supported");
     }
 
     private Map<String, Object> toMap(SummaryCounters resultSummary) {

--- a/full/src/main/java/apoc/bolt/BoltConfig.java
+++ b/full/src/main/java/apoc/bolt/BoltConfig.java
@@ -1,5 +1,6 @@
 package apoc.bolt;
 
+import apoc.util.Util;
 import org.neo4j.driver.AccessMode;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.SessionConfig;
@@ -20,6 +21,7 @@ public class BoltConfig {
     private final Map<String, Object> localParams;
     private final Map<String, Object> remoteParams;
     private final String databaseName;
+    private final boolean withRelationshipNodeProperties;
 
     public BoltConfig(Map<String, Object> config) {
         if (config == null) config = Collections.emptyMap();
@@ -31,6 +33,7 @@ public class BoltConfig {
         this.driverConfig = toDriverConfig((Map<String, Object>) config.getOrDefault("driverConfig", Collections.emptyMap()));
         this.localParams = (Map<String, Object>) config.getOrDefault("localParams", Collections.emptyMap());
         this.remoteParams = (Map<String, Object>) config.getOrDefault("remoteParams", Collections.emptyMap());
+        this.withRelationshipNodeProperties = Util.toBoolean(config.get("withRelationshipNodeProperties"));
     }
 
     private Config toDriverConfig(Map<String, Object> driverConfMap) {
@@ -97,8 +100,7 @@ public class BoltConfig {
     public boolean isAddStatistics() {
         return addStatistics;
     }
-
-
+    
     public boolean isStreamStatements() {
         return streamStatements;
     }
@@ -113,5 +115,13 @@ public class BoltConfig {
 
     public Map<String, Object> getRemoteParams() {
         return remoteParams;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public boolean isWithRelationshipNodeProperties() {
+        return withRelationshipNodeProperties;
     }
 }

--- a/full/src/main/java/apoc/cypher/CypherExtended.java
+++ b/full/src/main/java/apoc/cypher/CypherExtended.java
@@ -227,7 +227,7 @@ public class CypherExtended {
         return stmt.matches("(?is).*using\\s+periodic.*");
     }
 
-    private Map<String, Object> toMap(QueryStatistics stats, long time, long rows) {
+    public static Map<String, Object> toMap(QueryStatistics stats, long time, long rows) {
         return map(
                 "rows",rows,
                 "time",time,

--- a/full/src/main/java/apoc/diff/DiffConfig.java
+++ b/full/src/main/java/apoc/diff/DiffConfig.java
@@ -1,0 +1,46 @@
+package apoc.diff;
+
+import apoc.util.Util;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class DiffConfig {
+
+    private final boolean leftOnly;
+    private final boolean rightOnly;
+    private final boolean inCommon;
+    private final boolean different;
+    private final boolean findById;
+
+    public DiffConfig(Map<String, Object> config) {
+        if (config == null) {
+            config = Collections.emptyMap();
+        }
+        this.leftOnly = Util.toBoolean(config.getOrDefault("leftOnly", true));
+        this.rightOnly = Util.toBoolean(config.getOrDefault("rightOnly", true));
+        this.inCommon = Util.toBoolean(config.getOrDefault("inCommon", true));
+        this.different = Util.toBoolean(config.getOrDefault("different", true));
+        this.findById = Util.toBoolean(config.getOrDefault("findById", false));
+    }
+
+    public boolean isLeftOnly() {
+        return leftOnly;
+    }
+
+    public boolean isRightOnly() {
+        return rightOnly;
+    }
+
+    public boolean isInCommon() {
+        return inCommon;
+    }
+
+    public boolean isDifferent() {
+        return different;
+    }
+
+    public boolean isFindById() {
+        return findById;
+    }
+}

--- a/full/src/main/java/apoc/diff/DiffFull.java
+++ b/full/src/main/java/apoc/diff/DiffFull.java
@@ -1,0 +1,383 @@
+package apoc.diff;
+
+import apoc.Description;
+import apoc.export.util.FormatUtils;
+import apoc.export.util.MapSubGraph;
+import apoc.export.util.NodesAndRelsSubGraph;
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.cypher.export.CypherResultSubGraph;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.internal.helpers.collection.Iterables;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static apoc.diff.Diff.getPropertiesDiffering;
+import static apoc.util.Util.map;
+
+public class DiffFull {
+
+    public static final String NODE = "Node";
+    public static final String RELATIONSHIP = "Relationship";
+    public static final String DESTINATION_ENTITY_NOT_FOUND = "Destination Entity not found";
+    
+    @Context
+    public Transaction tx;
+
+    @Procedure("apoc.diff.graphs")
+    @Description("CALL apoc.diff.nodes(<source>, <dest>, <config>) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest - compares two graphs and returns the results")
+    public Stream<SourceDestResult> compare(@Name(value = "source") Object source,
+                                            @Name(value = "dest") Object dest,
+                                            @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
+        config = config == null ? Collections.emptyMap() : config;
+        SubGraph sourceGraph = toSubGraph(source, config, SourceDestConfig.fromMap((Map<String, Object>) config.get("source")));
+        SubGraph destGraph = toSubGraph(dest, config, SourceDestConfig.fromMap((Map<String, Object>) config.get("dest")));
+
+        Function<Map<String, Long>, Long> sum = (map) -> map.values().stream().reduce(0L, (x, y) -> x + y);
+        final SourceDestResult labelNodeCount = sourceDestCountByLabel(sourceGraph, destGraph);
+        final SourceDestResult nodeCount = labelNodeCount.areSourceAndDestEqual() ?
+                null : new SourceDestResult("Total count", NODE,
+                sum.apply((Map<String, Long>) labelNodeCount.source), sum.apply((Map<String, Long>) labelNodeCount.dest));
+        final SourceDestResult typeRelCount = sourceDestCountByType(sourceGraph, destGraph);
+        final SourceDestResult relCount = typeRelCount.areSourceAndDestEqual() ?
+                null : new SourceDestResult("Total count", RELATIONSHIP,
+                sum.apply((Map<String, Long>) typeRelCount.source), sum.apply((Map<String, Long>) typeRelCount.dest));
+
+        final Stream<SourceDestResult> generalStream = Stream.of(
+                nodeCount, nodeCount != null ? labelNodeCount : null,
+                relCount, relCount != null ? typeRelCount : null)
+                .filter(Objects::nonNull);
+        DiffConfig diffConfig = new DiffConfig(config);
+        final Stream<SourceDestResult> nodeStream = compareNodes(sourceGraph, destGraph, diffConfig);
+        final Stream<SourceDestResult> relStream = compareRels(sourceGraph, destGraph);
+        return Stream.of(generalStream, nodeStream, relStream)
+                .reduce(Stream::concat)
+                .orElse(Stream.empty());
+    }
+
+    public static class SourceDestResult {
+        public final String difference;
+        public final String entityType;
+        public final Long id;
+        public final String sourceLabel;
+        public final String destLabel;
+        public final Object source;
+        public final Object dest;
+
+        public SourceDestResult(String difference, String entityType, Long id, String sourceLabel,
+                                String destLabel, Object source, Object dest) {
+            this.difference = difference;
+            this.entityType = entityType;
+            this.id = id;
+            this.sourceLabel = sourceLabel;
+            this.destLabel = destLabel;
+            this.source = source;
+            this.dest = dest;
+        }
+
+        public SourceDestResult(String difference, String entityType, Object source, Object dest) {
+            this.difference = difference;
+            this.entityType = entityType;
+            this.id = null;
+            this.sourceLabel = null;
+            this.destLabel = null;
+            this.source = source;
+            this.dest = dest;
+        }
+
+        private boolean areSourceAndDestEqual() {
+            if (source == null && dest == null) return true;
+            if (source == null || dest == null) return false;
+            return source.equals(dest);
+        }
+    }
+
+    private SubGraph toSubGraph(Object input, Map<String, Object> config, SourceDestConfig sourceDestConfig) {
+        if (input == null) {
+            throw new NullPointerException("Input data is null");
+        }
+        if (input instanceof Map) {
+            Map<String, Object> graph = (Map<String, Object>) input;
+            if (graph.containsKey("schema")) {
+                return new MapSubGraph(graph);
+            } else {
+                Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
+                Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
+                return new NodesAndRelsSubGraph(tx, nodes, rels);
+            }
+        }
+        if (input instanceof String) {
+            final String inputString = (String) input;
+            if (sourceDestConfig != null) {
+                if (StringUtils.isNotBlank(sourceDestConfig.getTarget().getValue())) {
+                    switch (sourceDestConfig.getTarget().getType()) {
+                        case URL:
+                            final Map<String, List<Object>> graph = createMapFromRemoteDb(inputString,
+                                    sourceDestConfig.getTarget().getValue(),
+                                    sourceDestConfig.getParams());
+                            return toSubGraph(graph, config, null);
+                        default:
+                            throw new IllegalArgumentException("The following type is not supported: " + sourceDestConfig.getTarget().getType());
+                    }
+                } else {
+                    return toSubGraph(tx.execute(inputString, sourceDestConfig.getParams()), config, null);
+                }
+            }
+            return toSubGraph(tx.execute(inputString), config, null);
+        }
+        if (input instanceof Result) {
+            Result result = (Result) input;
+            return CypherResultSubGraph.from(tx, result, Util.toBoolean(config.getOrDefault("relsInBetween", false)));
+        }
+        if (input instanceof Path) {
+            Path path = (Path) input;
+            return new NodesAndRelsSubGraph(tx, Iterables.asCollection(path.nodes()),
+                    Iterables.asCollection(path.relationships()));
+        }
+        throw new IllegalArgumentException("Unsupported input type: " + input.getClass().getName());
+    }
+
+    private Map<String, List<Object>> createMapFromRemoteDb(String inputString, String url, Map<String, Object> params) {
+        params = params == null ? Collections.emptyMap() : params;
+        String boltLoadQuery = "CALL apoc.bolt.load($url, $boltQuery, $params, $boltConfig) YIELD row";
+        final Map<String, Object> boltConfig = map("virtual", true, "withRelationshipNodeProperties", true);
+
+        final Result execute = tx.execute(boltLoadQuery, map("boltConfig", boltConfig, "boltQuery", inputString, "url", url, "params", params));
+
+        final Map<String, List<Object>> graph = createBaseMapFromRemoteDb(execute);
+
+        final Optional<List<Object>> schemaOpt = retrieveSchemaFromRemoteDB(boltLoadQuery, boltConfig, url);
+        schemaOpt.ifPresent((schema) -> graph.put("schema", schema));
+        return graph;
+    }
+
+    private Optional<List<Object>> retrieveSchemaFromRemoteDB(String boltLoadQuery,
+                                                              Map<String, Object> boltConfig,
+                                                              String url) {
+        String boltQuery = "CALL db.indexes() YIELD labelsOrTypes, properties, state, uniqueness\n" +
+                "WHERE state = 'ONLINE' AND uniqueness = 'UNIQUE'\n" +
+                "RETURN collect({labels: labelsOrTypes, properties: properties, type: uniqueness}) AS schema\n";
+        return tx.execute(boltLoadQuery, map("boltConfig", boltConfig, "boltQuery", boltQuery, "url", url, "params", Collections.emptyMap()))
+                .stream()
+                .map(row -> (Map<String, Object>) row.get("row"))
+                .map(row -> (List<Object>) row.get("schema"))
+                .findFirst();
+    }
+
+    private Map<String, List<Object>> createBaseMapFromRemoteDb(Result execute) {
+        return execute.stream()
+                .map(row -> row.get("row"))
+                .map(this::extractGraphEntity)
+                .flatMap(elem -> elem instanceof Collection ? ((Collection<Object>) elem).stream() : Stream.of(elem))
+                .map(value -> {
+                    final String key;
+                    if (value instanceof Node) {
+                        key = "nodes";
+                    } else {
+                        key = "relationships";
+                    }
+                    return new AbstractMap.SimpleEntry<>(key, value);
+                })
+                .collect(Collectors.groupingBy(e -> e.getKey(), Collectors.mapping(e -> e.getValue(), Collectors.toList())));
+    }
+
+    private Object extractGraphEntity(Object input) {
+        if (input instanceof Collection) {
+            return ((Collection) input).stream()
+                    .flatMap(elem -> elem instanceof Collection ? ((Collection<Object>) elem).stream() : Stream.of(elem))
+                    .map(this::extractGraphEntity)
+                    .collect(Collectors.toList());
+        }
+        if (input instanceof Map) {
+            final Map<String, Object> map = (Map<String, Object>) input;
+            return extractGraphEntity(map.values());
+        }
+        if (input instanceof Node || input instanceof Relationship) {
+            return input;
+        }
+        throw new RuntimeException("Type not managed: " + input.getClass().getSimpleName());
+    }
+
+    private Map<String, Long> countByLabel(SubGraph graph) {
+        return StreamSupport.stream(graph.getNodes().spliterator(), false)
+                .flatMap(n -> StreamSupport.stream(n.getLabels().spliterator(), false)
+                        .map(Label::name))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    }
+
+    private Map<String, Long> countByType(SubGraph graph) {
+        return StreamSupport.stream(graph.getRelationships().spliterator(), false)
+                .map(r -> r.getType().name())
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    }
+
+    private SourceDestResult sourceDestCountByLabel(SubGraph source, SubGraph dest) {
+        return new SourceDestResult("Count by Label", NODE, countByLabel(source), countByLabel(dest));
+    }
+
+    private SourceDestResult sourceDestCountByType(SubGraph source, SubGraph dest) {
+        return new SourceDestResult("Count by Type", RELATIONSHIP, countByType(source), countByType(dest));
+    }
+
+    private <T extends Entity> T findEntityById(Iterable<T> it, long id) {
+        return StreamSupport.stream(it.spliterator(), true)
+                .filter(entity -> entity.getId() == id)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private Node findNode(Iterable<Node> it, Node node, SubGraph graph, DiffConfig config) {
+        ConstraintDefinition constraintDefinition = getConstraint(node, graph);
+        if (constraintDefinition == null) {
+            return config.isFindById() ? findEntityById(it, node.getId()) : null;
+        }
+        Map<String, Object> keys = getNodeKeys(node, constraintDefinition);
+        return StreamSupport.stream(it.spliterator(), true)
+                .filter(entity -> entity.getProperties(Iterables.asArray(String.class, keys.keySet())).equals(keys))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private ConstraintDefinition getConstraint(Node node, SubGraph graph) {
+        ConstraintDefinition constraintDefinition = null;
+        for (Label label : node.getLabels()) {
+            for (ConstraintDefinition constr : graph.getConstraints()) {
+                if (!constr.getLabel().name().equals(label.name())) continue;
+                final long count = Iterables.count(constr.getPropertyKeys());
+                if (constraintDefinition == null || Iterables.count(constraintDefinition.getPropertyKeys()) > count) {
+                    constraintDefinition = constr;
+                    if (count == 1) {
+                        break;
+                    }
+                }
+            }
+        }
+        return constraintDefinition;
+    }
+
+    private SourceDestDTO sourceDestMap(Object sourceVal, Object destVal) {
+        return new SourceDestDTO(sourceVal, destVal);
+    }
+
+    private SourceDestDTO transformDiff(Map<String, Map<String, Object>> propDiffs) {
+        Map<String, Object> sourceFields = new HashMap<>();
+        Map<String, Object> destFields = new HashMap<>();
+        propDiffs.forEach((prop, diff) -> {
+            sourceFields.put(prop, diff.get("left"));
+            destFields.put(prop, diff.get("right"));
+        });
+        return sourceDestMap(sourceFields, destFields);
+    }
+
+    private class SourceDestDTO {
+        private final Object source;
+        private final Object dest;
+        SourceDestDTO(Object source, Object dest) {
+            this.source = source;
+            this.dest = dest;
+        }
+    }
+
+    private Stream<SourceDestResult> compareRels(SubGraph sourceGraph, SubGraph destGraph) {
+        return StreamSupport.stream(sourceGraph.getRelationships().spliterator(), true)
+                .map(sourceRel -> {
+                    final Map<String, Object> startKeys = getNodeKeys(sourceRel.getStartNode(), sourceGraph);
+                    final Map<String, Object> endKeys = getNodeKeys(sourceRel.getEndNode(), sourceGraph);
+                    final Map<String, Object> sourceRelAllProperties = sourceRel.getAllProperties();
+                    final Relationship destRel = StreamSupport.stream(destGraph.getRelationships().spliterator(), true)
+                            .filter(elem -> {
+                                final Map<String, Object> startDestKeys = getNodeKeys(elem.getStartNode(), destGraph);
+                                final Map<String, Object> endDestKeys = getNodeKeys(elem.getEndNode(), destGraph);
+                                boolean areKeysEqual = startKeys.equals(startDestKeys) && endKeys.equals(endDestKeys);
+                                if (!sourceRelAllProperties.isEmpty()) {
+                                    return areKeysEqual && sourceRelAllProperties.equals(elem.getAllProperties());
+                                } else {
+                                    return areKeysEqual;
+                                }
+                            })
+                            .findFirst()
+                            .orElse(null);
+                    return destRel == null ? new SourceDestResult(DESTINATION_ENTITY_NOT_FOUND,
+                            RELATIONSHIP, sourceRel.getId(), sourceRel.getType().name(), null,
+                            Util.map("start", startKeys, "end", endKeys, "properties", sourceRelAllProperties), null) : null;
+                })
+                .filter(Objects::nonNull);
+    }
+
+    private Map<String, Object> getNodeKeys(Node node, ConstraintDefinition constraint) {
+        if (constraint == null) return null;
+        String[] propKeys = Iterables.asList(constraint.getPropertyKeys()).toArray(new String[0]);
+        return node.getProperties(propKeys);
+    }
+
+    private Map<String, Object> getNodeKeys(Node node, SubGraph subGraph) {
+        ConstraintDefinition constraint = getConstraint(node, subGraph);
+        return getNodeKeys(node, constraint);
+    }
+
+    private Stream<SourceDestResult> compareNodes(SubGraph source, SubGraph dest, DiffConfig config) {
+        return StreamSupport.stream(source.getNodes().spliterator(), true)
+                .map(node -> new AbstractMap.SimpleEntry<>(node, findNode(dest.getNodes(), node, dest, config)))
+                .flatMap(entry -> {
+                    List<SourceDestResult> diffs = new ArrayList<>();
+                    final Node sourceNode = entry.getKey();
+                    final Node destNode = entry.getValue();
+
+                    final String sourceLabel = getFirstLabel(sourceNode);
+                    final long id = sourceNode.getId();
+
+                    if (destNode == null) {
+                        final Map<String, Object> nodeKeys = getNodeKeys(sourceNode, getConstraint(sourceNode, source));
+                        diffs.add(new SourceDestResult(DESTINATION_ENTITY_NOT_FOUND, NODE, id, sourceLabel, null, nodeKeys, null));
+                    } else {
+                        final String destLabel = getFirstLabel(destNode);
+                        List<String> sourceLabels = FormatUtils.getLabelsSorted(sourceNode);
+                        List<String> destLabels = FormatUtils.getLabelsSorted(destNode);
+                        if (!sourceLabels.equals(destLabels)) {
+                            diffs.add(new SourceDestResult("Different Labels", NODE, id, sourceLabel, destLabel, sourceLabels, destLabels));
+                        } else {
+                            final Map<String, Map<String, Object>> propDiff = getPropertiesDiffering(sourceNode.getAllProperties(),
+                                    destNode.getAllProperties());
+                            if (!propDiff.isEmpty()) {
+                                final SourceDestDTO sourceDestDTO = transformDiff(propDiff);
+                                diffs.add(new SourceDestResult("Different Properties", NODE, id, sourceLabel, destLabel, sourceDestDTO.source, sourceDestDTO.dest));
+                            } else { // if the two nodes are equal lets compare the relationships
+                                return diffs.stream();
+                            }
+                        }
+                    }
+                    return diffs.stream();
+                });
+    }
+
+    private String getFirstLabel(Node sourceNode) {
+        return StreamSupport.stream(sourceNode.getLabels().spliterator(), false)
+                .map(Label::name)
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/full/src/main/java/apoc/diff/SourceDestConfig.java
+++ b/full/src/main/java/apoc/diff/SourceDestConfig.java
@@ -1,0 +1,56 @@
+package apoc.diff;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class SourceDestConfig {
+    public enum SourceDestConfigType { URL, DATABASE }
+
+    static class TargetConfig {
+        private final SourceDestConfigType type;
+        private final String value;
+
+        public TargetConfig(SourceDestConfigType type, String value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        public SourceDestConfigType getType() {
+            return type;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    private final Map<String, Object> params;
+    private final TargetConfig target;
+
+    public SourceDestConfig(SourceDestConfigType type, String value, Map<String, Object> params) {
+        this.target = new TargetConfig(type, value);
+        this.params = params;
+    }
+
+    public TargetConfig getTarget() {
+        return target;
+    }
+
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    public static SourceDestConfig fromMap(Map<String, Object> map) {
+        map = map == null ? Collections.emptyMap() : map;
+        if (map.isEmpty()) {
+            return null;
+        } else {
+            Map<String, Object> target = (Map<String, Object>) map.getOrDefault("target", Collections.emptyMap());
+            SourceDestConfigType type = SourceDestConfigType
+                    .valueOf((String) target.getOrDefault("type", SourceDestConfigType.URL.toString()));
+            return new SourceDestConfig(type,
+                    (String) target.get("value"),
+                    (Map<String, Object>) map.getOrDefault("params", Collections.emptyMap()));
+        }
+    }
+}

--- a/full/src/test/java/apoc/bolt/BoltTest.java
+++ b/full/src/test/java/apoc/bolt/BoltTest.java
@@ -9,7 +9,9 @@ import apoc.util.Util;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -19,14 +21,20 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import static apoc.util.TestUtil.isRunningInCI;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.Util.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
@@ -40,7 +48,8 @@ import static org.neo4j.driver.Values.point;
 public class BoltTest {
 
     @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.auth_enabled, true);
 
     private static Neo4jContainerExtension neo4jContainer;
     private static String BOLT_URL;
@@ -58,6 +67,8 @@ public class BoltTest {
         assumeNotNull(neo4jContainer);
         assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
         BOLT_URL = "'" + "bolt://neo4j:neo4j2020@" + neo4jContainer.getContainerIpAddress() + ":" + neo4jContainer.getMappedPort(7687) + "'";
+        neo4jContainer = createEnterpriseDB(true);
+        neo4jContainer.start();
 
         TestUtil.registerProcedure(db, Bolt.class, ExportCypher.class, Cypher.class);
     }
@@ -81,6 +92,26 @@ public class BoltTest {
                 assertEquals(true, node.getProperty("state"));
                 assertEquals(54L, node.getProperty("age"));
             });
+    }
+
+    @Test
+    public void shouldReturnMapOfCollection() throws Exception {
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'MATCH (p:Person {name: $name}) RETURN {nodes: collect(p)} AS map', $params, $config)",
+                map(/*"url", BOLT_URL,*/
+                        "params", map("name", "Tom"),
+                        "config", map("virtual", true)),
+                r -> {
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    Map<String, Collection<Node>> map = (Map<String, Collection<Node>>) row.get("map");
+                    Collection<Node> nodes = map.get("nodes");
+                    assertEquals(2, nodes.size());
+                    Set<Map<String, Object>> expected = new HashSet<>(Arrays.asList(map("name", "Tom", "surname", "Loagan"), map("name", "Tom", "surname", "Burton")));
+                    Set<Map<String, Object>> actual = nodes.stream()
+                            .map(n -> n.getProperties("name", "surname"))
+                            .collect(Collectors.toSet());
+                    assertEquals(expected, actual);
+                });
     }
 
     @Test
@@ -145,6 +176,61 @@ public class BoltTest {
                 assertEquals(2016L, rel.getProperty("since"));
                 assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("time"));
             });
+    }
+
+    @Test
+    public void testLoadRelWithNodeProperties() {
+        // given
+        String query = "MATCH (:Person{name: 'John', surname: 'Green'})-[r]->(:Person{name: 'Jim', surname: 'Brown'}) RETURN r";
+
+        // when
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",$query, null, $config)",
+                map("query", query, "config", map("virtual", true, "withRelationshipNodeProperties", true)),
+                r -> {
+                    // then
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    final Relationship rel = (Relationship) row.get("r");
+                    assertEquals("KNOWS", rel.getType().name());
+                    final Map<String, Object> expectedRel = map("born", point(4979, 56.7, 12.78, 100.0).asPoint(), "since", OffsetTime.parse("12:50:35.556+01:00"));
+                    assertEquals(expectedRel, rel.getAllProperties());
+                    final Node start = rel.getStartNode();
+                    final Map<String, Object> expectedStartNode = map("name", "John", "surname", "Green", "born", point(7203, 2.3, 4.5).asPoint());
+                    assertEquals(expectedStartNode, start.getAllProperties());
+                    final Node end = rel.getEndNode();
+                    final Map<String, Object> expectedEndNode = map("name", "Jim", "surname", "Brown");
+                    assertEquals(expectedEndNode, end.getAllProperties());
+                });
+    }
+
+    @Test
+    public void testLoadFromLocalRelWithNodeProperties() {
+        db.executeTransactionally("create (:LocalNode {name: 'John', surname: 'Green'})");
+        
+        // given
+        String localStatement = "MATCH (local:LocalNode) RETURN local.name as name";
+        String remoteStatement = "MATCH (:Person{name: name, surname: 'Green'})-[r]->(:Person{name: 'Jim', surname: 'Brown'}) RETURN r";
+
+        // when
+        TestUtil.testCall(db, "call apoc.bolt.load.fromLocal($url, $localStatement, $remoteStatement, $config)",
+                map("url", neo4jContainer.getBoltUrl(), "localStatement", localStatement, "remoteStatement", remoteStatement, "config", map("virtual", true, "withRelationshipNodeProperties", true)),
+                r -> {
+                    // then
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    final Relationship rel = (Relationship) row.get("r");
+                    assertEquals("KNOWS", rel.getType().name());
+                    final Map<String, Object> expectedRel = map("born", point(4979, 56.7, 12.78, 100.0).asPoint(), "since", OffsetTime.parse("12:50:35.556+01:00"));
+                    assertEquals(expectedRel, rel.getAllProperties());
+                    final Node start = rel.getStartNode();
+                    final Map<String, Object> expectedStartNode = map("name", "John", "surname", "Green", "born", point(7203, 2.3, 4.5).asPoint());
+                    assertEquals(expectedStartNode, start.getAllProperties());
+                    final Node end = rel.getEndNode();
+                    final Map<String, Object> expectedEndNode = map("name", "Jim", "surname", "Brown");
+                    assertEquals(expectedEndNode, end.getAllProperties());
+                });
+
+        db.executeTransactionally("match (n:LocalNode) delete n");
     }
 
     @Test

--- a/full/src/test/java/apoc/diff/DiffFullTest.java
+++ b/full/src/test/java/apoc/diff/DiffFullTest.java
@@ -1,0 +1,313 @@
+package apoc.diff;
+
+import apoc.bolt.Bolt;
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.time.OffsetTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
+import static apoc.ApocConfig.apocConfig;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestUtil.isRunningInCI;
+import static apoc.util.Util.map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+public class DiffFullTest {
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    private static Neo4jContainerExtension neo4jContainer;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        assumeFalse(isRunningInCI());
+//        TestUtil.ignoreException(() -> {
+            neo4jContainer = createEnterpriseDB(true)
+                    .withInitScript("init_neo4j_diff.cypher")
+                    .withLogging()
+                    .withoutAuthentication();
+            neo4jContainer.start();
+//        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
+
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
+        TestUtil.registerProcedure(db, Bolt.class, DiffFull.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (neo4jContainer != null && neo4jContainer.isRunning()) {
+            neo4jContainer.close();
+        }
+    }
+
+    @Before
+    public void before() throws Exception {
+        try (Scanner scanner = new Scanner(Thread
+                .currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream("init_neo4j_diff.cypher"))
+                .useDelimiter(";")) {
+            while (scanner.hasNext()) {
+                String statement = scanner.next().trim();
+                if (statement.isEmpty()) {
+                    continue;
+                }
+                db.executeTransactionally(statement);
+            }
+        }
+    }
+
+    @After
+    public void after() {
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+    }
+    
+    @Test
+    public void shouldCompareTwoEqualGraphsByQuery() {
+        // when
+        final String query = "MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m";
+        final String boltQuery = "CALL db.indexes() YIELD labelsOrTypes, properties, state, uniqueness\n" +
+                "WHERE state = 'ONLINE' AND uniqueness = 'UNIQUE'\n" +
+                "WITH collect({labels: labelsOrTypes, properties: properties, type: uniqueness}) AS schema\n" +
+                "MATCH (n)\n" +
+                "OPTIONAL MATCH (n)-[r]->(m)\n" +
+                "WITH collect(n) + collect(m) AS nodes, collect(r) AS relationships, schema\n" +
+                "UNWIND nodes AS node\n" +
+                "RETURN {nodes: collect(DISTINCT node), relationships: relationships, schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    assertFalse(r.hasNext()); // the two graphs are equal
+                });
+    }
+
+
+    @Test
+    public void shouldCompareTwoDifferentGraphsByQuery() {
+        // when
+        final String query = "MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m";
+        final String boltQuery = "CALL db.indexes() YIELD labelsOrTypes, properties, state, uniqueness\n" +
+                "WHERE state = 'ONLINE' AND uniqueness = 'UNIQUE'\n" +
+                "WITH collect({labels: labelsOrTypes, properties: properties, type: uniqueness}) AS schema\n" +
+                "MATCH (n:Person{name: 'Michael Jordan'})\n" +
+                "OPTIONAL MATCH (n)-[r]->(m)\n" +
+                "WITH collect(n) + collect(m) AS nodes, collect(r) AS relationships, schema\n" +
+                "UNWIND nodes AS node\n" +
+                "RETURN {nodes: collect(DISTINCT node), relationships: relationships, schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    final List<Map<String, Object>> expectedRows = List.of(
+                            map("entityType", "Node", "sourceLabel", null, "difference", "Total count", "id", null, "source", 3L, "dest", 1L, "destLabel", null),
+                            map("entityType", "Node", "sourceLabel", null, "difference", "Count by Label", "id", null, "source", map("Person", 3L), "dest", map("Person", 1L), "destLabel", null),
+                            map("entityType", "Relationship", "sourceLabel", null, "difference", "Total count", "id", null, "source", 1L, "dest", 0L, "destLabel", null),
+                            map("entityType", "Relationship", "sourceLabel", null, "difference", "Count by Type", "id", null, "source", map("KNOWS", 1L), "dest", map(), "destLabel", null),
+                            map("entityType", "Node", "sourceLabel", "Person", "difference", "Destination Entity not found", "id", 20L, "source", map("name", "Tom Burton"), "dest", null, "destLabel", null),
+                            map("entityType", "Node", "sourceLabel", "Person", "difference", "Destination Entity not found", "id", 21L, "source", map("name", "John William"), "dest", null, "destLabel", null),
+                            map("entityType", "Relationship", "sourceLabel", "KNOWS", "difference", "Destination Entity not found", "id", 0L, "source", map("start", map("name", "Tom Burton"),
+                                    "end", map("name", "John William"),
+                                    "properties", map("time", OffsetTime.parse("12:50:35.556+01:00"), "since", 2016L)
+                            ), "dest", null, "destLabel", null)
+                    );
+                    final List<Map<String, Object>> actuals = r.stream().collect(Collectors.toList());
+                    assertEquals(actuals.size(), expectedRows.size());
+
+                    IntStream.range(0, actuals.size()).forEach(index -> {
+                        final Map<String, Object> actual = actuals.get(index);
+                        getMapAssertions(expectedRows.get(index), actual);
+                    });
+                });
+    }
+
+    @Test
+    public void shouldCompareTwoDifferentNodesByQuery() {
+        db.executeTransactionally("MERGE (n:Person{name: 'Michael Jordan'}) ON MATCH SET n.age = 55");
+
+        // when
+        final String query = "MATCH (n:Person{name: 'Michael Jordan'}) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m";
+        final String boltQuery = "CALL db.indexes() YIELD labelsOrTypes, properties, state, uniqueness\n" +
+                "WHERE state = 'ONLINE' AND uniqueness = 'UNIQUE'\n" +
+                "WITH collect({labels: labelsOrTypes, properties: properties, type: uniqueness}) AS schema\n" +
+                "MATCH (n:Person{name: 'Michael Jordan'})\n" +
+                "OPTIONAL MATCH (n)-[r]->(m)\n" +
+                "WITH collect(n) + collect(m) AS nodes, collect(r) AS relationships, schema\n" +
+                "UNWIND nodes AS node\n" +
+                "RETURN {nodes: collect(DISTINCT node), relationships: relationships, schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    final Map<String, Object> expected = map("entityType", "Node", "sourceLabel", "Person", "difference", "Different Properties", "id", 0L, "source", map("age", 55L), "dest", map("age", 54L), "destLabel", "Person");
+                    assertTrue(r.hasNext()); // the two nodes have different properties
+                    getMapAssertions(expected, r.next());
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void shouldCompareTwoDifferentPathsByQuery() {
+        db.executeTransactionally("MATCH ()-[r:KNOWS]-() SET r.since = 2000");
+
+        // when
+        final String query = "MATCH p = ()-[:KNOWS]->() RETURN p";
+        final String boltQuery = "CALL db.indexes() YIELD labelsOrTypes, properties, state, uniqueness\n" +
+                "WHERE state = 'ONLINE' AND uniqueness = 'UNIQUE'\n" +
+                "WITH collect({labels: labelsOrTypes, properties: properties, type: uniqueness}) AS schema\n" +
+                "MATCH p = ()-[:KNOWS]->()\n" +
+                "RETURN {nodes: nodes(p), relationships: relationships(p), schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    final Map<String, Object> expected = map("entityType", "Relationship", "sourceLabel", "KNOWS", "difference", "Destination Entity not found", "id", 0L, "source", map(
+                            "start", map("name", "Tom Burton"),
+                            "end", map("name", "John William"),
+                            "properties", map("time", OffsetTime.parse("12:50:35.556+01:00"), "since", 2000L)
+                    ), "dest", null, "destLabel", null);
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    final Map<String, Object> next = r.next();
+                    getMapAssertions(expected, next);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void shouldCompareTwoDifferentPathsByBoltQueryUrl() {
+        db.executeTransactionally("MATCH ()-[r:KNOWS]-() SET r.since = 2000");
+
+        // when
+        final String localQuery = "MATCH p = ()-[:KNOWS]->() RETURN p";
+        final String remoteQuery = "MATCH p = ()-[:KNOWS]->() RETURN p";
+        TestUtil.testResult(db, "CALL apoc.diff.graphs($localQuery, $remoteQuery, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("localQuery", localQuery, "remoteQuery", remoteQuery,
+                        "diffConfig", Collections.singletonMap("dest", map("target", Collections.singletonMap("value", neo4jContainer.getBoltUrl())))),
+                (r) -> {
+                    // then
+                    final Map<String, Object> expected = map("entityType", "Relationship", "sourceLabel", "KNOWS", "difference", "Destination Entity not found", "id", 0L, "source", map(
+                            "start", map("name", "Tom Burton"),
+                            "end", map("name", "John William"),
+                            "properties", map("time", OffsetTime.parse("12:50:35.556+01:00"), "since", 2000L)
+                    ), "dest", null, "destLabel", null);
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    final Map<String, Object> next = r.next();
+                    getMapAssertions(expected, next);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void shouldInjectQueryParams() {
+        db.executeTransactionally("MATCH ()-[r:KNOWS]-() SET r.since = 2000");
+
+        // when
+        final String localQuery = "MATCH p = (n:Person{name: $name})-[:KNOWS]->() RETURN p";
+        final String remoteQuery = "MATCH p = (n:Person{name: $name})-[:KNOWS]->() RETURN p";
+        TestUtil.testResult(db, "CALL apoc.diff.graphs($localQuery, $remoteQuery, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("localQuery", localQuery, "remoteQuery", remoteQuery,
+                        "diffConfig", map("dest", map("target", Collections.singletonMap("value", neo4jContainer.getBoltUrl()),
+                                "params", map("name", "Tom Burton")),
+                                "source", map("params", map("name", "John William")))),
+                (r) -> {
+                    // then
+
+                    /*
+                    +-----------------------------------------------------------------------------------------------+
+                    | difference       | entityType     | id     | sourceLabel | destLabel | source | dest          |
+                    +-----------------------------------------------------------------------------------------------+
+                    | "Count by Label" | "Node"         | <null> | <null>      | <null>    | {}     | {Person -> 2} |
+                    | "Total count"    | "Relationship" | <null> | <null>      | <null>    | 0      | 1             |
+                    | "Count by Type"  | "Relationship" | <null> | <null>      | <null>    | {}     | {KNOWS -> 1}  |
+                    +-----------------------------------------------------------------------------------------------+
+                    3 rows
+                     */
+
+                    Map<String, Object> expected = map("entityType", "Node", "sourceLabel", null, "difference", "Total count", "id", null,
+                            "source", 0L, "dest", 2L, "destLabel", null);
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    Map<String, Object> next = r.next();
+                    getMapAssertions(expected, next);
+
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    expected = map("entityType", "Node", "sourceLabel", null, "difference", "Count by Label", "id", null,
+                            "source", Collections.emptyMap(), "dest", Collections.singletonMap("Person", 2L), "destLabel", null);
+                    next = r.next();
+                    getMapAssertions(expected, next);
+
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    expected = map("entityType", "Relationship", "sourceLabel", null, "difference", "Total count", "id", null,
+                            "source", 0L, "dest", 1L, "destLabel", null);
+                    next = r.next();
+                    getMapAssertions(expected, next);
+
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    expected = map("entityType", "Relationship", "sourceLabel", null, "difference", "Count by Type", "id", null,
+                            "source", Collections.emptyMap(), "dest", Collections.singletonMap("KNOWS", 1L), "destLabel", null);
+                    next = r.next();
+                    getMapAssertions(expected, next);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    private void getMapAssertions(Map<String, Object> expected, Map<String, Object> next) {
+        expected.forEach((k, v) -> {
+            if (k.equals("id")) {
+                assertTrue(v == null 
+                        ? next.get(k) == null 
+                        : next.get(k) instanceof Long);
+            } else {
+                assertEquals(v, next.get(k));
+            }
+        });
+    }
+}

--- a/full/src/test/resources/init_neo4j_diff.cypher
+++ b/full/src/test/resources/init_neo4j_diff.cypher
@@ -1,0 +1,5 @@
+CREATE CONSTRAINT IF NOT EXISTS FOR (p:Person) REQUIRE p.name IS UNIQUE;
+CREATE (m:Person {name: 'Michael Jordan', age: 54});
+CREATE (q:Person {name: 'Tom Burton', age: 23})
+CREATE (p:Person {name: 'John William', age: 22})
+CREATE (q)-[:KNOWS{since:2016, time:time('125035.556+0100')}]->(p);

--- a/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
+++ b/test-utils/src/main/java/apoc/util/Neo4jContainerExtension.java
@@ -4,7 +4,10 @@ import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.internal.summary.InternalSummaryCounters;
+import org.neo4j.driver.summary.SummaryCounters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Neo4jContainer;
@@ -17,6 +20,8 @@ import org.testcontainers.ext.ScriptUtils;
 
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Scanner;
 
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -87,19 +92,45 @@ public class Neo4jContainerExtension extends Neo4jContainer<Neo4jContainerExtens
             throw new ScriptUtils.ScriptLoadException("Could not load classpath init script: " + filePath + ". Resource not found.");
         }
 
+        List<SummaryCounters> counters = new ArrayList<>();
         try (Scanner scanner = new Scanner(resource).useDelimiter(";")) {
             while (scanner.hasNext()) {
                 String statement = scanner.next().trim();
                 if (statement.isEmpty()) {
                     continue;
                 }
-                session.writeTransaction(tx -> {
-                    tx.run(statement);
-                    tx.commit();
-                    return null;
-                });
+                counters.add(session.writeTransaction(tx -> tx.run(statement).consume().counters()));
             }
         }
+        if (counters.isEmpty()) return;
+
+        SummaryCounters sum = counters.stream().reduce(InternalSummaryCounters.EMPTY_STATS, (x, y) ->
+                new InternalSummaryCounters(x.nodesCreated() + y.nodesCreated(),
+                        x.nodesDeleted() + y.nodesDeleted(),
+                        x.relationshipsCreated() + y.relationshipsCreated(),
+                        x.relationshipsDeleted() + y.relationshipsDeleted(),
+                        x.propertiesSet() + y.propertiesSet(),
+                        x.labelsAdded() + y.labelsAdded(),
+                        x.labelsRemoved() + y.labelsRemoved(),
+                        x.indexesAdded() + y.indexesAdded(),
+                        x.indexesRemoved() + y.indexesRemoved(),
+                        x.constraintsAdded() + y.constraintsAdded(),
+                        x.constraintsRemoved() + y.constraintsRemoved(),
+                        x.systemUpdates() + y.systemUpdates())
+        );
+        logger().info("Dataset creation report:\n" +
+                "\tnodesCreated: " + sum.nodesCreated() + "\n" +
+                "\tnodesDeleted: " + sum.nodesDeleted() + "\n" +
+                "\trelationshipsCreated: " + sum.relationshipsCreated() + "\n" +
+                "\trelationshipsDeleted: " + sum.relationshipsDeleted() + "\n" +
+                "\tpropertiesSet: " + sum.propertiesSet() + "\n" +
+                "\tlabelsAdded: " + sum.labelsAdded() + "\n" +
+                "\tlabelsRemoved: " + sum.labelsRemoved() + "\n" +
+                "\tindexesAdded: " + sum.indexesAdded() + "\n" +
+                "\tindexesRemoved: " + sum.indexesRemoved() + "\n" +
+                "\tconstraintsAdded: " + sum.constraintsAdded() + "\n" +
+                "\tconstraintsRemoved: " + sum.constraintsRemoved() + "\n" +
+                "\tsystemUpdates: " + sum.systemUpdates());
     }
 
     public Session getSession() {


### PR DESCRIPTION
Cherry-pick fixes 1380 (`build.gradle` files)

Cherry pick 1064  
- added a `DiffFull` because of Bolt located in `full`
- `SourceDestConfig.java` invariated
- In Bolt.java changed `toMap(Session session..` , `toCollection(Session session... ` etc to `toMap(Transaction tx..` , `toCollection(Transaction tx... `
- Added `systemUpdates` in Neo4jContainerExtension`