### PR TITLE
Issue 2659: Apoc.import.graphml doesn't work for edges

### DIFF
--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -69,6 +69,8 @@ public class ExportGraphML {
             XmlGraphMLReader graphMLReader = new XmlGraphMLReader(db, tx).reporter(reporter)
                     .batchSize(exportConfig.getBatchSize())
                     .relType(exportConfig.defaultRelationshipType())
+                    .startLabel(exportConfig.getNodeStartLabel())
+                    .endLabel(exportConfig.getNodeEndLabel())
                     .nodeLabels(exportConfig.readLabels());
 
             if (exportConfig.storeNodeIds()) graphMLReader.storeNodeIds();

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -69,8 +69,8 @@ public class ExportGraphML {
             XmlGraphMLReader graphMLReader = new XmlGraphMLReader(db, tx).reporter(reporter)
                     .batchSize(exportConfig.getBatchSize())
                     .relType(exportConfig.defaultRelationshipType())
-                    .startLabel(exportConfig.getNodeStartLabel())
-                    .endLabel(exportConfig.getNodeEndLabel())
+                    .source(exportConfig.getSource())
+                    .target(exportConfig.getTarget())
                     .nodeLabels(exportConfig.readLabels());
 
             if (exportConfig.storeNodeIds()) graphMLReader.storeNodeIds();

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -31,6 +31,8 @@ public class XmlGraphMLReader {
     private final Transaction tx;
     private boolean storeNodeIds;
     private RelationshipType defaultRelType = RelationshipType.withName("UNKNOWN");
+    private String startLabel = null;
+    private String endLabel = null;
     private int batchSize = 40000;
     private Reporter reporter;
     private boolean labels;
@@ -52,6 +54,16 @@ public class XmlGraphMLReader {
 
     public XmlGraphMLReader nodeLabels(boolean readLabels) {
         this.labels = readLabels;
+        return this;
+    }
+
+    public XmlGraphMLReader startLabel(String startLabel) {
+        this.startLabel = startLabel;
+        return this;
+    }
+
+    public XmlGraphMLReader endLabel(String endLabel) {
+        this.endLabel = endLabel;
         return this;
     }
 
@@ -258,8 +270,8 @@ public class XmlGraphMLReader {
                         String source = getAttribute(element, SOURCE);
                         String target = getAttribute(element, TARGET);
                         String label = getAttribute(element, LABEL);
-                        Node from = tx.getTransaction().getNodeById(cache.get(source));
-                        Node to = tx.getTransaction().getNodeById(cache.get(target));
+                        Node from = getByNodeId(cache, tx.getTransaction(), this.startLabel, source);
+                        Node to = getByNodeId(cache, tx.getTransaction(), this.endLabel, target);
 
                         RelationshipType relationshipType = label == null ? getRelationshipType(reader) : RelationshipType.withName(label);
                         Relationship relationship = from.createRelationshipTo(to, relationshipType);
@@ -272,6 +284,18 @@ public class XmlGraphMLReader {
             }
         }
         return count;
+    }
+
+    private Node getByNodeId(Map<String, Long> cache, Transaction tx, String label, String sourceTarget) {
+        final Long id = cache.get(sourceTarget);
+        if (id == null) {
+            try {
+                return tx.findNode(Label.label(label), "id", sourceTarget);
+            } catch (Exception e) {
+                throw new RuntimeException("Node not found", e);
+            }
+        }
+        return tx.getNodeById(id);
     }
 
     private RelationshipType getRelationshipType(XMLEventReader reader) throws XMLStreamException {

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -1,6 +1,7 @@
 package apoc.export.graphml;
 
 import apoc.export.util.BatchTransaction;
+import apoc.export.util.ExportConfig;
 import apoc.export.util.Reporter;
 import apoc.util.JsonUtil;
 import org.apache.commons.lang3.StringUtils;
@@ -16,10 +17,10 @@ import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 import java.io.Reader;
 import java.lang.reflect.Array;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -32,8 +33,8 @@ public class XmlGraphMLReader {
     private final Transaction tx;
     private boolean storeNodeIds;
     private RelationshipType defaultRelType = RelationshipType.withName("UNKNOWN");
-    private Map<String, String> source = Collections.emptyMap();
-    private Map<String, String> target = Collections.emptyMap();
+    private ExportConfig.NodeConfig source;
+    private ExportConfig.NodeConfig target;
     private int batchSize = 40000;
     private Reporter reporter;
     private boolean labels;
@@ -58,12 +59,12 @@ public class XmlGraphMLReader {
         return this;
     }
 
-    public XmlGraphMLReader source(Map<String, String> sourceConfig) {
+    public XmlGraphMLReader source(ExportConfig.NodeConfig sourceConfig) {
         this.source = sourceConfig;
         return this;
     }
 
-    public XmlGraphMLReader target(Map<String, String> targetConfig) {
+    public XmlGraphMLReader target(ExportConfig.NodeConfig targetConfig) {
         this.target = targetConfig;
         return this;
     }
@@ -73,7 +74,13 @@ public class XmlGraphMLReader {
         return this;
     }
 
+    public ExportConfig.NodeConfig getSource() {
+        return source;
+    }
 
+    public ExportConfig.NodeConfig getTarget() {
+        return target;
+    }
 
     enum Type {
         BOOLEAN() {
@@ -269,8 +276,8 @@ public class XmlGraphMLReader {
                     if (name.equals("edge")) {
                         tx.increment();
                         String label = getAttribute(element, LABEL);
-                        Node from = getByNodeId(cache, tx.getTransaction(), element, "source");
-                        Node to = getByNodeId(cache, tx.getTransaction(), element, "target");
+                        Node from = getByNodeId(cache, tx.getTransaction(), element, XmlNodeExport.NodeType.SOURCE);
+                        Node to = getByNodeId(cache, tx.getTransaction(), element, XmlNodeExport.NodeType.TARGET);
 
                         RelationshipType relationshipType = label == null ? getRelationshipType(reader) : RelationshipType.withName(label);
                         Relationship relationship = from.createRelationshipTo(to, relationshipType);
@@ -285,35 +292,25 @@ public class XmlGraphMLReader {
         return count;
     }
 
-    private Node getByNodeId(Map<String, Long> cache, Transaction tx, StartElement element, String typeNode) {
-        final Map<String, String> sourceTargetConfig;
-        final String sourceTargetValue;
-        if (typeNode.equals("source")) {
-            sourceTargetConfig = this.source;
-            sourceTargetValue = getAttribute(element, SOURCE);
-        } else {
-            sourceTargetConfig = this.target;
-            sourceTargetValue = getAttribute(element, TARGET);
-        }
+    private Node getByNodeId(Map<String, Long> cache, Transaction tx, StartElement element, XmlNodeExport.NodeType nodeType) {
+        final XmlNodeExport.ExportNode xmlNodeInterface = nodeType.get();
+        final ExportConfig.NodeConfig nodeConfig = xmlNodeInterface.getNodeConfigReader(this);
+        
+        final String sourceTargetValue = getAttribute(element, QName.valueOf(nodeType.getName()));
         
         final Long id = cache.get(sourceTargetValue);
-        if (id == null) {
-            try {
-                final String label = sourceTargetConfig.get("label");
-                if (label == null) {
-                    throw new RuntimeException("The source and target config map must have a key 'label'");
-                }
-                final String idKey = sourceTargetConfig.getOrDefault("id", "id");
-                final String attribute = getAttribute(element, QName.valueOf(typeNode + "Type"));
-                final Object value = attribute == null 
-                        ? sourceTargetValue 
-                        : Type.forType(attribute).parse(sourceTargetValue);
-                return tx.findNode(Label.label(label), idKey, value);
-            } catch (Exception e) {
-                throw new RuntimeException("Node not found", e);
-            }
+        // without source/target config, we look for the internal id
+        if (StringUtils.isBlank(nodeConfig.label)) {
+            return tx.getNodeById(id);
         }
-        return tx.getNodeById(id);
+        // with source/target configured, we search a node with a specified label 
+        // and with a type specified in sourceType, if present, or string by default
+        final String attribute = getAttribute(element, QName.valueOf(nodeType.getNameType()));
+        final Object value = attribute == null 
+                ? sourceTargetValue 
+                : Type.forType(attribute).parse(sourceTargetValue);
+        
+        return tx.findNode(Label.label(nodeConfig.label), Optional.ofNullable(nodeConfig.id).orElse("id"), value);
     }
 
     private RelationshipType getRelationshipType(XMLEventReader reader) throws XMLStreamException {

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -16,6 +16,7 @@ import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 import java.io.Reader;
 import java.lang.reflect.Array;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +32,8 @@ public class XmlGraphMLReader {
     private final Transaction tx;
     private boolean storeNodeIds;
     private RelationshipType defaultRelType = RelationshipType.withName("UNKNOWN");
-    private String startLabel = null;
-    private String endLabel = null;
+    private Map<String, String> source = Collections.emptyMap();
+    private Map<String, String> target = Collections.emptyMap();
     private int batchSize = 40000;
     private Reporter reporter;
     private boolean labels;
@@ -57,13 +58,13 @@ public class XmlGraphMLReader {
         return this;
     }
 
-    public XmlGraphMLReader startLabel(String startLabel) {
-        this.startLabel = startLabel;
+    public XmlGraphMLReader source(Map<String, String> sourceConfig) {
+        this.source = sourceConfig;
         return this;
     }
 
-    public XmlGraphMLReader endLabel(String endLabel) {
-        this.endLabel = endLabel;
+    public XmlGraphMLReader target(Map<String, String> targetConfig) {
+        this.target = targetConfig;
         return this;
     }
 
@@ -267,11 +268,9 @@ public class XmlGraphMLReader {
                     }
                     if (name.equals("edge")) {
                         tx.increment();
-                        String source = getAttribute(element, SOURCE);
-                        String target = getAttribute(element, TARGET);
                         String label = getAttribute(element, LABEL);
-                        Node from = getByNodeId(cache, tx.getTransaction(), this.startLabel, source);
-                        Node to = getByNodeId(cache, tx.getTransaction(), this.endLabel, target);
+                        Node from = getByNodeId(cache, tx.getTransaction(), element, "source");
+                        Node to = getByNodeId(cache, tx.getTransaction(), element, "target");
 
                         RelationshipType relationshipType = label == null ? getRelationshipType(reader) : RelationshipType.withName(label);
                         Relationship relationship = from.createRelationshipTo(to, relationshipType);
@@ -286,11 +285,30 @@ public class XmlGraphMLReader {
         return count;
     }
 
-    private Node getByNodeId(Map<String, Long> cache, Transaction tx, String label, String sourceTarget) {
-        final Long id = cache.get(sourceTarget);
+    private Node getByNodeId(Map<String, Long> cache, Transaction tx, StartElement element, String typeNode) {
+        final Map<String, String> sourceTargetConfig;
+        final String sourceTargetValue;
+        if (typeNode.equals("source")) {
+            sourceTargetConfig = this.source;
+            sourceTargetValue = getAttribute(element, SOURCE);
+        } else {
+            sourceTargetConfig = this.target;
+            sourceTargetValue = getAttribute(element, TARGET);
+        }
+        
+        final Long id = cache.get(sourceTargetValue);
         if (id == null) {
             try {
-                return tx.findNode(Label.label(label), "id", sourceTarget);
+                final String label = sourceTargetConfig.get("label");
+                if (label == null) {
+                    throw new RuntimeException("The source and target config map must have a key 'label'");
+                }
+                final String idKey = sourceTargetConfig.getOrDefault("id", "id");
+                final String attribute = getAttribute(element, QName.valueOf(typeNode + "Type"));
+                final Object value = attribute == null 
+                        ? sourceTargetValue 
+                        : Type.forType(attribute).parse(sourceTargetValue);
+                return tx.findNode(Label.label(label), idKey, value);
             } catch (Exception e) {
                 throw new RuntimeException("Node not found", e);
             }

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
@@ -4,6 +4,7 @@ import apoc.export.util.*;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
 
 import javax.xml.stream.XMLOutputFactory;
@@ -119,8 +120,8 @@ public class XmlGraphMLWriter {
     private int writeRelationship(XMLStreamWriter writer, Relationship rel, ExportConfig config) throws XMLStreamException {
         writer.writeStartElement("edge");
         writer.writeAttribute("id", id(rel));
-        writer.writeAttribute("source", id(rel.getStartNode()));
-        writer.writeAttribute("target", id(rel.getEndNode()));
+        getSourceTargetAttribute(writer, "source", config, rel);
+        getSourceTargetAttribute(writer, "target", config, rel);
         writer.writeAttribute("label", rel.getType().name());
         writeData(writer, "label", rel.getType().name());
         if (config.getFormat() == ExportFormat.GEPHI) {
@@ -129,6 +130,44 @@ public class XmlGraphMLWriter {
         int props = writeProps(writer, rel);
         endElement(writer);
         return props;
+    }
+
+    private void getSourceTargetAttribute(XMLStreamWriter writer, String localName, ExportConfig config, Relationship rel) throws XMLStreamException {
+        final Map<String, String> sourceTargetConf;
+        final Node node;
+        if (localName.equals("source")) {
+            sourceTargetConf = config.getSource();
+            node = rel.getStartNode();
+        } else {
+            sourceTargetConf = config.getTarget();
+            node = rel.getEndNode();
+        }
+        final String id = sourceTargetConf.get("id");
+        if (id == null) {
+            writer.writeAttribute(localName, id(node));
+            return;
+        }
+        try {
+            final Object nodeProperty = node.getProperty(id);
+            writer.writeAttribute(localName, nodeProperty.toString());
+            writer.writeAttribute(localName + "Type", MetaInformation.typeFor(nodeProperty.getClass(), MetaInformation.GRAPHML_ALLOWED));
+        } catch (NotFoundException e) {
+            throw new RuntimeException(
+                    "The config source and/or target cannot be used because the node with id " + node.getId() + " doesn't have property " + id);
+        }
+    }
+
+    private String getSourceTargetId(Map<String, String> source, Node startNode) {
+        final String id = source.get("id");
+        if (id == null) {
+            return id(startNode);
+        }
+        try {
+            return startNode.getProperty(id).toString();
+        } catch (NotFoundException e) {
+            throw new RuntimeException(
+                    "The config source and/or target cannot be used because the node with id " + startNode.getId() + " doesn't have property " + id);
+        }
     }
 
     private String id(Relationship rel) {

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
@@ -1,8 +1,10 @@
 package apoc.export.graphml;
 
 import apoc.export.util.*;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
@@ -120,8 +122,8 @@ public class XmlGraphMLWriter {
     private int writeRelationship(XMLStreamWriter writer, Relationship rel, ExportConfig config) throws XMLStreamException {
         writer.writeStartElement("edge");
         writer.writeAttribute("id", id(rel));
-        getSourceTargetAttribute(writer, "source", config, rel);
-        getSourceTargetAttribute(writer, "target", config, rel);
+        getNodeAttribute(writer, XmlNodeExport.NodeType.SOURCE, config, rel);
+        getNodeAttribute(writer, XmlNodeExport.NodeType.TARGET, config, rel);
         writer.writeAttribute("label", rel.getType().name());
         writeData(writer, "label", rel.getType().name());
         if (config.getFormat() == ExportFormat.GEPHI) {
@@ -132,41 +134,26 @@ public class XmlGraphMLWriter {
         return props;
     }
 
-    private void getSourceTargetAttribute(XMLStreamWriter writer, String localName, ExportConfig config, Relationship rel) throws XMLStreamException {
-        final Map<String, String> sourceTargetConf;
-        final Node node;
-        if (localName.equals("source")) {
-            sourceTargetConf = config.getSource();
-            node = rel.getStartNode();
-        } else {
-            sourceTargetConf = config.getTarget();
-            node = rel.getEndNode();
-        }
-        final String id = sourceTargetConf.get("id");
-        if (id == null) {
-            writer.writeAttribute(localName, id(node));
+    private void getNodeAttribute(XMLStreamWriter writer, XmlNodeExport.NodeType nodeType, ExportConfig config, Relationship rel) throws XMLStreamException {
+
+        final XmlNodeExport.ExportNode xmlNodeInterface = nodeType.get();
+        final Node node = xmlNodeInterface.getNode(rel);
+        final String name = nodeType.getName();
+        final ExportConfig.NodeConfig nodeConfig = xmlNodeInterface.getNodeConfig(config);
+        // without config the source/target configs, we leverage the internal node id
+        if (StringUtils.isBlank(nodeConfig.id)) {
+            writer.writeAttribute(name, id(node));
             return;
         }
+        // with source/target with an id configured 
+        // we put a source with the property value and a sourceType with the prop type of node
         try {
-            final Object nodeProperty = node.getProperty(id);
-            writer.writeAttribute(localName, nodeProperty.toString());
-            writer.writeAttribute(localName + "Type", MetaInformation.typeFor(nodeProperty.getClass(), MetaInformation.GRAPHML_ALLOWED));
+            final Object nodeProperty = node.getProperty(nodeConfig.id);
+            writer.writeAttribute(name, nodeProperty.toString());
+            writer.writeAttribute(nodeType.getNameType(), MetaInformation.typeFor(nodeProperty.getClass(), MetaInformation.GRAPHML_ALLOWED));
         } catch (NotFoundException e) {
             throw new RuntimeException(
-                    "The config source and/or target cannot be used because the node with id " + node.getId() + " doesn't have property " + id);
-        }
-    }
-
-    private String getSourceTargetId(Map<String, String> source, Node startNode) {
-        final String id = source.get("id");
-        if (id == null) {
-            return id(startNode);
-        }
-        try {
-            return startNode.getProperty(id).toString();
-        } catch (NotFoundException e) {
-            throw new RuntimeException(
-                    "The config source and/or target cannot be used because the node with id " + startNode.getId() + " doesn't have property " + id);
+                    "The config source and/or target cannot be used because the node with id " + node.getId() + " doesn't have property " + nodeConfig.id);
         }
     }
 

--- a/core/src/main/java/apoc/export/graphml/XmlNodeExport.java
+++ b/core/src/main/java/apoc/export/graphml/XmlNodeExport.java
@@ -1,0 +1,72 @@
+package apoc.export.graphml;
+
+import apoc.export.util.ExportConfig;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
+import static apoc.export.util.ExportConfig.NodeConfig;
+
+public class XmlNodeExport {
+    
+    public interface ExportNode {
+        NodeConfig getNodeConfig(ExportConfig config);
+        NodeConfig getNodeConfigReader(XmlGraphMLReader reader);
+        Node getNode(Relationship rel);
+    }
+
+    enum NodeType {
+        SOURCE("source", new ExportNode() {
+            @Override
+            public ExportConfig.NodeConfig getNodeConfig(ExportConfig config) {
+                return config.getSource();
+            }
+
+            @Override
+            public Node getNode(Relationship rel) {
+                return rel.getStartNode();
+            }
+
+            @Override
+            public NodeConfig getNodeConfigReader(XmlGraphMLReader reader) {
+                return reader.getSource();
+            }
+        }),
+        
+        TARGET("target", new ExportNode() {
+            @Override
+            public ExportConfig.NodeConfig getNodeConfig(ExportConfig config) {
+                return config.getTarget();
+            }
+
+            @Override
+            public Node getNode(Relationship rel) {
+                return rel.getEndNode();
+            }
+
+            @Override
+            public NodeConfig getNodeConfigReader(XmlGraphMLReader reader) {
+                return reader.getTarget();
+            }
+        });
+
+        private final String name;
+        private final ExportNode exportNode;
+
+        NodeType(String name, ExportNode exportNode) {
+            this.name = name;
+            this.exportNode = exportNode;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getNameType() {
+            return name + "Type";
+        }
+
+        ExportNode get() {
+            return exportNode;
+        }
+    }
+}

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -26,6 +26,8 @@ public class ExportConfig extends CompressionConfig {
     public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
     private final boolean ifNotExists;
+    private final Map<String, String> source;
+    private final Map<String, String> target;
 
     private int batchSize;
     private boolean silent;
@@ -109,6 +111,8 @@ public class ExportConfig extends CompressionConfig {
         this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
+        this.source = (Map<String, String>) config.getOrDefault("source", Collections.emptyMap());
+        this.target = (Map<String, String>) config.getOrDefault("target", Collections.emptyMap());
         validate();
     }
 
@@ -150,12 +154,12 @@ public class ExportConfig extends CompressionConfig {
         return config.getOrDefault("defaultRelationshipType","RELATED").toString();
     }
 
-    public String getNodeStartLabel() {
-        return (String) config.get("startLabel");
+    public Map<String, String> getSource() {
+        return source;
     }
 
-    public String getNodeEndLabel() {
-        return (String) config.get("endLabel");
+    public Map<String, String> getTarget() {
+        return target;
     }
 
     public boolean readLabels() {

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -150,6 +150,14 @@ public class ExportConfig extends CompressionConfig {
         return config.getOrDefault("defaultRelationshipType","RELATED").toString();
     }
 
+    public String getNodeStartLabel() {
+        return (String) config.get("startLabel");
+    }
+
+    public String getNodeEndLabel() {
+        return (String) config.get("endLabel");
+    }
+
     public boolean readLabels() {
         return toBoolean(config.getOrDefault("readLabels",false));
     }

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -14,6 +14,18 @@ import static java.util.Arrays.asList;
  * @since 19.01.14
  */
 public class ExportConfig extends CompressionConfig {
+
+    public static class NodeConfig {
+        public String label;
+        public String id;
+
+        public NodeConfig(Map<String, String> config) {
+            config = config == null ? Collections.emptyMap() : config;
+            this.label = config.get("label");
+            this.id = config.get("id");
+        }
+    }
+    
     public static final char QUOTECHAR = '"';
     public static final String NONE_QUOTES = "none";
     public static final String ALWAYS_QUOTES = "always";
@@ -26,8 +38,8 @@ public class ExportConfig extends CompressionConfig {
     public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
     private final boolean ifNotExists;
-    private final Map<String, String> source;
-    private final Map<String, String> target;
+    private final NodeConfig source;
+    private final NodeConfig target;
 
     private int batchSize;
     private boolean silent;
@@ -111,8 +123,8 @@ public class ExportConfig extends CompressionConfig {
         this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
-        this.source = (Map<String, String>) config.getOrDefault("source", Collections.emptyMap());
-        this.target = (Map<String, String>) config.getOrDefault("target", Collections.emptyMap());
+        this.source = new NodeConfig((Map<String, String>) config.get("source"));
+        this.target = new NodeConfig((Map<String, String>) config.get("target"));
         validate();
     }
 
@@ -154,11 +166,11 @@ public class ExportConfig extends CompressionConfig {
         return config.getOrDefault("defaultRelationshipType","RELATED").toString();
     }
 
-    public Map<String, String> getSource() {
+    public NodeConfig getSource() {
         return source;
     }
 
-    public Map<String, String> getTarget() {
+    public NodeConfig getTarget() {
         return target;
     }
 

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -203,6 +203,8 @@ public class ExportGraphMLTest {
                 "source", map("label", "Foo"),
                 "target", map("label", "Bar"));
 
+        // we didn't specified a source/target in export config
+        // so we have to store the nodeIds and looking for them during relationship import
         separatedFileCommons(exportConfig, importConfig);
     }
 
@@ -216,12 +218,15 @@ public class ExportGraphMLTest {
                 "source", map("label", "Foo", "id", "name"), 
                 "target", map("label", "Bar", "id", "age"));
         
+        // we specified a source/target in export config
+        // so storeNodeIds config is unnecessary and we search nodes by properties Foo.name and Bar.age
         separatedFileCommons(exportConfig, importConfig);
     }
 
     private void separatedFileCommons(Map<String, Object> exportConfig, Map<String, Object> importConfig) {
         db.executeTransactionally("CREATE (:Foo {name: 'zzz'})-[:KNOWS]->(:Bar {age: 0}), (:Foo {name: 'aaa'})-[:KNOWS {id: 1}]->(:Bar {age: 666})");
 
+        // we export 3 files: 1 for source nodes, 1 for end nodes, 1 for relationships
         String outputNodesFoo = new File(directory, "queryNodesFoo.graphml").getAbsolutePath();
         String outputNodesBar = new File(directory, "queryNodesBar.graphml").getAbsolutePath();
         String outputRelationships = new File(directory, "queryRelationship.graphml").getAbsolutePath();

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -194,6 +194,86 @@ public class ExportGraphMLTest {
 
         TestUtil.testCall(db, "MATCH  (c:Bar {age: 12, values: [1,2,3]}) RETURN COUNT(c) AS c", null, (r) -> assertEquals(1L, r.get("c")));
     }
+    
+    @Test
+    public void testRoundTripWithSeparatedImport() {
+        Map<String, Object> exportConfig = map("useTypes", true);
+
+        Map<String, Object> importConfig = map("readLabels", true, "storeNodeIds", true,
+                "source", map("label", "Foo"),
+                "target", map("label", "Bar"));
+
+        separatedFileCommons(exportConfig, importConfig);
+    }
+
+    @Test
+    public void testImportSeparatedFilesWithCustomId() {
+        Map<String, Object> exportConfig = map("useTypes", true,
+                "source", map("id", "name"), 
+                "target", map("id", "age"));
+        
+        Map<String, Object> importConfig = map("readLabels", true,
+                "source", map("label", "Foo", "id", "name"), 
+                "target", map("label", "Bar", "id", "age"));
+        
+        separatedFileCommons(exportConfig, importConfig);
+    }
+
+    private void separatedFileCommons(Map<String, Object> exportConfig, Map<String, Object> importConfig) {
+        db.executeTransactionally("CREATE (:Foo {name: 'zzz'})-[:KNOWS]->(:Bar {age: 0}), (:Foo {name: 'aaa'})-[:KNOWS {id: 1}]->(:Bar {age: 666})");
+
+        String outputNodesFoo = new File(directory, "queryNodesFoo.graphml").getAbsolutePath();
+        String outputNodesBar = new File(directory, "queryNodesBar.graphml").getAbsolutePath();
+        String outputRelationships = new File(directory, "queryRelationship.graphml").getAbsolutePath();
+
+        TestUtil.testCall(db, "CALL apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start',$file, $config)",
+                map("file", outputNodesFoo, "config", exportConfig),
+                (r) -> assertEquals(3L, r.get("nodes")));
+
+        TestUtil.testCall(db, "CALL apoc.export.graphml.query('MATCH (:Foo)-[:KNOWS]->(end:Bar) RETURN end', $file, $config) ",
+                map("file", outputNodesBar, "config", exportConfig),
+                (r) -> assertEquals(3L, r.get("nodes")));
+
+        TestUtil.testCall(db, "MATCH (:Foo)-[rel:KNOWS]->(:Bar) WITH collect(rel) as rels \n" +
+                        "call apoc.export.graphml.data([], rels, $file, $config) " +
+                        "YIELD nodes, relationships RETURN nodes, relationships",
+                map("file", outputRelationships, "config", exportConfig),
+                (r) -> assertEquals(3L, r.get("relationships")));
+
+        // delete current entities and re-import
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+
+        TestUtil.testCall(db, "CALL apoc.import.graphml($file, $config)",
+                map("file", outputNodesFoo, "config", importConfig),
+                (r) -> assertEquals(3L, r.get("nodes")));
+
+        TestUtil.testCall(db, "CALL apoc.import.graphml($file, $config)",
+                map("file", outputNodesBar, "config", importConfig),
+                (r) -> assertEquals(3L, r.get("nodes")));
+
+        TestUtil.testCall(db, "CALL apoc.import.graphml($file, $config)",
+                map("file", outputRelationships, "config", importConfig),
+                (r) -> assertEquals(3L, r.get("relationships")));
+
+        TestUtil.testResult(db, "MATCH (start:Foo)-[rel:KNOWS]->(end:Bar) \n" +
+                        "RETURN start.name AS startName, rel.id AS relId, end.age AS endAge \n" +
+                        "ORDER BY start.name",
+                (r) -> {
+                    Map<String, Object> row = r.next();
+                    assertions(row, "aaa", 1L, 666L);
+                    row = r.next();
+                    assertions(row, "foo", null, 42L);
+                    row = r.next();
+                    assertions(row, "zzz", null, 0L);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    private void assertions(Map<String, Object> row, String expectedSource, Long expectedRel, Long expectedTarget) {
+        assertEquals(expectedSource, row.get("startName"));
+        assertEquals(expectedRel, row.get("relId"));
+        assertEquals(expectedTarget, row.get("endAge"));
+    }
 
     @Test
     public void testImportGraphMLLargeFile() {

--- a/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
@@ -64,6 +64,10 @@ The procedures support the following config parameters:
 | defaultRelationshipType | "RELATED" | set relationship type (import/export graphml)
 | separateFiles | false | export results in separated file by type (nodes, relationships..)
 | stream | false | stream the xml directly to the client into the `data` field
+| useTypes | false | Write the attribute type information to the graphml output
+| source | Map<String,String> | Empty map | To be used together with `target` to import (via `apoc.import.graphml`) a relationships-only file. In this case the source and target attributes of `edge` tag are not based on an internal id of nodes but on a custom property value. + 
+For example, with a path like `(:Foo {name: "aaa"})-[:KNOWS]->(:Bar {age: 666})`, we can export the `KNOWS` rel with a config `<edge id="e2" source="aaa" sourceType="string" target="666" targetType="long" label="KNOWS"><data key="label">KNOWS</data><data key="id">1</data></edge>`. Note the additional `sourceType`/`targetType` to detect the right type during the import.
+| target | Map<String,String> | Empty map | Same as `source`, for end node.
 |===
 
 [[export-graphml-file-export]]
@@ -92,6 +96,9 @@ include::partial$createExportGraph.adoc[]
 The Neo4j Browser visualization below shows the imported graph:
 
 image::play-movies.png[title="Movies Graph Visualization"]
+
+[[roundtip-separated-files]]
+include::partial$roundtripSeparatedGraphml.adoc[]
 
 [[export-graphml-whole-database]]
 === Export whole database to GraphML

--- a/docs/asciidoc/modules/ROOT/partials/roundtripSeparatedGraphml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/roundtripSeparatedGraphml.adoc
@@ -11,14 +11,13 @@ CREATE (:Foo {name: 'aaa'})-[:KNOWS {id: 1}]->(:Bar {age: 666});
 
 we can execute these 3 export queries:
 
-
 [source,cypher]
 ----
 // Foo nodes
 call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesFoo.graphml', {useTypes: true});
 
 // Bar nodes
-call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesBar.graphml', {useTypes: true});
+call apoc.export.graphml.query('MATCH (:Foo)-[:KNOWS]->(end:Bar) RETURN end', 'queryNodesBar.graphml', {useTypes: true});
 
 // KNOWS rels
 MATCH (:Foo)-[rel:KNOWS]->(:Bar) 
@@ -92,22 +91,27 @@ and we used the `useTypes: true` to import the attribute `id` of `node` tags as 
 
 === With custom property key 
 
-Otherwise, we can leverage a custom property and avoid importing the `id` attribute (via `useTypes:true`) in this way (same dataset and nodes export query as before):
+Otherwise, we can leverage a custom property and avoid importing the `id` attribute (via `useTypes:true`)
+in this way (same dataset and nodes export query as before):
+
 [source,cypher]
 ----
-// Foo nodes
-call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesFoo.graphml', {useTypes: true});
-
-// Bar nodes
-call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesBar.graphml', {useTypes: true});
-
 // KNOWS rels
 MATCH (:Foo)-[rel:KNOWS]->(:Bar) 
 WITH collect(rel) as rels
-call apoc.export.graphml.data([], rels, 'queryRelationship.graphml', {useTypes: true})
+call apoc.export.graphml.data([], rels, 'queryRelationship.graphml', 
+  {useTypes: true, source: {id: 'name'}, label: {id: 'age'}})
 YIELD nodes, relationships RETURN nodes, relationships;
 ----
-with this rel file:
+
+[Note]
+====
+Is strongly recommended using an unique constraint to ensure uniqueness, 
+so in this case for label `Foo` and property `name` and for label `Bar` and property `age`
+====
+
+
+The above query generate this rel file:
 
 .queryRelationship.graphml
 [source,xml]
@@ -124,7 +128,7 @@ with this rel file:
 </graphml>
 ----
 
-Finally, we can import the files:
+Finally, we can import the files using the same id (name and age) as above:
 [source,cypher]
 ----
 CALL apoc.import.graphml('queryNodesFoo.graphml', {readLabels: true});

--- a/docs/asciidoc/modules/ROOT/partials/roundtripSeparatedGraphml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/roundtripSeparatedGraphml.adoc
@@ -1,0 +1,134 @@
+== Round trip separated GraphML files
+
+With this dataset:
+
+[source,cypher]
+----
+CREATE (f:Foo:Foo2:Foo0 {name:'foo', born:Date('2018-10-10'), place:point({ longitude: 56.7, latitude: 12.78, height: 100 })})-[:KNOWS]->(b:Bar {name:'bar',age:42, place:point({ longitude: 56.7, latitude: 12.78})});
+CREATE (:Foo {name: 'zzz'})-[:KNOWS]->(:Bar {age: 0});
+CREATE (:Foo {name: 'aaa'})-[:KNOWS {id: 1}]->(:Bar {age: 666});
+----
+
+we can execute these 3 export queries:
+
+
+[source,cypher]
+----
+// Foo nodes
+call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesFoo.graphml', {useTypes: true});
+
+// Bar nodes
+call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesBar.graphml', {useTypes: true});
+
+// KNOWS rels
+MATCH (:Foo)-[rel:KNOWS]->(:Bar) 
+WITH collect(rel) as rels
+call apoc.export.graphml.data([], rels, 'queryRelationship.graphml', {useTypes: true})
+YIELD nodes, relationships RETURN nodes, relationships;
+----
+
+
+In this case we will have these 3 files:
+.queryNodesFoo.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="born" for="node" attr.name="born" attr.type="string"/>
+<key id="name" for="node" attr.name="name" attr.type="string"/>
+<key id="place" for="node" attr.name="place" attr.type="string"/>
+<key id="labels" for="node" attr.name="labels" attr.type="string"/>
+<graph id="G" edgedefault="directed">
+<node id="n0" labels=":Foo:Foo0:Foo2"><data key="labels">:Foo:Foo0:Foo2</data><data key="born">2018-10-10</data><data key="name">foo</data><data key="place">{"crs":"wgs-84-3d","latitude":12.78,"longitude":56.7,"height":100.0}</data></node>
+<node id="n3" labels=":Foo"><data key="labels">:Foo</data><data key="name">zzz</data></node>
+<node id="n5" labels=":Foo"><data key="labels">:Foo</data><data key="name">aaa</data></node>
+</graph>
+</graphml>
+----
+
+.queryNodesBar.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="name" for="node" attr.name="name" attr.type="string"/>
+<key id="place" for="node" attr.name="place" attr.type="string"/>
+<key id="age" for="node" attr.name="age" attr.type="long"/>
+<key id="labels" for="node" attr.name="labels" attr.type="string"/>
+<graph id="G" edgedefault="directed">
+<node id="n1" labels=":Bar"><data key="labels">:Bar</data><data key="name">bar</data><data key="age">42</data><data key="place">{"crs":"wgs-84","latitude":12.78,"longitude":56.7,"height":null}</data></node>
+<node id="n4" labels=":Bar"><data key="labels">:Bar</data><data key="age">0</data></node>
+<node id="n6" labels=":Bar"><data key="labels">:Bar</data><data key="age">666</data></node>
+</graph>
+</graphml>
+----
+
+.queryRelationship.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="label" for="edge" attr.name="label" attr.type="string"/>
+<key id="id" for="edge" attr.name="id" attr.type="long"/>
+<graph id="G" edgedefault="directed">
+<edge id="e0" source="n0" target="n1" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e1" source="n3" target="n4" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e2" source="n5" target="n6" label="KNOWS"><data key="label">KNOWS</data><data key="id">1</data></edge>
+</graph>
+</graphml>
+----
+
+So we can import, in another db, in this way, to recreate the original dataset, using these queries:
+[source,cypher]
+----
+CALL apoc.import.graphml('queryNodesFoo.graphml', {readLabels: true, storeNodeIds: true});
+CALL apoc.import.graphml('queryNodesBar.graphml', {readLabels: true, storeNodeIds: true});
+CALL apoc.import.graphml('queryRelationship.graphml', {readLabels: true, source: {label: 'Foo'}, target: {label: 'Bar'}});
+----
+
+Note that we have to execute the import of nodes before, 
+and we used the `useTypes: true` to import the attribute `id` of `node` tags as a property and `readLabels` to populate nodes with labels.
+
+
+=== With custom property key 
+
+Otherwise, we can leverage a custom property and avoid importing the `id` attribute (via `useTypes:true`) in this way (same dataset and nodes export query as before):
+[source,cypher]
+----
+// Foo nodes
+call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesFoo.graphml', {useTypes: true});
+
+// Bar nodes
+call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesBar.graphml', {useTypes: true});
+
+// KNOWS rels
+MATCH (:Foo)-[rel:KNOWS]->(:Bar) 
+WITH collect(rel) as rels
+call apoc.export.graphml.data([], rels, 'queryRelationship.graphml', {useTypes: true})
+YIELD nodes, relationships RETURN nodes, relationships;
+----
+with this rel file:
+
+.queryRelationship.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="label" for="edge" attr.name="label" attr.type="string"/>
+<key id="id" for="edge" attr.name="id" attr.type="long"/>
+<graph id="G" edgedefault="directed">
+<edge id="e0" source="foo" sourceType="string" target="42" targetType="long" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e1" source="zzz" sourceType="string" target="0" targetType="long" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e2" source="aaa" sourceType="string" target="666" targetType="long" label="KNOWS"><data key="label">KNOWS</data><data key="id">1</data></edge>
+</graph>
+</graphml>
+----
+
+Finally, we can import the files:
+[source,cypher]
+----
+CALL apoc.import.graphml('queryNodesFoo.graphml', {readLabels: true});
+CALL apoc.import.graphml('queryNodesBar.graphml', {readLabels: true});
+CALL apoc.import.graphml('queryRelationship.graphml', 
+  {readLabels: true, source: {label: 'Foo', id: 'name'}, target: {label: 'Bar', id: 'age'}});
+----

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.graphml.adoc
@@ -229,3 +229,6 @@ RETURN source, format, nodes, relationships, properties
 | source    | format    | nodes | relationships | properties
 | "binary"  | "graphml" | 2     | 1             | 7
 |===
+
+[[roundtip-separated-files]]
+include::partial$roundtripSeparatedGraphml.adoc[]

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.graphml.adoc
@@ -9,5 +9,19 @@ The procedure support the following config parameters:
 | storeNodeIds | Boolean | false | store the `id` property of `node` elements
 | batchSize | Integer | 20000 | The number of elements to process per transaction
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)
+| source | Map<String,String> | Empty map | See below
+| target | Map<String,String> | Empty map | See below
 See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example]
 |===
+
+=== source / target config
+
+Allows the import of relations in case the source and / or target nodes are not present in the file, searching for nodes via a custom label and property.
+To do this, we can insert into the config map `source: {label: '<MY_SOURCE_LABEL>', id: `'<MY_SOURCE_ID>'`}` and/or `source: {label: '<MY_TARGET_LABEL>', id: `'<MY_TARGET_ID>'`}`
+In this way, we can search start and end nodes via the source and end attribute of `edge` tag.
+
+For example, with a config map `{source: {id: 'myId', label: 'Foo'}, target: {id: 'other', label: 'Bar'}}`
+with a edge row like `<edge id="e0" source="n0" target="n1" label="KNOWS"><data key="label">KNOWS</data></edge>`
+we search a source node `(:Foo {myId: 'n0'})` and an end node `(:Bar {other: 'n1'})`.
+The id key is optional (the default is `'id'`).
+


### PR DESCRIPTION
Issue 2659

note:
```
this.label = Objects.requireNonNull(config.get("label"), 
```


Added 2 configs `source` and `target` with keys `label` and (optional) `id` to import rel-only files, e.g.:

```
call apoc.import.graphml("rels.graphml", {startLabel: 'Person', endLabel: 'Movie'})
```

<br>
<br>
<br>
<br>


Nb: La query del tizio è sbagliata --> with collect(DISTINCT person)+collect(DISTINCT movie) as node

