### PR TITLE
Issue 2608:  XML DOCTYPE is disallowed when the feature set to true

### DIFF
--- a/core/src/main/java/apoc/load/Xml.java
+++ b/core/src/main/java/apoc/load/Xml.java
@@ -31,6 +31,7 @@ import org.xml.sax.InputSource;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -65,6 +66,8 @@ import java.util.stream.Stream;
 import static apoc.util.CompressionConfig.COMPRESSION;
 import static apoc.util.FileUtils.getInputStreamFromBinary;
 import static apoc.util.Util.ERROR_BYTES_OR_STRING;
+import static org.apache.xerces.impl.Constants.DISALLOW_DOCTYPE_DECL_FEATURE;
+import static org.apache.xerces.impl.Constants.XERCES_FEATURE_PREFIX;
 
 public class Xml {
 
@@ -93,17 +96,19 @@ public class Xml {
     public Map<String, Object> parse(@Name("data") String data, @Name(value = "path", defaultValue = "/") String path, @Name(value = "config",defaultValue = "{}") Map<String, Object> config, @Name(value = "simple", defaultValue = "false") boolean simpleMode) throws Exception {
         if (config == null) config = Collections.emptyMap();
         boolean failOnError = (boolean) config.getOrDefault("failOnError", true);
-        return parse(new ByteArrayInputStream(data.getBytes(Charset.forName("UTF-8"))), simpleMode, path, failOnError)
+        Map<String, Boolean> features = (Map<String, Boolean>) config.getOrDefault("features", Map.of(XERCES_FEATURE_PREFIX + DISALLOW_DOCTYPE_DECL_FEATURE, true));
+        return parse(new ByteArrayInputStream(data.getBytes(Charset.forName("UTF-8"))), simpleMode, path, failOnError, features)
                 .map(mr -> mr.value).findFirst().orElse(null);
     }
 
     private Stream<MapResult> xmlXpathToMapResult(@Name("urlOrBinary") Object urlOrBinary, boolean simpleMode, String path, Map<String, Object> config) throws Exception {
         if (config == null) config = Collections.emptyMap();
         boolean failOnError = (boolean) config.getOrDefault("failOnError", true);
+        Map<String, Boolean> features = (Map<String, Boolean>) config.getOrDefault("features", Map.of(XERCES_FEATURE_PREFIX + DISALLOW_DOCTYPE_DECL_FEATURE, true));
         try {
             Map<String, Object> headers = (Map) config.getOrDefault("headers", Collections.emptyMap());
             CountingInputStream is = FileUtils.inputStreamFor(urlOrBinary, headers, null, (String) config.getOrDefault(COMPRESSION, CompressionAlgo.NONE.name()));
-            return parse(is, simpleMode, path, failOnError);
+            return parse(is, simpleMode, path, failOnError, features);
         } catch (Exception e){
             if(!failOnError)
                 return Stream.of(new MapResult(Collections.emptyMap()));
@@ -112,13 +117,19 @@ public class Xml {
         }
     }
 
-    private Stream<MapResult> parse(InputStream data, boolean simpleMode, String path, boolean failOnError) throws Exception {
+    private Stream<MapResult> parse(InputStream data, boolean simpleMode, String path, boolean failOnError, Map<String, Boolean> features) throws Exception {
         List<MapResult> result = new ArrayList<>();
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);
             documentBuilderFactory.setIgnoringElementContentWhitespace(true);
-            documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            features.forEach((k,v) -> {
+                try {
+                    documentBuilderFactory.setFeature(k, v);
+                } catch (ParserConfigurationException e) {
+                    throw new RuntimeException(e);
+                }
+            });
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
             documentBuilder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
 

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -18,6 +18,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import org.xml.sax.SAXParseException;
 
 import java.io.File;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
@@ -438,5 +439,19 @@ public class XmlTest {
             assertEquals("DOCTYPE is disallowed when the feature \"http://apache.org/xml/features/disallow-doctype-decl\" set to true.", except.getMessage());
             throw e;
         }
+    }
+    
+    @Test
+    public void testIssue2608() {
+        final String url = getUrlFileName("xml/issue2608.xml").toString();
+        testCall(db, "CALL apoc.load.xml($url, '/', $config)", 
+                map("url", url, "config", 
+                        map("features", map("http://apache.org/xml/features/disallow-doctype-decl", false, 
+                                "http://xml.org/sax/features/use-entity-resolver2", true))),
+                (row) -> {
+                    final Map<String, Object> expected = map("_type", "PubmedArticleSet", 
+                            "_children", List.of(map("_type", "PubmedArticle", "_text", "Article 1")));
+                    assertEquals(expected, row.get("value"));
+                });
     }
 }

--- a/core/src/test/resources/xml/issue2608.xml
+++ b/core/src/test/resources/xml/issue2608.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+<PubmedArticleSet>
+    <PubmedArticle>
+        Article 1
+    </PubmedArticle>
+</PubmedArticleSet>

--- a/docs/asciidoc/modules/ROOT/pages/import/xml.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/xml.adoc
@@ -69,6 +69,7 @@ This function supports the following config parameter:
 |===
 | name | type | default | description
 | failOnError | boolean | true | fail if error encountered while parsing XML
+| features | Map<String, Boolean> | {`http://apache.org/xml/features/disallow-doctype-decl`: false} | to set additional parser features. See link:https://xerces.apache.org/xerces2-j/features.html[here].
 |===
 
 .The following parses an XML string into a Cypher map
@@ -83,6 +84,36 @@ RETURN apoc.xml.parse(xmlString) AS value
 |===
 | value
 | {_type: "table", _children: [{_type: "tr", _children: [{_type: "td", _children: [{_type: "img", src: "pix/logo-tl.gif"}]}]}]}
+|===
+
+
+.The following parses an XML string using a custom parser feature.
+[source,cypher]
+----
+WITH '<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+<PubmedArticleSet> <PubmedArticle>Article 1</PubmedArticle></PubmedArticleSet>' AS xmlString
+RETURN apoc.xml.parse(xmlString, '/', 
+  {features: {`http://apache.org/xml/features/disallow-doctype-decl`: false}}) AS value
+----
+
+.Results
+[options="header"]
+|===
+| value
+|
+[source,json]
+----
+{
+  "_children": [
+    {
+      "_type": "PubmedArticle",
+      "_text": "Article 1"
+    }
+  ],
+  "_type": "PubmedArticleSet"
+}
+----
 |===
 
 [[load-xml-available-procedures-apoc.import.xml]]

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.xml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.xml.adoc
@@ -417,3 +417,52 @@ RETURN value
 }
 ----
 |===
+
+== Parser Features
+
+You can set custom parser features, putting in the 3rd parameter a map with key "features" and
+value a Map<String, Boolean>.
+By default, the config is set with {`http://apache.org/xml/features/disallow-doctype-dec`: true}. 
+A list of possible features is link:https://xerces.apache.org/xerces2-j/features.html[here]
+
+For example, with the following xml
+.fileWithDatatype.graphml
+[source,xml]
+----
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE PubmedArticleSet PUBLIC "-//NLM//DTD PubMedArticle, 1st January 2019//EN" "https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd">
+<PubmedArticleSet>
+    <PubmedArticle>
+        Article 1
+    </PubmedArticle>
+</PubmedArticleSet>
+----
+
+you can do:
+
+[source,cypher]
+----
+CALL apoc.load.xml("fileWithDatatype.xml", "/", 
+  {features: {`http://apache.org/xml/features/disallow-doctype-decl`: false}})
+----
+
+.Results
+[opts="header"]
+|===
+| value
+|
+[source,json]
+----
+{
+  "_children": [
+    {
+      "_type": "PubmedArticle",
+      "_text": "Article 1"
+    }
+  ],
+  "_type": "PubmedArticleSet"
+}
+----
+|===
+
+


### PR DESCRIPTION
Issue 2608.

Added a config map `features`, where we can set  [these config](https://xerces.apache.org/xerces2-j/features.html).

todo - maybe waiting for https://github.com/vga91/neo4j-apoc-procedures/pull/113/files to add features into `LoadXmlConfig.java`