### PR TITLE
Issue 2612: Confusing behavior with map as a custom functions

### DIFF
--- a/core/src/main/java/apoc/SystemPropertyKeys.java
+++ b/core/src/main/java/apoc/SystemPropertyKeys.java
@@ -13,6 +13,7 @@ public enum SystemPropertyKeys  {
     outputs,
     output,
     forceSingle,
+    config,
     prefix,
 
     // triggers

--- a/full/src/main/java/apoc/custom/CustomCypherConfig.java
+++ b/full/src/main/java/apoc/custom/CustomCypherConfig.java
@@ -1,0 +1,22 @@
+package apoc.custom;
+
+import apoc.util.Util;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CustomCypherConfig {
+    public static final CustomCypherConfig EMPTY = new CustomCypherConfig(null);
+    public static final String WRAP_MAP = "wrapMap";
+    
+    private final boolean wrapMap;
+    
+    public CustomCypherConfig(Map<String, Object> config) {
+        if (config == null) config = Collections.emptyMap();
+        this.wrapMap = Util.toBoolean(config.getOrDefault(WRAP_MAP, true));
+    }
+
+    public boolean isWrapMap() {
+        return wrapMap;
+    }
+}

--- a/full/src/main/java/apoc/custom/CypherProcedures.java
+++ b/full/src/main/java/apoc/custom/CypherProcedures.java
@@ -103,20 +103,22 @@ public class CypherProcedures {
                            @Name(value = "description", defaultValue = "") String description) throws ProcedureException {
         UserFunctionSignature signature = cypherProceduresHandler.functionSignature(name, output, inputs, description);
         validateFunction(statement, signature.inputSignature());
-        cypherProceduresHandler.storeFunction(signature, statement, forceSingle);
+        cypherProceduresHandler.storeFunction(signature, statement, forceSingle, CustomCypherConfig.EMPTY);
     }
 
     @Procedure(value = "apoc.custom.declareFunction", mode = Mode.WRITE)
     @Description("apoc.custom.declareFunction(signature, statement, forceSingle, description) - register a custom cypher function")
     public void declareFunction(@Name("signature") String signature, @Name("statement") String statement,
                            @Name(value = "forceSingle", defaultValue = "false") boolean forceSingle,
-                           @Name(value = "description", defaultValue = "") String description) throws ProcedureException {
+                           @Name(value = "description", defaultValue = "") String description, 
+                            @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws ProcedureException {
+        CustomCypherConfig conf = new CustomCypherConfig(config);
         UserFunctionSignature userFunctionSignature = new Signatures(PREFIX).asFunctionSignature(signature, description);
         validateFunction(statement, userFunctionSignature.inputSignature());
-        if (!cypherProceduresHandler.registerFunction(userFunctionSignature, statement, forceSingle)) {
+        if (!cypherProceduresHandler.registerFunction(userFunctionSignature, statement, forceSingle, conf)) {
             throw new IllegalStateException("Error registering function " + signature + ", see log.");
         }
-        cypherProceduresHandler.storeFunction(userFunctionSignature, statement, forceSingle);
+        cypherProceduresHandler.storeFunction(userFunctionSignature, statement, forceSingle, conf);
     }
 
 
@@ -135,7 +137,7 @@ public class CypherProcedures {
                         procedureDescriptor.getStatement(),
                         convertInputSignature(signature.inputSignature()),
                         Iterables.asList(Iterables.map(f -> Arrays.asList(f.name(), prettyPrintType(f.neo4jType())), signature.outputSignature())),
-                        null);
+                        null, null);
             } else {
                 CypherProceduresHandler.UserFunctionDescriptor userFunctionDescriptor = (CypherProceduresHandler.UserFunctionDescriptor) descriptor;
                 UserFunctionSignature signature = userFunctionDescriptor.getSignature();
@@ -147,7 +149,8 @@ public class CypherProcedures {
                         userFunctionDescriptor.getStatement(),
                         convertInputSignature(signature.inputSignature()),
                         prettyPrintType(signature.outputType()),
-                        userFunctionDescriptor.isForceSingle());
+                        userFunctionDescriptor.isForceSingle(),
+                        userFunctionDescriptor.getConfig());
             }
         });
     }
@@ -251,10 +254,11 @@ public class CypherProcedures {
         public List<List<String>>inputs;
         public Object outputs;
         public Boolean forceSingle;
+        public Map<String, Object> config;
 
         public CustomProcedureInfo(String type, String name, String description, String mode,
                                    String statement, List<List<String>> inputs, Object outputs,
-                                   Boolean forceSingle){
+                                   Boolean forceSingle, Map<String, Object> config) {
             this.type = type;
             this.name = name;
             this.description = description;
@@ -263,6 +267,7 @@ public class CypherProcedures {
             this.inputs = inputs;
             this.forceSingle = forceSingle;
             this.mode = mode;
+            this.config = config;
         }
     }
 

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -3,7 +3,6 @@ package apoc.custom;
 import apoc.ApocConfig;
 import apoc.SystemLabels;
 import apoc.SystemPropertyKeys;
-import apoc.meta.Meta;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -185,7 +184,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 false), statement);
     }
 
