### PR TITLE
Issue 2645: csv import fails when parse an empty string as a date

### DIFF
--- a/core/src/main/java/apoc/load/Mapping.java
+++ b/core/src/main/java/apoc/load/Mapping.java
@@ -3,6 +3,7 @@ package apoc.load;
 import apoc.load.util.LoadCsvConfig;
 import apoc.meta.Meta;
 import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.values.storable.DateTimeValue;
 import org.neo4j.values.storable.DateValue;
 import org.neo4j.values.storable.DurationValue;
@@ -70,7 +71,9 @@ public class Mapping {
     }
 
     private Object convertType(String value) {
-        if (nullValues.contains(value)) return null;
+        if (nullValues.contains(value) || (StringUtils.isBlank(value) && !type.equals(Meta.Types.STRING))) {
+            return null;
+        }
         if (type == Meta.Types.STRING) return value;
 
         final Supplier<ZoneId> timezone = () -> ZoneId.of((String) optionalData.getOrDefault("timezone", apocConfig().getString(db_temporal_timezone.name())));


### PR DESCRIPTION
Trello issue: https://trello.com/c/9kk5cLwh/958-s4govtech-singapore-csv-import-fails-when-parse-an-empty-string-as-a-date

Positive feedback received

Issue 2645