### PR TITLE
Issue 2739: Allow apoc.spatial.geoCodeOnce to also receive config via procedure call

### DIFF
--- a/core/src/main/java/apoc/spatial/Geocode.java
+++ b/core/src/main/java/apoc/spatial/Geocode.java
@@ -7,7 +7,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
 
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -285,33 +284,40 @@ public class Geocode {
         }
     }
 
-    private GeocodeSupplier getSupplier() {
+    private GeocodeSupplier getSupplier(Map<String, Object> configMap) {
         Configuration activeConfig = apocConfig().getConfig().subset(PREFIX);
-        if (activeConfig.containsKey(GEOCODE_PROVIDER_KEY)) {
-            String supplier = activeConfig.getString(GEOCODE_PROVIDER_KEY).toLowerCase();
-            switch (supplier) {
-                case "google" : return new GoogleSupplier(activeConfig, terminationGuard);
-                case "osm" : return new OSMSupplier(activeConfig,terminationGuard);
-                default: return new SupplierWithKey(activeConfig, terminationGuard, supplier);
-            }
+        // with configMap we overwrite the ApocConfig, if none of these is found, we choose the default one, 'osm'
+        final String provider = (String) configMap.getOrDefault(GEOCODE_PROVIDER_KEY,
+                activeConfig.getString(GEOCODE_PROVIDER_KEY, "osm"));
+        
+        configMap.forEach((key, value) -> {
+            // we transform e.g. key `reverseUrl` to `reverse.url`, consistently to ApocConfig
+            final String dotCase = key.replaceAll("[A-Z][a-z]", ".$0").toLowerCase();
+            activeConfig.setProperty(provider  + "." + dotCase, value);
+        });
+
+        String supplier = provider.toLowerCase();
+        switch (supplier) {
+            case "google" : return new GoogleSupplier(activeConfig, terminationGuard);
+            case "osm" : return new OSMSupplier(activeConfig,terminationGuard);
+            default: return new SupplierWithKey(activeConfig, terminationGuard, supplier);
         }
-        return new OSMSupplier(activeConfig, terminationGuard);
     }
 
     @Procedure
-    @Description("apoc.spatial.geocodeOnce('address') YIELD location, latitude, longitude, description, osmData - look up geographic location of address from a geocoding service (the default one is OpenStreetMap)")
-    public Stream<GeoCodeResult> geocodeOnce(@Name("location") String address) throws UnsupportedEncodingException {
-        return geocode(address, 1L, false);
+    @Description("apoc.spatial.geocodeOnce('address', $config) YIELD location, latitude, longitude, description, osmData - look up geographic location of address from a geocoding service (the default one is OpenStreetMap)")
+    public Stream<GeoCodeResult> geocodeOnce(@Name("location") String address, @Name(value="config", defaultValue = "{}") Map<String, Object> config) {
+        return geocode(address, 1L, false, config);
     }
 
     @Procedure
-    @Description("apoc.spatial.geocode('address') YIELD location, latitude, longitude, description, osmData - look up geographic location of address from a geocoding service (the default one is OpenStreetMap)")
-    public Stream<GeoCodeResult> geocode(@Name("location") String address, @Name(value = "maxResults",defaultValue = "100") long maxResults, @Name(value = "quotaException",defaultValue = "false") boolean quotaException) {
+    @Description("apoc.spatial.geocode('address', maxResults, quotaException, $config) YIELD location, latitude, longitude, description, osmData - look up geographic location of address from a geocoding service (the default one is OpenStreetMap)")
+    public Stream<GeoCodeResult> geocode(@Name("location") String address, @Name(value = "maxResults",defaultValue = "100") long maxResults, @Name(value = "quotaException",defaultValue = "false") boolean quotaException, @Name(value="config", defaultValue = "{}") Map<String, Object> config) {
         if (address == null || address.isEmpty())
             return Stream.empty();
         else {
             try {
-                return getSupplier().geocode(address, maxResults == 0 ? MAX_RESULTS : Math.min(Math.max(maxResults, 1), MAX_RESULTS));
+                return getSupplier(config).geocode(address, maxResults == 0 ? MAX_RESULTS : Math.min(Math.max(maxResults, 1), MAX_RESULTS));
             } catch (IllegalStateException re) {
                 if (!quotaException && re.getMessage().startsWith("QUOTA_EXCEEDED")) return Stream.empty();
                 throw re;
@@ -321,9 +327,9 @@ public class Geocode {
 
     @Procedure
     @Description("apoc.spatial.reverseGeocode(latitude,longitude) YIELD location, latitude, longitude, description - look up address from latitude and longitude from a geocoding service (the default one is OpenStreetMap)")
-    public Stream<GeoCodeResult> reverseGeocode(@Name("latitude") double latitude, @Name("longitude") double longitude, @Name(value = "quotaException",defaultValue = "false") boolean quotaException) {
+    public Stream<GeoCodeResult> reverseGeocode(@Name("latitude") double latitude, @Name("longitude") double longitude, @Name(value = "quotaException",defaultValue = "false") boolean quotaException, @Name(value="config", defaultValue = "{}") Map<String, Object> config) {
         try {
-            return getSupplier().reverseGeocode(latitude, longitude);
+            return getSupplier(config).reverseGeocode(latitude, longitude);
         } catch(IllegalStateException re) {
             if (!quotaException && re.getMessage().startsWith("QUOTA_EXCEEDED")) return Stream.empty();
             throw re;

--- a/core/src/test/resources/spatial.json
+++ b/core/src/test/resources/spatial.json
@@ -6,25 +6,36 @@
   "addresses": [
     {
       "address": "21 rue Paul Bellamy 44000 NANTES FRANCE",
-      "latitude": 47.2221667,
-      "longitude": -1.5566624
+      "osm": {
+        "latitude": 47.2221667,
+        "longitude": -1.5566624
+      }
     },
     {
       "address": "12 Rue Cubain 49000 Angers France",
-      "latitude": 47.4607430,
-      "longitude": -0.5453014
+      "osm": {
+        "latitude": 47.4607430,
+        "longitude": -0.5453014
+      }
     },
     {
       "_comment": "Test for unicode characters",
       "address": "Rämistrasse 71 8006 Zürich Switzerland",
-      "latitude": 47.37457,
-      "longitude": 8.54875
+      "osm": {
+        "latitude": 47.37457,
+        "longitude": 8.54875
+      },
+      "opencage": {
+        "latitude": 47.00016,
+        "longitude": 8.01427
+      }
     },
     {
       "address": "FRANCE",
       "count": {
         "google": 1,
-        "osm": 10
+        "osm": 10,
+        "opencage": 10
       }
     },
     {


### PR DESCRIPTION
Issue 2739

- Added config map to geocodeOnce, geocode, reverseGeocode procedures
- Updated docs

Other changes:
- Changed always-ignored test, even with assertion/other errors (`try{} catch() { Assume.assumeNoException("out of quota", e); `})
- Fixed openCage ignored tests (`spatial.json` file)