-    private UserFunctionDescriptor userFunctionDescriptor(Node node) { // todo
+    private UserFunctionDescriptor userFunctionDescriptor(Node node) {
         String statement = (String) node.getProperty(SystemPropertyKeys.statement.name());
 
         String name = (String) node.getProperty(SystemPropertyKeys.name.name());
@@ -259,7 +258,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.config.name(), JsonUtil.writeValueAsString(conf));
 
             setLastUpdate(tx);
-            registerFunction(signature, statement, forceSingle, conf); // todo..
+            registerFunction(signature, statement, forceSingle, conf);
             return null;
         });
     }
@@ -360,10 +359,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                         resourceTracker.registerCloseableResource(result);
 
                         List<FieldSignature> outputs = signature.outputSignature();
-//                        String[] names = outputs == null ? null : outputs.stream().map(FieldSignature::name).toArray(String[]::new);
+                        String[] names = outputs == null ? null : outputs.stream().map(FieldSignature::name).toArray(String[]::new);
                         boolean defaultOutputs = outputs == null || outputs.equals(DEFAULT_MAP_OUTPUT);
 
-                        Stream<AnyValue[]> stream = result.stream().map(row -> toResult(row, outputs, defaultOutputs));
+                        Stream<AnyValue[]> stream = result.stream().map(row -> toResult(row, names, defaultOutputs));
                         return Iterators.asRawIterator(stream);
                     }
                 }
@@ -379,56 +378,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             return false;
         }
     }
-    
-//    private AnyValue returnFunction(AnyType outType, Result result, boolean forceSingle, CustomCypherConfig conf) {
-//        if (!result.hasNext()) return null;
-//        if (outType.equals(NTAny)) {
-//            return ValueUtils.of(result.stream().collect(Collectors.toList()));
-//        }
-//        List<String> cols = result.columns();
-//        if (cols.isEmpty()) return null;
-//        if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
-//            Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
-//            Neo4jTypes.AnyType innerType = listType.innerType();
-//            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-//            if (conf.isWrapMap() && innerType.getClass().equals(Neo4jTypes.MapType.class))
-//                return ValueUtils.of(result.stream().collect(Collectors.toList()));
-//            if (cols.size() == 1)
-//                return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
-////                return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
-//        } else {
-//            Map<String, Object> row = result.next();
-//            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-//            if (conf.isWrapMap() && outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
-//            if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
-//        }
-//        throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
-//    }
-    
-    private Object returnFunction(AnyType outType, Result result, boolean forceSingle, CustomCypherConfig conf) {
-        if (!result.hasNext()) return null;
-        if (outType.equals(NTAny)) {
-            return result.stream().collect(Collectors.toList());
-        }
-        List<String> cols = result.columns();
-        if (cols.isEmpty()) return null;
-        if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
-            Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
-            Neo4jTypes.AnyType innerType = listType.innerType();
-            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-            if (conf.isWrapMap() && innerType.getClass().equals(Neo4jTypes.MapType.class))
-                return result.stream().collect(Collectors.toList());
-            if (cols.size() == 1)
-                return result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList());
-//                return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
-        } else {
-            Map<String, Object> row = result.next();
-            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-            if (conf.isWrapMap() && outType.getClass().equals(Neo4jTypes.MapType.class)) return row;
-            if (cols.size() == 1) return row.get(cols.get(0));
-        }
-        throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
-    }
 
     public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle, CustomCypherConfig conf) {
         try {
@@ -440,15 +389,36 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                         final String error = String.format("Unknown function '%s'", signature.name());
                         throw new QueryExecutionException(error, null, "Neo.ClientError.Statement.SyntaxError");
                     } else {
+                        // TODO - it might be worthwhile to create a validation of the type of output as well, 
+                        //  to avoid situations such as 'CALL apoc.custom.declareFunction('funWithMap(map :: MAP) :: STRING' , 'RETURN {a: 1}' )'
+                        //  but in this way will be introduced a breaking-change (see: registerSimpleStatementFunction(), which would fail). Perhaps validation could be configured?
                         Map<String, Object> params = params(input, signature.inputSignature(), ctx.valueMapper());
                         AnyType outType = signature.outputType();
 
                         Transaction tx = transactionComponentFunction.apply(ctx);
                         try (Result result = tx.execute(statement, params)) {
 //                resourceTracker.registerCloseableResource(result); // TODO
-                            final Object anyValue = returnFunction(outType, result, forceSingle, conf);
-                            validateOutputType(outType, anyValue);
-                            return ValueUtils.of(anyValue);
+                            if (!result.hasNext()) return null;
+                            if (outType.equals(NTAny)) {
+                                return ValueUtils.of(result.stream().collect(Collectors.toList()));
+                            }
+                            List<String> cols = result.columns();
+                            if (cols.isEmpty()) return null;
+                            if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
+                                Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
+                                Neo4jTypes.AnyType innerType = listType.innerType();
+                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
+                                if (conf.isWrapMap() && innerType.getClass().equals(Neo4jTypes.MapType.class))
+                                    return ValueUtils.of(result.stream().collect(Collectors.toList()));
+                                if (cols.size() == 1)
+                                    return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
+                            } else {
+                                Map<String, Object> row = result.next();
+                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
+                                if (conf.isWrapMap() && outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
+                                if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
+                            }
+                            throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
                         }
                     }
 
@@ -599,29 +569,15 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
-    private AnyValue[] toResult(Map<String, Object> row, List<FieldSignature> outputs, boolean defaultOutputs) {
+    private AnyValue[] toResult(Map<String, Object> row, String[] names, boolean defaultOutputs) {
         if (defaultOutputs) {
             return new AnyValue[]{convertToValueRecursive(row)};
         } else {
-            AnyValue[] result = new AnyValue[outputs.size()];
-//            AnyValue[] result = new AnyValue[names.length];
-//            for (int i = 0; i < names.length; i++) {
-            IntStream.range(0, outputs.size()).forEach(i -> {
-                final FieldSignature fieldSignature = outputs.get(i);
-                final AnyType anyType = fieldSignature.neo4jType();
-                final Object o = row.get(fieldSignature.name());
-                final AnyValue anyValue = convertToValueRecursive(o);
-                validateOutputType(anyType, o);
-                result[i] = anyValue;
-            });
+            AnyValue[] result = new AnyValue[names.length];
+            for (int i = 0; i < names.length; i++) {
+                result[i] = convertToValueRecursive(row.get(names[i]));
+            }
             return result;
-        }
-    }
-
-    private void validateOutputType(AnyType anyType, Object anyValue) {
-        if (anyValue != null && !Meta.Types.of(anyValue).toString().toUpperCase().equals(anyType.toString().replace("?", ""))) {
-            throw new RuntimeException(String.format("Error, the output query type (%s) is different from the type set in the procedure (%s)", 
-                    ));
         }
     }
 

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -5,6 +5,7 @@ import apoc.SystemLabels;
 import apoc.SystemPropertyKeys;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.function.ThrowingFunction;
 import org.neo4j.graphdb.Entity;
@@ -58,7 +59,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.ApocConfig.apocConfig;
-import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.AnyType;
@@ -183,7 +183,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 false), statement);
     }
 
