### PR TITLE
Issue 2269: Removed eclipse jetty dep

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective
-    testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.2.22.v20170606'
     testCompile group: 'org.apache.derby', name: 'derby', version: '10.12.1.1'
 
     testCompile group: 'org.neo4j', name: 'neo4j-common', version: neo4jVersionEffective, classifier: "tests"

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -7,7 +7,6 @@ import apoc.util.hdfs.HDFSUtils;
 import apoc.util.s3.S3URLConnection;
 import apoc.util.s3.S3UploadUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.configuration.GraphDatabaseSettings;
 
@@ -32,7 +31,6 @@ import static apoc.ApocConfig.APOC_IMPORT_FILE_ALLOW__READ__FROM__FILESYSTEM;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.util.Util.ERROR_BYTES_OR_STRING;
 import static apoc.util.Util.readHttpInputStream;
-import static org.eclipse.jetty.util.URIUtil.encodePath;
 
 /**
  * @author mh
@@ -174,13 +172,12 @@ public class FileUtils {
         return inputStreamFor(fileName, null, null, CompressionAlgo.NONE.name());
     }
 
-    public static String changeFileUrlIfImportDirectoryConstrained(String urlNotEncoded) throws IOException {
-        final String url = encodeExceptQM(urlNotEncoded);
+    public static String changeFileUrlIfImportDirectoryConstrained(String url) throws IOException {
         if (isFile(url) && isImportUsingNeo4jConfig()) {
             if (!apocConfig().getBoolean(APOC_IMPORT_FILE_ALLOW__READ__FROM__FILESYSTEM)) {
                 throw new RuntimeException(String.format(ERROR_READ_FROM_FS_NOT_ALLOWED, url));
             }
-            final Path resolvedPath = resolvePath(urlNotEncoded);
+            final Path resolvedPath = resolvePath(url);
             return resolvedPath
                     .normalize()
                     .toUri()
@@ -353,11 +350,6 @@ public class FileUtils {
         return Paths.get(URI.create(urlDir));
     }
 
-    // to exclude cases like 'testload.tar.gz?raw=true'
-    private static String encodeExceptQM(String url) {
-        return encodePath(url).replace("%3F", "?");
-    }
-    
     public static CountingInputStream getInputStreamFromBinary(byte[] urlOrBinary, String compressionAlgo) {
         return CompressionAlgo.valueOf(compressionAlgo).toInputStream(urlOrBinary);
     }

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -97,7 +97,6 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.formatProperties
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatToString;
 import static apoc.util.DateFormatUtil.getOrCreate;
 import static java.lang.String.format;
-import static org.eclipse.jetty.util.URIUtil.encodePath;
 
 /**
  * @author mh
@@ -937,7 +936,7 @@ public class Util {
 
     public static Map<String, Object> extractCredentialsIfNeeded(String url, boolean failOnError) {
         try {
-            URI uri = new URI(encodePath(url));
+            URI uri = new URI(url);
             String authInfo = uri.getUserInfo();
             if (null != authInfo) {
                 String[] parts = authInfo.split(":");

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -83,7 +83,6 @@ dependencies {
 
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective
-    testCompile group: 'org.eclipse.jetty', name: 'jetty-server', version: '9.2.22.v20170606'
     testCompile group: 'org.apache.derby', name: 'derby', version: '10.12.1.1'
 
     testCompile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'


### PR DESCRIPTION
Waiting for `issue_2269`.

Instead of cherry-pick the `d15a08b5449f6840eb31101e43ff46ae26402e8a` commit 
we can reemove the eclipse jetty dependency and leverage on java API.