-    private UserFunctionDescriptor userFunctionDescriptor(Node node) {
+    private UserFunctionDescriptor userFunctionDescriptor(Node node) { // todo
         String statement = (String) node.getProperty(SystemPropertyKeys.statement.name());
 
         String name = (String) node.getProperty(SystemPropertyKeys.name.name());
@@ -194,16 +194,21 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         List<FieldSignature> inputs = deserializeSignatures(property);
 
         boolean forceSingle = (boolean) node.getProperty(SystemPropertyKeys.forceSingle.name(), false);
-        return new UserFunctionDescriptor(new UserFunctionSignature(
-                new QualifiedName(prefix, name),
-                inputs,
-                typeof((String) node.getProperty(SystemPropertyKeys.output.name())),
-                null,
-                new String[0],
-                description,
-                "apoc.custom",
-                false
-        ), statement, forceSingle);
+        try {
+            Map<String, Object> map = JsonUtil.OBJECT_MAPPER.readValue((String) node.getProperty(SystemPropertyKeys.config.name(), "{}") , Map.class);
+            return new UserFunctionDescriptor(new UserFunctionSignature(
+                    new QualifiedName(prefix, name),
+                    inputs,
+                    typeof((String) node.getProperty(SystemPropertyKeys.output.name())),
+                    null,
+                    new String[0],
+                    description,
+                    "apoc.custom",
+                    false
+            ), statement, forceSingle, map);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public void restoreProceduresAndFunctions() {
@@ -224,7 +229,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
         // de-register removed procs/functions
         currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));
-        currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false));
+        currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false, CustomCypherConfig.EMPTY));
 
         api.executeTransactionally("call db.clearQueryCaches()");
     }
@@ -237,7 +242,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
-    public void storeFunction(UserFunctionSignature signature, String statement, boolean forceSingle) {
+    public void storeFunction(UserFunctionSignature signature, String statement, boolean forceSingle, CustomCypherConfig conf) {
         withSystemDb(tx -> {
             Node node = Util.mergeNode(tx, SystemLabels.ApocCypherProcedures, SystemLabels.Function,
                     Pair.of(SystemPropertyKeys.database.name(), api.databaseName()),
@@ -249,9 +254,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));
             node.setProperty(SystemPropertyKeys.output.name(), signature.outputType().toString());
             node.setProperty(SystemPropertyKeys.forceSingle.name(), forceSingle);
+            node.setProperty(SystemPropertyKeys.config.name(), JsonUtil.writeValueAsString(conf));
 
             setLastUpdate(tx);
-            registerFunction(signature, statement, forceSingle);
+            registerFunction(signature, statement, forceSingle, conf); // todo..
             return null;
         });
     }
@@ -372,7 +378,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
-    public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle) {
+    public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle, CustomCypherConfig conf) {
         try {
             final boolean isStatementNull = statement == null;
             globalProceduresRegistry.register(new CallableUserFunction.BasicUserFunction(signature) {
@@ -398,14 +404,14 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                                 Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
                                 Neo4jTypes.AnyType innerType = listType.innerType();
                                 // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (innerType.getClass().equals(Neo4jTypes.MapType.class))
+                                if (conf.isWrapMap() && innerType.getClass().equals(Neo4jTypes.MapType.class))
                                     return ValueUtils.of(result.stream().collect(Collectors.toList()));
                                 if (cols.size() == 1)
                                     return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
                             } else {
                                 Map<String, Object> row = result.next();
                                 // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
+                                if (conf.isWrapMap() && outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
                                 if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
                             }
                             throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
@@ -637,7 +643,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     SystemPropertyKeys.prefix.name(), qName.namespace()
             ).stream().filter(n -> n.hasLabel(SystemLabels.Function)).forEach(node -> {
                 UserFunctionDescriptor descriptor = userFunctionDescriptor(node);
-                registerFunction(descriptor.getSignature(), null, false);
+                registerFunction(descriptor.getSignature(), null, false, CustomCypherConfig.EMPTY);
                 node.delete();
                 setLastUpdate(tx);
             });
@@ -681,11 +687,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     public class UserFunctionDescriptor extends ProcedureOrFunctionDescriptor {
         private final UserFunctionSignature signature;
         private final boolean forceSingle;
+        private final Map<String, Object> config;
 
-        public UserFunctionDescriptor(UserFunctionSignature signature, String statement, boolean forceSingle) {
+        public UserFunctionDescriptor(UserFunctionSignature signature, String statement, boolean forceSingle, Map<String, Object> config) {
             super(statement);
             this.signature = signature;
             this.forceSingle = forceSingle;
+            this.config = config;
         }
 
         public UserFunctionSignature getSignature() {
@@ -696,9 +704,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             return forceSingle;
         }
 
+        public Map<String, Object> getConfig() {
+            return config;
+        }
+
         @Override
         public void register() {
-            registerFunction(getSignature(), getStatement(), isForceSingle());
+            registerFunction(getSignature(), getStatement(), isForceSingle(), new CustomCypherConfig(getConfig()));
         }
     }
 }

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -3,6 +3,7 @@ package apoc.custom;
 import apoc.ApocConfig;
 import apoc.SystemLabels;
 import apoc.SystemPropertyKeys;
+import apoc.meta.Meta;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -56,6 +57,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static apoc.ApocConfig.apocConfig;
@@ -358,10 +360,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                         resourceTracker.registerCloseableResource(result);
 
                         List<FieldSignature> outputs = signature.outputSignature();
-                        String[] names = outputs == null ? null : outputs.stream().map(FieldSignature::name).toArray(String[]::new);
+//                        String[] names = outputs == null ? null : outputs.stream().map(FieldSignature::name).toArray(String[]::new);
                         boolean defaultOutputs = outputs == null || outputs.equals(DEFAULT_MAP_OUTPUT);
 
-                        Stream<AnyValue[]> stream = result.stream().map(row -> toResult(row, names, defaultOutputs));
+                        Stream<AnyValue[]> stream = result.stream().map(row -> toResult(row, outputs, defaultOutputs));
                         return Iterators.asRawIterator(stream);
                     }
                 }
@@ -376,6 +378,56 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             log.error("Could not register procedure: " + signature.name() + " with " + statement + "\n accepting" + signature.inputSignature() + " resulting in " + signature.outputSignature() + " mode " + signature.mode(), e);
             return false;
         }
+    }
+    
+//    private AnyValue returnFunction(AnyType outType, Result result, boolean forceSingle, CustomCypherConfig conf) {
+//        if (!result.hasNext()) return null;
+//        if (outType.equals(NTAny)) {
+//            return ValueUtils.of(result.stream().collect(Collectors.toList()));
+//        }
+//        List<String> cols = result.columns();
+//        if (cols.isEmpty()) return null;
+//        if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
+//            Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
+//            Neo4jTypes.AnyType innerType = listType.innerType();
+//            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
+//            if (conf.isWrapMap() && innerType.getClass().equals(Neo4jTypes.MapType.class))
+//                return ValueUtils.of(result.stream().collect(Collectors.toList()));
+//            if (cols.size() == 1)
+//                return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
+////                return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
+//        } else {
+//            Map<String, Object> row = result.next();
+//            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
+//            if (conf.isWrapMap() && outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
+//            if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
+//        }
+//        throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
+//    }
+    
+    private Object returnFunction(AnyType outType, Result result, boolean forceSingle, CustomCypherConfig conf) {
+        if (!result.hasNext()) return null;
+        if (outType.equals(NTAny)) {
+            return result.stream().collect(Collectors.toList());
+        }
+        List<String> cols = result.columns();
+        if (cols.isEmpty()) return null;
+        if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
+            Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
+            Neo4jTypes.AnyType innerType = listType.innerType();
+            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
+            if (conf.isWrapMap() && innerType.getClass().equals(Neo4jTypes.MapType.class))
+                return result.stream().collect(Collectors.toList());
+            if (cols.size() == 1)
+                return result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList());
+//                return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
+        } else {
+            Map<String, Object> row = result.next();
+            // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
+            if (conf.isWrapMap() && outType.getClass().equals(Neo4jTypes.MapType.class)) return row;
+            if (cols.size() == 1) return row.get(cols.get(0));
+        }
+        throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
     }
 
     public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle, CustomCypherConfig conf) {
@@ -394,27 +446,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                         Transaction tx = transactionComponentFunction.apply(ctx);
                         try (Result result = tx.execute(statement, params)) {
 //                resourceTracker.registerCloseableResource(result); // TODO
-                            if (!result.hasNext()) return null;
-                            if (outType.equals(NTAny)) {
-                                return ValueUtils.of(result.stream().collect(Collectors.toList()));
-                            }
-                            List<String> cols = result.columns();
-                            if (cols.isEmpty()) return null;
-                            if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
-                                Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
-                                Neo4jTypes.AnyType innerType = listType.innerType();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (conf.isWrapMap() && innerType.getClass().equals(Neo4jTypes.MapType.class))
-                                    return ValueUtils.of(result.stream().collect(Collectors.toList()));
-                                if (cols.size() == 1)
-                                    return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
-                            } else {
-                                Map<String, Object> row = result.next();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (conf.isWrapMap() && outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
-                                if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
-                            }
-                            throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
+                            final Object anyValue = returnFunction(outType, result, forceSingle, conf);
+                            validateOutputType(outType, anyValue);
+                            return ValueUtils.of(anyValue);
                         }
                     }
 
@@ -565,15 +599,29 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
-    private AnyValue[] toResult(Map<String, Object> row, String[] names, boolean defaultOutputs) {
+    private AnyValue[] toResult(Map<String, Object> row, List<FieldSignature> outputs, boolean defaultOutputs) {
         if (defaultOutputs) {
             return new AnyValue[]{convertToValueRecursive(row)};
         } else {
-            AnyValue[] result = new AnyValue[names.length];
-            for (int i = 0; i < names.length; i++) {
-                result[i] = convertToValueRecursive(row.get(names[i]));
-            }
+            AnyValue[] result = new AnyValue[outputs.size()];
+//            AnyValue[] result = new AnyValue[names.length];
+//            for (int i = 0; i < names.length; i++) {
+            IntStream.range(0, outputs.size()).forEach(i -> {
+                final FieldSignature fieldSignature = outputs.get(i);
+                final AnyType anyType = fieldSignature.neo4jType();
+                final Object o = row.get(fieldSignature.name());
+                final AnyValue anyValue = convertToValueRecursive(o);
+                validateOutputType(anyType, o);
+                result[i] = anyValue;
+            });
             return result;
+        }
+    }
+
+    private void validateOutputType(AnyType anyType, Object anyValue) {
+        if (anyValue != null && !Meta.Types.of(anyValue).toString().toUpperCase().equals(anyType.toString().replace("?", ""))) {
+            throw new RuntimeException(String.format("Error, the output query type (%s) is different from the type set in the procedure (%s)", 
+                    ));
         }
     }
 

--- a/full/src/main/java/apoc/systemdb/metadata/ExportFunction.java
+++ b/full/src/main/java/apoc/systemdb/metadata/ExportFunction.java
@@ -3,12 +3,17 @@ package apoc.systemdb.metadata;
 import apoc.SystemPropertyKeys;
 import apoc.custom.CypherProceduresHandler;
 import apoc.export.util.ProgressReporter;
+import apoc.util.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.neo4j.graphdb.Node;
 import org.neo4j.internal.helpers.collection.Pair;
 import org.neo4j.internal.kernel.api.procs.FieldSignature;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import static apoc.util.Util.toCypherMap;
 
 
 public class ExportFunction implements ExportMetadata {
@@ -21,14 +26,19 @@ public class ExportFunction implements ExportMetadata {
         final String outputs = node.hasProperty(outputName)
                 ? (String) node.getProperty(outputName)
                 : getSignature(node, SystemPropertyKeys.outputs.name());
-
-        String statement = String.format("CALL apoc.custom.declareFunction('%s(%s) :: (%s)', '%s', %s, '%s');",
-                node.getProperty(SystemPropertyKeys.name.name()), inputs, outputs,
-                node.getProperty(SystemPropertyKeys.statement.name()),
-                node.getProperty(SystemPropertyKeys.forceSingle.name()),
-                node.getProperty(SystemPropertyKeys.description.name()));
-        progressReporter.nextRow();
-        return List.of(Pair.of(getFileName(node, Type.CypherFunction.name()), statement));
+        try {
+            final String configMap = toCypherMap(JsonUtil.OBJECT_MAPPER.readValue((String) node.getProperty(SystemPropertyKeys.config.name(), "{}"), Map.class));
+            String statement = String.format("CALL apoc.custom.declareFunction('%s(%s) :: (%s)', '%s', %s, '%s', %s);",
+                    node.getProperty(SystemPropertyKeys.name.name()), inputs, outputs,
+                    node.getProperty(SystemPropertyKeys.statement.name()),
+                    node.getProperty(SystemPropertyKeys.forceSingle.name()),
+                    node.getProperty(SystemPropertyKeys.description.name()),
+                    configMap);
+            progressReporter.nextRow();
+            return List.of(Pair.of(getFileName(node, Type.CypherFunction.name()), statement));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -2,6 +2,7 @@ package apoc.custom;
 
 import apoc.path.PathExplorer;
 import apoc.util.FileUtils;
+import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -19,6 +20,9 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
+import static apoc.custom.CustomCypherConfig.WRAP_MAP;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -89,6 +93,46 @@ public class CypherProceduresStorageTest {
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("procedure", row.get("type"));
+        });
+    }
+    
+    @Test
+    public void testWrapMapAfterRestart() throws Exception {
+        final Map<String, Boolean> config = Map.of(WRAP_MAP, false);
+        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map(val :: INTEGER) :: MAP ', 'RETURN {value : $val} as value', false, '', $config)",
+                Map.of("config", config));
+        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map_list(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value', false, '', $config)",
+                Map.of("config", config));
+        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map_list_single(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value', true, '', $config)",
+                Map.of("config", config));
+
+        final Map<String, Long> mapValue = Map.of("value", 3L);
+
+        assertionsTestWrapMap(config, mapValue);
+        restartDb();
+        assertionsTestWrapMap(config, mapValue);
+    }
+
+    private void assertionsTestWrapMap(Map<String, Boolean> config, Map<String, Long> mapValue) {
+        TestUtil.testCall(db, "RETURN custom.ret_map(3) AS val", (result) -> {
+            Map<String, Object> map = (Map<String, Object>) result.get("val");
+            assertEquals(mapValue, map);
+        });
+        TestUtil.testCall(db, "RETURN custom.ret_map_list(3) AS val", (result) -> {
+            List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("val");
+            assertEquals(List.of(List.of(mapValue)), list);
+        });
+        TestUtil.testCall(db, "RETURN custom.ret_map_list_single(3) AS val", (result) -> {
+            List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("val");
+            assertEquals(List.of(mapValue), list);
+        });
+
+        TestUtil.testResult(db, "call apoc.custom.list()", result -> {
+            result.forEachRemaining(function -> {
+                assertEquals("function", function.get("type"));
+                assertThat(function.get("name"), isOneOf("ret_map", "ret_map_list", "ret_map_list_single"));
+                assertEquals(config, function.get("config"));
+            });
         });
     }
 

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static apoc.custom.CustomCypherConfig.WRAP_MAP;
 import static apoc.custom.CypherProcedures.ERROR_MISMATCHED_INPUTS;
 import static apoc.custom.CypherProcedures.ERROR_MISMATCHED_OUTPUTS;
 import static apoc.custom.CypherProceduresHandler.FUNCTION;
@@ -154,6 +155,32 @@ public class CypherProceduresTest  {
             assertEquals(4L, list.get(0).get("value").get(0).get("value"));
         });
     }
+    
+//    @Test
+//    public void testWrapMap() {
+//        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map(val :: INTEGER) :: MAP ', 'RETURN {value : $val} as value', false, '', $config)",
+//                Map.of("config", Map.of(WRAP_MAP, false)));
+//        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map_list(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value', false, '', $config)",
+//                Map.of("config", Map.of(WRAP_MAP, false)));
+//        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map_list_single(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value', true, '', $config)",
+//                Map.of("config", Map.of(WRAP_MAP, false)));
+//
+//        // then
+//        final Map<String, Long> mapValue = Map.of("value", 3L);
+//        
+//        testCall(db, "RETURN custom.ret_map(3) AS val", (result) -> {
+//            Map<String, Object> map = (Map<String, Object>) result.get("val");
+//            assertEquals(mapValue, map);
+//        });
+//        testCall(db, "RETURN custom.ret_map_list(3) AS val", (result) -> {
+//            List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("val");
+//            assertEquals(List.of(List.of(mapValue)), list);
+//        });
+//        testCall(db, "RETURN custom.ret_map_list_single(3) AS val", (result) -> {
+//            List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("val");
+//            assertEquals(List.of(mapValue), list);
+//        });
+//    }
 
     @Test
     public void testRegisterFunctionReturnTypes() {
@@ -307,6 +334,7 @@ public class CypherProceduresTest  {
                     assertEquals(asList(asList("input", "integer", "42")), value.get("inputs"));
                     assertEquals("Procedure that answer to the Ultimate Question of Life, the Universe, and Everything", value.get("description").toString());
                     assertNull(value.get("forceSingle"));
+                    // todo ... force map
                     assertEquals("read", value.get("mode"));
                 }
 
@@ -316,6 +344,7 @@ public class CypherProceduresTest  {
                     assertEquals(asList(asList("input", "number")), value.get("inputs"));
                     assertEquals("", value.get("description"));
                     assertFalse((Boolean) value.get("forceSingle"));
+                    // todo ... force map
                     assertNull(value.get("mode"));
                 }
             }

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -55,10 +55,19 @@ public class CypherProceduresTest  {
 
     @Test
     public void registerSimpleStatement() throws Exception {
-        db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
-        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::INT)','RETURN 42 as answer')");
+//        db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
+//        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::STRING, answer2::MAP)','RETURN 42 as answer, 43 as answer2')");
         TestUtil.testCall(db, "call custom.answer2()", (row) -> assertEquals(42L, row.get("answer")));
+    }
+
+    @Test
+    public void validateOutputType() throws Exception {
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::STRING, answer2::INT)','RETURN 42 as answer, 43 as answer2')");
+        TestUtil.testCall(db, "call custom.answer2()", (row) -> assertEquals(42L, row.get("answer")));
+        
+//        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::INT, answer2::INT)','RETURN 42 as answer, 43 as answer2')");
+//        TestUtil.testCall(db, "call custom.answer2()", (row) -> assertEquals(42L, row.get("answer")));
     }
 
     @Test
@@ -156,31 +165,15 @@ public class CypherProceduresTest  {
         });
     }
     
-//    @Test
-//    public void testWrapMap() {
-//        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map(val :: INTEGER) :: MAP ', 'RETURN {value : $val} as value', false, '', $config)",
-//                Map.of("config", Map.of(WRAP_MAP, false)));
-//        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map_list(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value', false, '', $config)",
-//                Map.of("config", Map.of(WRAP_MAP, false)));
-//        db.executeTransactionally("CALL apoc.custom.declareFunction('ret_map_list_single(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value', true, '', $config)",
-//                Map.of("config", Map.of(WRAP_MAP, false)));
-//
-//        // then
-//        final Map<String, Long> mapValue = Map.of("value", 3L);
-//        
-//        testCall(db, "RETURN custom.ret_map(3) AS val", (result) -> {
-//            Map<String, Object> map = (Map<String, Object>) result.get("val");
-//            assertEquals(mapValue, map);
-//        });
-//        testCall(db, "RETURN custom.ret_map_list(3) AS val", (result) -> {
-//            List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("val");
-//            assertEquals(List.of(List.of(mapValue)), list);
-//        });
-//        testCall(db, "RETURN custom.ret_map_list_single(3) AS val", (result) -> {
-//            List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("val");
-//            assertEquals(List.of(mapValue), list);
-//        });
-//    }
+    @Test
+    public void testWrapMap() {
+        // todo - validation output type...
+        db.executeTransactionally("CALL apoc.custom.declareFunction('funWithMap(map :: MAP) :: MAP' , 'RETURN $map' )");
+
+        TestUtil.testCall(db, "RETURN custom.funWithMap({a:1}) AS val", (result) -> {
+            Map<String, Object> map = (Map<String, Object>) result.get("val");
+        });
+    }
 
     @Test
     public void testRegisterFunctionReturnTypes() {
@@ -702,8 +695,8 @@ public class CypherProceduresTest  {
     @Test
     public void shouldCreateFunctionWithDefaultParameters() {
         // default inputs
-        db.executeTransactionally("CALL apoc.custom.declareFunction('multiParDeclareFun(params = {} :: MAP) :: INT ', 'RETURN $one + $two as sum')");
-        TestUtil.testCall(db, "return custom.multiParDeclareFun({one:2, two: 3}) as row", (row) -> assertEquals(5L, row.get("row")));
+//        db.executeTransactionally("CALL apoc.custom.declareFunction('multiParDeclareFun(params = {} :: MAP) :: INT ', 'RETURN $one + $two as sum')");
+//        TestUtil.testCall(db, "return custom.multiParDeclareFun({one:2, two: 3}) as row", (row) -> assertEquals(5L, row.get("row")));
         
         db.executeTransactionally("CALL apoc.custom.declareProcedure('multiParDeclareProc(params = {} :: MAP) :: (sum :: INT) ', 'RETURN $one + $two + $three as sum')");
         TestUtil.testCall(db, "call custom.multiParDeclareProc({one:2, two: 3, three: 4})", (row) -> assertEquals(9L, row.get("sum")));

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -55,19 +55,10 @@ public class CypherProceduresTest  {
 
     @Test
     public void registerSimpleStatement() throws Exception {
-//        db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
-//        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
-        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::STRING, answer2::MAP)','RETURN 42 as answer, 43 as answer2')");
+        db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
+        TestUtil.testCall(db, "call custom.answer()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::INT)','RETURN 42 as answer')");
         TestUtil.testCall(db, "call custom.answer2()", (row) -> assertEquals(42L, row.get("answer")));
-    }
-
-    @Test
-    public void validateOutputType() throws Exception {
-        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::STRING, answer2::INT)','RETURN 42 as answer, 43 as answer2')");
-        TestUtil.testCall(db, "call custom.answer2()", (row) -> assertEquals(42L, row.get("answer")));
-        
-//        db.executeTransactionally("CALL apoc.custom.declareProcedure('answer2() :: (answer::INT, answer2::INT)','RETURN 42 as answer, 43 as answer2')");
-//        TestUtil.testCall(db, "call custom.answer2()", (row) -> assertEquals(42L, row.get("answer")));
     }
 
     @Test
@@ -167,12 +158,18 @@ public class CypherProceduresTest  {
     
     @Test
     public void testWrapMap() {
-        // todo - validation output type...
-        db.executeTransactionally("CALL apoc.custom.declareFunction('funWithMap(map :: MAP) :: MAP' , 'RETURN $map' )");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('funWithMap(map :: MAP) :: MAP' , 'RETURN $map as res')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('funWithMapWrap(map :: MAP) :: MAP' , 'RETURN $map as res', false, '', $config)",
+                Map.of("config", Map.of(WRAP_MAP, false)));
 
-        TestUtil.testCall(db, "RETURN custom.funWithMap({a:1}) AS val", (result) -> {
+        final Map<String, Long> inputMap = Map.of("a", 1L);
+        TestUtil.testCall(db, "RETURN custom.funWithMap($map) AS val", Map.of("map", inputMap), (result) -> {
             Map<String, Object> map = (Map<String, Object>) result.get("val");
+            assertEquals(inputMap, map.get("res"));
         });
+        
+        TestUtil.testCall(db, "RETURN custom.funWithMapWrap($map) AS val", Map.of("map", inputMap),
+                res -> assertEquals(inputMap, res.get("val")));
     }
 
     @Test
@@ -327,7 +324,6 @@ public class CypherProceduresTest  {
                     assertEquals(asList(asList("input", "integer", "42")), value.get("inputs"));
                     assertEquals("Procedure that answer to the Ultimate Question of Life, the Universe, and Everything", value.get("description").toString());
                     assertNull(value.get("forceSingle"));
-                    // todo ... force map
                     assertEquals("read", value.get("mode"));
                 }
 
@@ -337,7 +333,7 @@ public class CypherProceduresTest  {
                     assertEquals(asList(asList("input", "number")), value.get("inputs"));
                     assertEquals("", value.get("description"));
                     assertFalse((Boolean) value.get("forceSingle"));
-                    // todo ... force map
+                    assertEquals(Map.of(WRAP_MAP, true), value.get("config"));
                     assertNull(value.get("mode"));
                 }
             }
@@ -695,8 +691,8 @@ public class CypherProceduresTest  {
     @Test
     public void shouldCreateFunctionWithDefaultParameters() {
         // default inputs
-//        db.executeTransactionally("CALL apoc.custom.declareFunction('multiParDeclareFun(params = {} :: MAP) :: INT ', 'RETURN $one + $two as sum')");
-//        TestUtil.testCall(db, "return custom.multiParDeclareFun({one:2, two: 3}) as row", (row) -> assertEquals(5L, row.get("row")));
+        db.executeTransactionally("CALL apoc.custom.declareFunction('multiParDeclareFun(params = {} :: MAP) :: INT ', 'RETURN $one + $two as sum')");
+        TestUtil.testCall(db, "return custom.multiParDeclareFun({one:2, two: 3}) as row", (row) -> assertEquals(5L, row.get("row")));
         
         db.executeTransactionally("CALL apoc.custom.declareProcedure('multiParDeclareProc(params = {} :: MAP) :: (sum :: INT) ', 'RETURN $one + $two + $three as sum')");
         TestUtil.testCall(db, "call custom.multiParDeclareProc({one:2, two: 3, three: 4})", (row) -> assertEquals(9L, row.get("sum")));

--- a/full/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/full/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -111,7 +111,7 @@ public class SystemDbTest {
         db.executeTransactionally(pauseTrigger);
 
         // We test custom procedures and functions
-        final String declareFunction = "CALL apoc.custom.declareFunction('declareFoo(input :: NUMBER?) :: (INTEGER?)', 'RETURN $input as answer', false, '');";
+        final String declareFunction = "CALL apoc.custom.declareFunction('declareFoo(input :: NUMBER?) :: (INTEGER?)', 'RETURN $input as answer', false, '', {});";
         db.executeTransactionally(declareFunction);
         final String declareProcedure = "CALL apoc.custom.declareProcedure('declareBar(one = 2 :: INTEGER?, two = 3 :: INTEGER?) :: (sum :: INTEGER?)', 'RETURN $one + $two as sum', 'READ', '');";
         db.executeTransactionally(declareProcedure);
@@ -120,7 +120,7 @@ public class SystemDbTest {
         // the expected exported cypher queries will leverage the new procedures (declareFunction and declareProcedure) 
         db.executeTransactionally("CALL apoc.custom.asProcedure('procName','RETURN $input as answer','read',[['answer','number']],[['input','int','42']], 'Procedure that answer to the Ultimate Question of Life, the Universe, and Everything');");
         db.executeTransactionally("CALL apoc.custom.asFunction('funName','RETURN $input as answer', 'long', [['input','number']], false);");
-        String declareStatementFromFunction = "CALL apoc.custom.declareFunction('funName(input :: NUMBER?) :: (INTEGER?)', 'RETURN $input as answer', false, '');";
+        String declareStatementFromFunction = "CALL apoc.custom.declareFunction('funName(input :: NUMBER?) :: (INTEGER?)', 'RETURN $input as answer', false, '', {});";
         String declareStatementFromProcedure = "CALL apoc.custom.declareProcedure('procName(input = 42 :: INTEGER?) :: (answer :: NUMBER?)', 'RETURN $input as answer', 'READ', 'Procedure that answer to the Ultimate Question of Life, the Universe, and Everything');";
 
         // We test uuid, we also need to export the related constraint (in another file)


### PR DESCRIPTION
Closed in favor of https://github.com/vga91/neo4j-apoc-procedures/pull/252

Issue 2612

waiting for 1714_4.3


I tried also to do a validation output to avoid situation like this:
```
CALL apoc.custom.declareFunction('funWithMap(map :: MAP) :: STRING' , 'RETURN {a: 1}' )
```
but it would be a breaking change because this test case, present in `registerSimpleStatementFunction`, 
seems wrong but actually works.
```
CALL apoc.custom.declareFunction('answer2() :: STRING','RETURN 42 as answer') 
```