### PR TITLE
Export cypher overwrite in case of merge with multi-relationships [WAITING FOR FEEDBACK]

### DIFF
--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -20,6 +20,7 @@ import java.util.stream.StreamSupport;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_LABEL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_REL;
 
 /*
  * Idea is to lookup nodes for relationships via a unique index
@@ -196,7 +197,7 @@ public class MultiStatementCypherSubGraphExporter {
     }
 
     private void appendRelationship(PrintWriter out, Relationship rel, Reporter reporter) {
-        String cypher = this.cypherFormat.statementForRelationship(rel, uniqueConstraints, indexedProperties);
+        String cypher = this.cypherFormat.statementForRelationship(rel, uniqueConstraints, indexedProperties, exportConfig);
         if (cypher != null && !"".equals(cypher)) {
             out.println(cypher);
             reporter.update(0, 1, Iterables.count(rel.getPropertyKeys()));
@@ -209,7 +210,7 @@ public class MultiStatementCypherSubGraphExporter {
         List<String> indexesAndConstraints = new ArrayList<>();
         indexesAndConstraints.addAll(exportIndexes());
         indexesAndConstraints.addAll(exportConstraints());
-        if (indexesAndConstraints.isEmpty() && artificialUniques == 0) return;
+        if (indexesAndConstraints.isEmpty() && artificialUniques == 0 && !config.isCleanupUniqueIdRels()) return;
         begin(out);
         for (String index : indexesAndConstraints) {
             out.println(index);
@@ -219,6 +220,16 @@ public class MultiStatementCypherSubGraphExporter {
             if (cypher != null && !"".equals(cypher)) {
                 out.println(cypher);
             }
+        }
+        
+        if (config.isCleanupUniqueIdRels()) {
+            // add rel-indexes
+            graph.getAllRelationshipTypesInUse().forEach(type -> {
+                // TODO - this indexes should be deleted after cleanup, we need the index name, waiting for 2652 in branch 4.3+ to drop them
+                final String statement = this.cypherFormat
+                        .statementForIndexRelationship(type.name(), List.of(UNIQUE_ID_REL), true);
+                printIfNotEmpty(out, statement);
+            });
         }
         commit(out);
         if (graph.getIndexes().iterator().hasNext()) {
@@ -320,23 +331,46 @@ public class MultiStatementCypherSubGraphExporter {
     // ---- CleanUp ----
 
     private void exportCleanUp(PrintWriter out, int batchSize) {
-        if (artificialUniques > 0) {
-            while (artificialUniques > 0) {
-                String cypher = this.cypherFormat.statementForCleanUp(batchSize);
-                begin(out);
-                if (cypher != null && !"".equals(cypher)) {
-                    out.println(cypher);
+        exportCleanUp(null, out, batchSize, artificialUniques);
+        if (exportConfig.isCleanupUniqueIdRels()) {
+            graph.getAllRelationshipTypesInUse().forEach(type -> {
+                final long count = graph.countsForRelationship(type);
+                exportCleanUp(type, out, batchSize, count);
+            });
+        }
+    }
+    
+    private void printIfNotEmpty(PrintWriter out, String line) {
+        if (StringUtils.isNotEmpty(line)) {
+            out.println(line);
+        }
+    }
+    
+    private void exportCleanUp(RelationshipType type, PrintWriter out, int batchSize, Long entityCount) {
+        if (entityCount > 0) {
+            while (entityCount > 0) {
+                if (type == null) {
+                    // todo - not to cause breaking-change, a begin and commit is always printed, even with an empty body
+                    //  might be worth to remove these empty statements
+                    begin(out);
+                    printIfNotEmpty(out, this.cypherFormat.statementForCleanUp(batchSize));
+                    commit(out);
+                } else {
+                    final String statement = this.cypherFormat.statementForCleanUpRel(type, batchSize);
+                    if (StringUtils.isNotEmpty(statement)) {
+                        begin(out);
+                        out.println(statement);
+                        commit(out);
+                    }
                 }
+                entityCount -= batchSize;
+            }
+            if (type == null) {
+                begin(out);
+                printIfNotEmpty(out, this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false, StringUtils.EMPTY)
+                        .replaceAll("^CREATE", "DROP"));
                 commit(out);
-                artificialUniques -= batchSize;
             }
-            begin(out);
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false, StringUtils.EMPTY)
-                    .replaceAll("^CREATE", "DROP");
-            if (cypher != null && !"".equals(cypher)) {
-                out.println(cypher);
-            }
-            commit(out);
         }
         out.flush();
     }

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -20,7 +20,6 @@ import java.util.stream.StreamSupport;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_LABEL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
-import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_REL;
 
 /*
  * Idea is to lookup nodes for relationships via a unique index
@@ -210,7 +209,7 @@ public class MultiStatementCypherSubGraphExporter {
         List<String> indexesAndConstraints = new ArrayList<>();
         indexesAndConstraints.addAll(exportIndexes());
         indexesAndConstraints.addAll(exportConstraints());
-        if (indexesAndConstraints.isEmpty() && artificialUniques == 0 && !config.isCleanupUniqueIdRels()) return;
+        if (indexesAndConstraints.isEmpty() && artificialUniques == 0) return;
         begin(out);
         for (String index : indexesAndConstraints) {
             out.println(index);
@@ -220,16 +219,6 @@ public class MultiStatementCypherSubGraphExporter {
             if (cypher != null && !"".equals(cypher)) {
                 out.println(cypher);
             }
-        }
-        
-        if (config.isCleanupUniqueIdRels()) {
-            // add rel-indexes
-            graph.getAllRelationshipTypesInUse().forEach(type -> {
-                // TODO - this indexes should be deleted after cleanup, we need the index name, waiting for 2652 in branch 4.3+ to drop them
-                final String statement = this.cypherFormat
-                        .statementForIndexRelationship(type.name(), List.of(UNIQUE_ID_REL), true);
-                printIfNotEmpty(out, statement);
-            });
         }
         commit(out);
         if (graph.getIndexes().iterator().hasNext()) {
@@ -331,46 +320,23 @@ public class MultiStatementCypherSubGraphExporter {
     // ---- CleanUp ----
 
     private void exportCleanUp(PrintWriter out, int batchSize) {
-        exportCleanUp(null, out, batchSize, artificialUniques);
-        if (exportConfig.isCleanupUniqueIdRels()) {
-            graph.getAllRelationshipTypesInUse().forEach(type -> {
-                final long count = graph.countsForRelationship(type);
-                exportCleanUp(type, out, batchSize, count);
-            });
-        }
-    }
-    
-    private void printIfNotEmpty(PrintWriter out, String line) {
-        if (StringUtils.isNotEmpty(line)) {
-            out.println(line);
-        }
-    }
-    
-    private void exportCleanUp(RelationshipType type, PrintWriter out, int batchSize, Long entityCount) {
-        if (entityCount > 0) {
-            while (entityCount > 0) {
-                if (type == null) {
-                    // todo - not to cause breaking-change, a begin and commit is always printed, even with an empty body
-                    //  might be worth to remove these empty statements
-                    begin(out);
-                    printIfNotEmpty(out, this.cypherFormat.statementForCleanUp(batchSize));
-                    commit(out);
-                } else {
-                    final String statement = this.cypherFormat.statementForCleanUpRel(type, batchSize);
-                    if (StringUtils.isNotEmpty(statement)) {
-                        begin(out);
-                        out.println(statement);
-                        commit(out);
-                    }
-                }
-                entityCount -= batchSize;
-            }
-            if (type == null) {
+        if (artificialUniques > 0) {
+            while (artificialUniques > 0) {
+                String cypher = this.cypherFormat.statementForCleanUp(batchSize);
                 begin(out);
-                printIfNotEmpty(out, this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false, StringUtils.EMPTY)
-                        .replaceAll("^CREATE", "DROP"));
+                if (cypher != null && !"".equals(cypher)) {
+                    out.println(cypher);
+                }
                 commit(out);
+                artificialUniques -= batchSize;
             }
+            begin(out);
+            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false, StringUtils.EMPTY)
+                    .replaceAll("^CREATE", "DROP");
+            if (cypher != null && !"".equals(cypher)) {
+                out.println(cypher);
+            }
+            commit(out);
         }
         out.flush();
     }

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -21,7 +21,9 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_LABEL;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_REL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_REL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.quote;
 
 /**
@@ -41,6 +43,13 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		return "MATCH (n:" + Q_UNIQUE_ID_LABEL + ") " +
 				" WITH n LIMIT " + batchSize +
 				" REMOVE n:" + Q_UNIQUE_ID_LABEL + " REMOVE n." + quote(UNIQUE_ID_PROP) + ";";
+	}
+	
+	@Override
+	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
+		return String.format("MATCH ()-[rel:%1$s]->() WHERE rel.%2$s IS NOT NULL" +
+				" WITH rel LIMIT %3$s REMOVE rel.%2$s;",
+				Util.quote(type.name()), Q_UNIQUE_ID_REL, batchSize);
 	}
 
 	@Override
@@ -119,13 +128,16 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		return result.toString();
 	}
 
-	public String mergeStatementForRelationship(CypherFormat cypherFormat, Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
+	public String mergeStatementForRelationship(CypherFormat cypherFormat, Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
 		StringBuilder result = new StringBuilder(1000);
 		result.append("MATCH ");
 		result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));
 		result.append(", ");
 		result.append(CypherFormatterUtils.formatNodeLookup("n2", relationship.getEndNode(), uniqueConstraints, indexedProperties));
-		result.append(" MERGE (n1)-[r:" + CypherFormatterUtils.quote(relationship.getType().name()) + "]->(n2)");
+		String mergeUniqueKey = exportConfig.isUniqueIdRels()
+				? Util.toCypherMap(Map.of(UNIQUE_ID_REL, relationship.getId()))
+				: "";
+		result.append(" MERGE (n1)-[r:" + Util.quote(relationship.getType().name()) + mergeUniqueKey + "]->(n2)");
 		if (relationship.getPropertyKeys().iterator().hasNext()) {
 			result.append(cypherFormat.equals(CypherFormat.UPDATE_STRUCTURE) ? " ON CREATE SET " : " SET ");
 			result.append(CypherFormatterUtils.formatRelationshipProperties("r", relationship, false));
@@ -268,6 +280,9 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 						"start", new AbstractMap.SimpleImmutableEntry<>(startLabels, CypherFormatterUtils.getNodeIdProperties(start, uniqueConstraints).keySet()),
 						"end", new AbstractMap.SimpleImmutableEntry<>(endLabels, CypherFormatterUtils.getNodeIdProperties(end, uniqueConstraints).keySet()));
 
+				if (exportConfig.isUniqueIdRels()) {
+					key.put(UNIQUE_ID_REL, rel.getId());
+				}
 				tx.commit();
 				return key;
 			}
@@ -340,7 +355,10 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 		// create the relationship (depends on the strategy)
 		out.append(relationshipClause);
-		out.append("(start)-[r:" + Util.quote(path.get("type").toString()) + "]->(end) ");
+		String mergeUniqueKey = Optional.ofNullable(path.get(UNIQUE_ID_REL))
+				.map(val -> Util.toCypherMap(Map.of(UNIQUE_ID_REL, val)))
+				.orElse("");
+		out.append("(start)-[r:" + Util.quote(path.get("type").toString()) + mergeUniqueKey + "]->(end) ");
 		out.append(setClause);
 		out.append("r += row.properties;");
 		out.append(StringUtils.LF);

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -37,6 +37,8 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR (n:%s) ON EACH [%s];";
 	private static final String STATEMENT_REL_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR ()-[rel:%s]-() ON EACH [%s];";
+	public static final String PROPERTY_QUOTING_FORMAT = "'%s'";
+	private static final String ID_REL_KEY = "id";
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
@@ -280,9 +282,6 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 						"start", new AbstractMap.SimpleImmutableEntry<>(startLabels, CypherFormatterUtils.getNodeIdProperties(start, uniqueConstraints).keySet()),
 						"end", new AbstractMap.SimpleImmutableEntry<>(endLabels, CypherFormatterUtils.getNodeIdProperties(end, uniqueConstraints).keySet()));
 
-				if (exportConfig.isUniqueIdRels()) {
-					key.put(UNIQUE_ID_REL, rel.getId());
-				}
 				tx.commit();
 				return key;
 			}
@@ -315,6 +314,10 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 				writeRelationshipNodeIds(uniqueConstraints, out, start, startNode);
 
 				out.append(", ");
+				if (exportConfig.isUniqueIdRels()) {
+					String uniqueId = String.format("%s: %s, ", ID_REL_KEY, rel.getId());
+					out.append(uniqueId);
+				}
 
 				// end node
 				Node endNode = rel.getEndNode();
@@ -355,9 +358,9 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 		// create the relationship (depends on the strategy)
 		out.append(relationshipClause);
-		String mergeUniqueKey = Optional.ofNullable(path.get(UNIQUE_ID_REL))
-				.map(val -> Util.toCypherMap(Map.of(UNIQUE_ID_REL, val)))
-				.orElse("");
+		String mergeUniqueKey = (exportConfig.isUniqueIdRels())
+				? Util.toCypherMap(Map.of(UNIQUE_ID_REL, ID_REL_KEY))
+				: "";
 		out.append("(start)-[r:" + Util.quote(path.get("type").toString()) + mergeUniqueKey + "]->(end) ");
 		out.append(setClause);
 		out.append("r += row.properties;");

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -5,6 +5,7 @@ import apoc.export.util.ExportFormat;
 import apoc.export.util.Reporter;
 import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
+import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -23,8 +24,8 @@ import java.util.stream.StreamSupport;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_LABEL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_REL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
-import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_REL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.quote;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.simpleKeyValue;
 
 /**
  * @author AgileLARUS
@@ -37,7 +38,6 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR (n:%s) ON EACH [%s];";
 	private static final String STATEMENT_REL_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR ()-[rel:%s]-() ON EACH [%s];";
-	public static final String PROPERTY_QUOTING_FORMAT = "'%s'";
 	private static final String ID_REL_KEY = "id";
 
 	@Override
@@ -45,13 +45,6 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		return "MATCH (n:" + Q_UNIQUE_ID_LABEL + ") " +
 				" WITH n LIMIT " + batchSize +
 				" REMOVE n:" + Q_UNIQUE_ID_LABEL + " REMOVE n." + quote(UNIQUE_ID_PROP) + ";";
-	}
-	
-	@Override
-	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
-		return String.format("MATCH ()-[rel:%1$s]->() WHERE rel.%2$s IS NOT NULL" +
-				" WITH rel LIMIT %3$s REMOVE rel.%2$s;",
-				Util.quote(type.name()), Q_UNIQUE_ID_REL, batchSize);
 	}
 
 	@Override
@@ -133,13 +126,20 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	public String mergeStatementForRelationship(CypherFormat cypherFormat, Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
 		StringBuilder result = new StringBuilder(1000);
 		result.append("MATCH ");
-		result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));
+		final Node startNode = relationship.getStartNode();
+		result.append(CypherFormatterUtils.formatNodeLookup("n1", startNode, uniqueConstraints, indexedProperties));
 		result.append(", ");
-		result.append(CypherFormatterUtils.formatNodeLookup("n2", relationship.getEndNode(), uniqueConstraints, indexedProperties));
-		String mergeUniqueKey = exportConfig.isUniqueIdRels()
-				? Util.toCypherMap(Map.of(UNIQUE_ID_REL, relationship.getId()))
+		final Node endNode = relationship.getEndNode();
+		result.append(CypherFormatterUtils.formatNodeLookup("n2", endNode, uniqueConstraints, indexedProperties));
+		final RelationshipType type = relationship.getType();
+		final boolean withMultiRels = exportConfig.isMultipleRelationshipsWithType() &&
+				StreamSupport.stream(startNode.getRelationships(Direction.OUTGOING, type).spliterator(), false)
+						.anyMatch(r -> !r.equals(relationship) && r.getEndNode().equals(endNode));
+
+		String mergeUniqueKey = withMultiRels
+				? simpleKeyValue(Q_UNIQUE_ID_REL, relationship.getId())
 				: "";
-		result.append(" MERGE (n1)-[r:" + Util.quote(relationship.getType().name()) + mergeUniqueKey + "]->(n2)");
+		result.append(" MERGE (n1)-[r:" + Util.quote(type.name()) + mergeUniqueKey + "]->(n2)");
 		if (relationship.getPropertyKeys().iterator().hasNext()) {
 			result.append(cypherFormat.equals(CypherFormat.UPDATE_STRUCTURE) ? " ON CREATE SET " : " SET ");
 			result.append(CypherFormatterUtils.formatRelationshipProperties("r", relationship, false));
@@ -313,14 +313,17 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 				Node startNode = rel.getStartNode();
 				writeRelationshipNodeIds(uniqueConstraints, out, start, startNode);
 
+				Node endNode = rel.getEndNode();
+				final boolean withMultipleRels = exportConfig.isMultipleRelationshipsWithType() && 
+						relationshipList.stream()
+								.anyMatch(r -> !r.equals(rel) && r.getEndNode().equals(endNode) && r.getStartNode().equals(startNode));
 				out.append(", ");
-				if (exportConfig.isUniqueIdRels()) {
+				if (withMultipleRels) {
 					String uniqueId = String.format("%s: %s, ", ID_REL_KEY, rel.getId());
 					out.append(uniqueId);
 				}
 
 				// end node
-				Node endNode = rel.getEndNode();
 				writeRelationshipNodeIds(uniqueConstraints, out, end, endNode);
 
 				// properties
@@ -333,7 +336,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 				out.append("}");
 
 				if (last.equals(rel) || isBatchMatch(exportConfig, batchCount) || isUnwindBatchMatch(exportConfig, unwindCount)) {
-					closeUnwindRelationships(relationshipClause, setClause, uniqueConstraints, exportConfig, out, start, end, path, last);
+					closeUnwindRelationships(relationshipClause, setClause, uniqueConstraints, exportConfig, out, start, end, path, last, withMultipleRels);
 					writeBatchEnd(exportConfig, out, batchCount);
 					unwindCount.set(0);
 				} else {
@@ -346,7 +349,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		reporter.update(0, relCount.get(), propertiesCount.longValue());
 	}
 
-	private void closeUnwindRelationships(String relationshipClause, String setClause, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, String start, String end, Map<String, Object> path, Relationship last) {
+	private void closeUnwindRelationships(String relationshipClause, String setClause, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, String start, String end, Map<String, Object> path, Relationship last, boolean withMultipleRels) {
 		writeUnwindEnd(exportConfig, out);
 		// match start node
 		writeRelationshipMatchAsciiNode(last.getStartNode(), out, start, uniqueConstraints);
@@ -358,8 +361,8 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 		// create the relationship (depends on the strategy)
 		out.append(relationshipClause);
-		String mergeUniqueKey = (exportConfig.isUniqueIdRels())
-				? Util.toCypherMap(Map.of(UNIQUE_ID_REL, ID_REL_KEY))
+		String mergeUniqueKey = withMultipleRels
+				? simpleKeyValue(Q_UNIQUE_ID_REL, "row." + ID_REL_KEY)
 				: "";
 		out.append("(start)-[r:" + Util.quote(path.get("type").toString()) + mergeUniqueKey + "]->(end) ");
 		out.append(setClause);

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -5,7 +5,6 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -30,11 +29,6 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
-		return "";
-	}
-
-	@Override
-	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -5,6 +5,7 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -23,12 +24,17 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-		return new CreateCypherFormatter().statementForRelationship(relationship, uniqueConstraints, indexedProperties);
+	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
+		return new CreateCypherFormatter().statementForRelationship(relationship, uniqueConstraints, indexedProperties, exportConfig);
 	}
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
+		return "";
+	}
+
+	@Override
+	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
@@ -36,7 +36,7 @@ public class CreateCypherFormatter extends AbstractCypherFormatter implements Cy
     }
 
     @Override
-    public String statementForRelationship(Relationship relationship,  Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
+    public String statementForRelationship(Relationship relationship,  Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
         StringBuilder result = new StringBuilder(100);
         result.append("MATCH ");
         result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -30,8 +30,6 @@ public interface CypherFormatter {
 	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String name);
 
 	String statementForCleanUp(int batchSize);
-	
-	String statementForCleanUpRel(RelationshipType type, int batchSize);
 
 	void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -17,7 +17,7 @@ public interface CypherFormatter {
 
 	String statementForNode(Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames);
 
-	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties);
+	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig);
 
 	String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExist, String idxName);
 
@@ -30,6 +30,8 @@ public interface CypherFormatter {
 	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String name);
 
 	String statementForCleanUp(int batchSize);
+	
+	String statementForCleanUpRel(RelationshipType type, int batchSize);
 
 	void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -279,4 +279,8 @@ public class CypherFormatterUtils {
     public static String cypherNode(Label label) {
         return String.format("(%s)", label == null ? "" : ":" + Util.quote(label.name()));
     }
+    
+    public static String simpleKeyValue(String key, Object value) {
+        return String.format("{%s:%s}", key, value);
+    }
 }

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -27,6 +27,8 @@ public class CypherFormatterUtils {
     public final static String UNIQUE_ID_LABEL = "UNIQUE IMPORT LABEL";
     public final static String UNIQUE_ID_PROP = "UNIQUE IMPORT ID";
     public final static String Q_UNIQUE_ID_LABEL = quote(UNIQUE_ID_LABEL);
+    public final static String UNIQUE_ID_REL = "UNIQUE IMPORT ID REL";
+    public final static String Q_UNIQUE_ID_REL = quote(UNIQUE_ID_REL);
 
     public final static String FUNCTION_TEMPLATE = "%s('%s')";
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
@@ -23,8 +23,8 @@ public class UpdateAllCypherFormatter extends AbstractCypherFormatter implements
 	}
 
 	@Override
-	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-        return super.mergeStatementForRelationship(CypherFormat.UPDATE_ALL, relationship, uniqueConstraints, indexedProperties);
+	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
+        return super.mergeStatementForRelationship(CypherFormat.UPDATE_ALL, relationship, uniqueConstraints, indexedProperties, exportConfig);
 	}
 
 	@Override

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -5,7 +5,6 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -30,11 +29,6 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
-		return "";
-	}
-
-	@Override
-	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -5,6 +5,7 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -23,12 +24,17 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-        return super.mergeStatementForRelationship(CypherFormat.UPDATE_STRUCTURE, relationship, uniqueConstraints, indexedProperties);
+	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
+        return super.mergeStatementForRelationship(CypherFormat.UPDATE_STRUCTURE, relationship, uniqueConstraints, indexedProperties, exportConfig);
 	}
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
+		return "";
+	}
+
+	@Override
+	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -15,7 +15,8 @@ import static java.util.Arrays.asList;
  */
 public class ExportConfig extends CompressionConfig {
     public static final ExportConfig EMPTY = new ExportConfig(null);
-    
+    public static final String RELS_WITH_TYPE_KEY = "multipleRelationshipsWithType";
+
     public static class NodeConfig {
         public String label;
         public String id;
@@ -44,8 +45,7 @@ public class ExportConfig extends CompressionConfig {
 
     private int batchSize;
     private boolean silent;
-    private boolean uniqueIdRels; 
-    private boolean cleanupUniqueRels;
+    private boolean multipleRelationshipsWithType; 
     private boolean saveIndexNames;
     private boolean saveConstraintNames;
     private boolean bulkImport = false;
@@ -103,12 +103,8 @@ public class ExportConfig extends CompressionConfig {
 
     public CypherFormat getCypherFormat() { return cypherFormat; }
 
-    public boolean isUniqueIdRels() {
-        return uniqueIdRels;
-    }
-
-    public boolean isCleanupUniqueIdRels() {
-        return cleanupUniqueRels;
+    public boolean isMultipleRelationshipsWithType() {
+        return multipleRelationshipsWithType;
     }
 
     public ExportConfig(Map<String,Object> config) {
@@ -138,8 +134,7 @@ public class ExportConfig extends CompressionConfig {
         this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
-        this.uniqueIdRels = toBoolean(config.get("uniqueIdRels"));
-        this.cleanupUniqueRels = toBoolean(config.getOrDefault("cleanupUniqueRels", uniqueIdRels));
+        this.multipleRelationshipsWithType = toBoolean(config.get(RELS_WITH_TYPE_KEY));
         this.source = new NodeConfig((Map<String, String>) config.get("source"));
         this.target = new NodeConfig((Map<String, String>) config.get("target"));
         validate();

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -44,6 +44,8 @@ public class ExportConfig extends CompressionConfig {
 
     private int batchSize;
     private boolean silent;
+    private boolean uniqueIdRels; 
+    private boolean cleanupUniqueRels;
     private boolean saveIndexNames;
     private boolean saveConstraintNames;
     private boolean bulkImport = false;
@@ -101,6 +103,14 @@ public class ExportConfig extends CompressionConfig {
 
     public CypherFormat getCypherFormat() { return cypherFormat; }
 
+    public boolean isUniqueIdRels() {
+        return uniqueIdRels;
+    }
+
+    public boolean isCleanupUniqueIdRels() {
+        return cleanupUniqueRels;
+    }
+
     public ExportConfig(Map<String,Object> config) {
         super(config);
         config = config != null ? config : Collections.emptyMap();
@@ -128,6 +138,8 @@ public class ExportConfig extends CompressionConfig {
         this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
+        this.uniqueIdRels = toBoolean(config.get("uniqueIdRels"));
+        this.cleanupUniqueRels = toBoolean(config.getOrDefault("cleanupUniqueRels", uniqueIdRels));
         this.source = new NodeConfig((Map<String, String>) config.get("source"));
         this.target = new NodeConfig((Map<String, String>) config.get("target"));
         validate();

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1,5 +1,6 @@
 package apoc.export.cypher;
 
+import apoc.cypher.Cypher;
 import apoc.graph.Graphs;
 import apoc.util.BinaryTestUtil;
 import apoc.util.CompressionAlgo;
@@ -12,19 +13,41 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
+import static apoc.export.cypher.ExportCypherTestUtils.CLEANUP;
+import static apoc.export.cypher.ExportCypherTestUtils.CLEANUP_EMPTY;
+import static apoc.export.cypher.ExportCypherTestUtils.NODES_MULTI_RELS;
+import static apoc.export.cypher.ExportCypherTestUtils.NODES_MULTI_RELS_ADD_STRUCTURE;
+import static apoc.export.cypher.ExportCypherTestUtils.NODES_MULTI_REL_CREATE;
+import static apoc.export.cypher.ExportCypherTestUtils.NODES_UNWIND;
+import static apoc.export.cypher.ExportCypherTestUtils.NODES_UNWIND_ADD_STRUCTURE;
+import static apoc.export.cypher.ExportCypherTestUtils.NODES_UNWIND_UPDATE_STRUCTURE;
+import static apoc.export.cypher.ExportCypherTestUtils.RELSUPDATE_STRUCTURE_2;
+import static apoc.export.cypher.ExportCypherTestUtils.RELS_ADD_STRUCTURE_MULTI_RELS;
+import static apoc.export.cypher.ExportCypherTestUtils.RELS_MULTI_RELS;
+import static apoc.export.cypher.ExportCypherTestUtils.RELS_UNWIND_MULTI_RELS;
+import static apoc.export.cypher.ExportCypherTestUtils.RELS_UNWIND_UPDATE_ALL_MULTI_RELS;
+import static apoc.export.cypher.ExportCypherTestUtils.SCHEMA_MULTI_REL;
+import static apoc.export.cypher.ExportCypherTestUtils.SCHEMA_UPDATE_STRUCTURE_MULTI_REL;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_REL;
 import static apoc.export.util.ExportFormat.*;
 import static apoc.util.BinaryTestUtil.getDecompressedData;
 import static apoc.util.Util.map;
@@ -62,7 +85,10 @@ public class ExportCypherTest {
     @Before
     public void setUp() throws Exception {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
-        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
+        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class, Cypher.class);
+        if (testName.getMethodName().endsWith("MultiRel")) {
+            return; // we exclude setUp query statement in order to lighten assertions
+        }
         db.executeTransactionally("CREATE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name)");
         db.executeTransactionally("CREATE INDEX fooIndex FOR (n:Foo) ON (n.name)");
         db.executeTransactionally("CREATE CONSTRAINT consBar ON (n:Bar) ASSERT (n.name) IS UNIQUE");
@@ -91,6 +117,174 @@ public class ExportCypherTest {
         });
     }
 
+    
+    @Test
+    public void teastMultiRel() {
+        String expectedCypherStatement = NODES_MULTI_RELS + SCHEMA_MULTI_REL + RELS_MULTI_RELS + CLEANUP;
+        final Map<String, Object> map = withoutOptimization(
+                map("cypherFormat", "updateAll"));
+
+        multiRelTestsCommon(expectedCypherStatement, map);
+    }
+    
+    @Test
+    public void cypherFormatOptimizationNonedMultiRel() {
+        String expectedCypherStatement = NODES_MULTI_REL_CREATE + SCHEMA_MULTI_REL + RELS_ADD_STRUCTURE_MULTI_RELS + CLEANUP;
+        final Map<String, Object> map = withoutOptimization(
+                map("cypherFormat", "create"));
+
+        multiRelTestsCommon(expectedCypherStatement, map);
+    }
+    
+    @Test
+    public void addStructureOptimizationNoneMultiRel() {
+        String expectedCypherStatement = NODES_MULTI_RELS_ADD_STRUCTURE + SCHEMA_UPDATE_STRUCTURE_MULTI_REL + RELS_ADD_STRUCTURE_MULTI_RELS + CLEANUP_EMPTY;
+        final Map<String, Object> map = withoutOptimization(
+                map( "cypherFormat", "addStructure"));
+        multiRelTestsCommon(expectedCypherStatement, map);
+    }
+    
+    @Test
+    public void updateStructureOptimizationNoneMultiRel() {
+        String expectedCypherStatement = ":begin\n:commit\n" + SCHEMA_UPDATE_STRUCTURE_MULTI_REL + RELSUPDATE_STRUCTURE_2 + CLEANUP_EMPTY;
+        final Map<String, Object> map = withoutOptimization(
+                map("cypherFormat", "updateStructure"));
+
+        multiRelTestsCommon(expectedCypherStatement, map, true, true);
+    }
+    
+    
+    @Test
+    public void updateAllMultiRel() {
+        String expectedCypherStatement = SCHEMA_MULTI_REL + NODES_UNWIND_UPDATE_STRUCTURE + RELS_UNWIND_UPDATE_ALL_MULTI_RELS + CLEANUP;
+        final Map<String, Object> map = withOptimizationSmallBatch(
+                map("cypherFormat", "updateAll"));
+
+        multiRelTestsCommon(expectedCypherStatement, map);
+    }
+    
+    @Test
+    public void createMultiRel() {
+        String expectedCypherStatement = SCHEMA_MULTI_REL + NODES_UNWIND + RELS_UNWIND_MULTI_RELS + CLEANUP;
+        final Map<String, Object> map = withOptimizationSmallBatch(
+                map("cypherFormat", "create"));
+
+        multiRelTestsCommon(expectedCypherStatement, map);
+    }
+    
+    @Test
+    public void addStructureMultiRel() {
+        String expectedCypherStatement = SCHEMA_UPDATE_STRUCTURE_MULTI_REL + NODES_UNWIND_ADD_STRUCTURE + RELS_UNWIND_MULTI_RELS + CLEANUP_EMPTY;
+        final Map<String, Object> map = withOptimizationSmallBatch
+                (map("cypherFormat", "addStructure"));
+
+        multiRelTestsCommon(expectedCypherStatement, map);
+    }
+    
+    @Test
+    public void addStructureWithoutCleanupMultiRel() {
+        String expectedCypherStatement = SCHEMA_UPDATE_STRUCTURE_MULTI_REL + NODES_UNWIND_ADD_STRUCTURE + RELS_UNWIND_MULTI_RELS + CLEANUP_EMPTY;
+        final Map<String, Object> map = withOptimizationSmallBatch
+                (map("cypherFormat", "addStructure", "cleanup", false));
+
+        multiRelTestsCommon(expectedCypherStatement, map, false, true);
+    }
+    
+    @Test
+    public void updateStructureMultiRel() {
+        String expectedCypherStatement = SCHEMA_UPDATE_STRUCTURE_MULTI_REL + RELS_UNWIND_UPDATE_ALL_MULTI_RELS + CLEANUP_EMPTY;
+        final Map<String, Object> map = withOptimizationSmallBatch(
+                map("cypherFormat", "updateStructure"));
+
+        multiRelTestsCommon(expectedCypherStatement, map, true, true);
+    }
+
+    private Map<String, Object> withoutOptimization(Map<String, Object> map) {
+        map.put("useOptimizations", map("type", "none"));
+        return map;
+    }
+
+    private Map<String, Object> withOptimizationSmallBatch(Map<String, Object> map) {
+        map.put("useOptimizations", map("type", "unwind_batch", "unwindBatchSize", 5L));
+        return map;
+    }
+
+    private void multiRelTestsCommon(String expectedCypherStatement, Map<String, Object> otherConfigs) {
+        multiRelTestsCommon(expectedCypherStatement, otherConfigs, false, false);
+    }
+
+    private void multiRelTestsCommon(String expectedCypherStatement, Map<String, Object> otherConfigs, boolean recreateNodes, boolean withRelId) {
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+        // we create a :Person node with a triple rel with :Project node and other 2 single rels
+        db.executeTransactionally("create (pers:Person {name: 'MyName'})-[:WORKS_FOR {id: 1}]->(proj:Project {a: 1}), \n" +
+                "(pers)-[:WORKS_FOR {id: 2}]->(proj), " +
+                "(pers)-[:WORKS_FOR {id: 2}]->(proj), \n" +
+                "(pers)-[:WORKS_FOR {id: 3}]->(proj), \n" +
+                "(pers)-[:WORKS_FOR {id: 4}]->(proj), \n" +
+                "(pers)-[:WORKS_FOR {id: 5}]->(proj), \n" +
+                "(pers)-[:IS_TEAM_MEMBER_OF {name: 'aaa'}]->(:Team {name: 'one'}),\n" +
+                "(pers)-[:IS_TEAM_MEMBER_OF {name: 'eee'}]->(:Team {name: 'two'})");
+        
+        multiRelConsistencyCheck(false);
+
+        // all test with batch size, to ensure it works and with uniqueIdRels: true
+        final Map<String, Object> config = map("stream", true, "uniqueIdRels", true, "batchSize", 5);
+        config.putAll(otherConfigs);
+        final String cypherStatements = db.executeTransactionally("CALL apoc.export.cypher.all(null, $config)", 
+                map("config",  config), 
+                r -> Iterators.stream(r.<String>columnAs("cypherStatements")).collect(Collectors.joining("\n")));
+        
+        // check cypherStatements result
+        assertEquals(expectedCypherStatement, cypherStatements.replace("  ", " "));
+        
+        // delete and recreate using export nodeStatements, relationshipStatements
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+
+        // re-create all
+        if (recreateNodes) {
+            // for 'cypherFormat: updateStructure', because doesn't create nodes, only match them
+            db.executeTransactionally("CREATE (:Person:`UNIQUE IMPORT LABEL`{name: 'MyName', `UNIQUE IMPORT ID`:0}), " +
+                    "(:Project:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1})," +
+                    "(:Team:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2, name: 'one'})," +
+                    "(:Team:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3, name: 'two'})");
+        }
+        db.executeTransactionally("call apoc.cypher.runMany($statements, {})", map("statements", cypherStatements));
+
+        // check that before and after import the results are equivalents
+        multiRelConsistencyCheck(withRelId);
+    }
+
+    private void multiRelConsistencyCheck(boolean withRelId) {
+        TestUtil.testResult(db, "match p=(start:Person {name: 'MyName'})-[rel:WORKS_FOR]->(end:Project) return rel ORDER BY rel.id", r -> {
+            final ResourceIterator<Relationship> rels = r.columnAs("rel");
+            Relationship next = rels.next();
+            final Node startNode = next.getStartNode();
+            final Node endNode = next.getEndNode();
+            if (withRelId) {
+                assertTrue(next.hasProperty(UNIQUE_ID_REL));
+            }
+            assertEquals(1L, next.getProperty("id"));
+            multiRelAssertions(rels.next(), startNode, endNode, 2L, withRelId);
+            multiRelAssertions(rels.next(), startNode, endNode, 2L, withRelId);
+            multiRelAssertions(rels.next(), startNode, endNode, 3L, withRelId);
+            multiRelAssertions(rels.next(), startNode, endNode, 4L, withRelId);
+            multiRelAssertions(rels.next(), startNode, endNode, 5L, withRelId);
+            assertFalse(rels.hasNext());
+        });
+
+        final List<Object> teams = TestUtil.firstColumn(db, "match p=(start {name: 'MyName'})-[rel:IS_TEAM_MEMBER_OF]->(end:Team) return end.name order by end.name");
+        assertEquals(List.of("one", "two"), teams);
+    }
+
+    private void multiRelAssertions(Relationship next, Node startNode, Node endNode, long id, boolean withRelId) {
+        assertEquals(startNode, next.getStartNode());
+        assertEquals(endNode, next.getEndNode());
+        assertEquals(id, next.getProperty("id"));
+        if (withRelId) {
+            assertTrue(next.hasProperty(UNIQUE_ID_REL));
+        }
+    }
+    
     @Test
     public void testExportAllCypherStreaming() {
         final String query = "CALL apoc.export.cypher.all(null,{useOptimizations: { type: 'none'}, streamStatements:true,batchSize:3, format: 'neo4j-shell'})";

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
-import static apoc.export.cypher.ExportCypherTestUtils.CLEANUP;
+import static apoc.export.cypher.ExportCypherTestUtils.CLEANUP_SMALL_BATCH;
 import static apoc.export.cypher.ExportCypherTestUtils.CLEANUP_EMPTY;
 import static apoc.export.cypher.ExportCypherTestUtils.NODES_MULTI_RELS;
 import static apoc.export.cypher.ExportCypherTestUtils.NODES_MULTI_RELS_ADD_STRUCTURE;
@@ -45,9 +45,10 @@ import static apoc.export.cypher.ExportCypherTestUtils.RELS_ADD_STRUCTURE_MULTI_
 import static apoc.export.cypher.ExportCypherTestUtils.RELS_MULTI_RELS;
 import static apoc.export.cypher.ExportCypherTestUtils.RELS_UNWIND_MULTI_RELS;
 import static apoc.export.cypher.ExportCypherTestUtils.RELS_UNWIND_UPDATE_ALL_MULTI_RELS;
-import static apoc.export.cypher.ExportCypherTestUtils.SCHEMA_MULTI_REL;
+import static apoc.export.cypher.ExportCypherTestUtils.SCHEMA_WITH_UNIQUE_IMPORT_ID;
 import static apoc.export.cypher.ExportCypherTestUtils.SCHEMA_UPDATE_STRUCTURE_MULTI_REL;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_REL;
+import static apoc.export.util.ExportConfig.RELS_WITH_TYPE_KEY;
 import static apoc.export.util.ExportFormat.*;
 import static apoc.util.BinaryTestUtil.getDecompressedData;
 import static apoc.util.Util.map;
@@ -120,7 +121,7 @@ public class ExportCypherTest {
     
     @Test
     public void teastMultiRel() {
-        String expectedCypherStatement = NODES_MULTI_RELS + SCHEMA_MULTI_REL + RELS_MULTI_RELS + CLEANUP;
+        String expectedCypherStatement = NODES_MULTI_RELS + SCHEMA_WITH_UNIQUE_IMPORT_ID + RELS_MULTI_RELS + CLEANUP_SMALL_BATCH;
         final Map<String, Object> map = withoutOptimization(
                 map("cypherFormat", "updateAll"));
 
@@ -129,7 +130,7 @@ public class ExportCypherTest {
     
     @Test
     public void cypherFormatOptimizationNonedMultiRel() {
-        String expectedCypherStatement = NODES_MULTI_REL_CREATE + SCHEMA_MULTI_REL + RELS_ADD_STRUCTURE_MULTI_RELS + CLEANUP;
+        String expectedCypherStatement = NODES_MULTI_REL_CREATE + SCHEMA_WITH_UNIQUE_IMPORT_ID + RELS_ADD_STRUCTURE_MULTI_RELS + CLEANUP_SMALL_BATCH;
         final Map<String, Object> map = withoutOptimization(
                 map("cypherFormat", "create"));
 
@@ -156,7 +157,7 @@ public class ExportCypherTest {
     
     @Test
     public void updateAllMultiRel() {
-        String expectedCypherStatement = SCHEMA_MULTI_REL + NODES_UNWIND_UPDATE_STRUCTURE + RELS_UNWIND_UPDATE_ALL_MULTI_RELS + CLEANUP;
+        String expectedCypherStatement = SCHEMA_WITH_UNIQUE_IMPORT_ID + NODES_UNWIND_UPDATE_STRUCTURE + RELS_UNWIND_UPDATE_ALL_MULTI_RELS + CLEANUP_SMALL_BATCH;
         final Map<String, Object> map = withOptimizationSmallBatch(
                 map("cypherFormat", "updateAll"));
 
@@ -165,7 +166,7 @@ public class ExportCypherTest {
     
     @Test
     public void createMultiRel() {
-        String expectedCypherStatement = SCHEMA_MULTI_REL + NODES_UNWIND + RELS_UNWIND_MULTI_RELS + CLEANUP;
+        String expectedCypherStatement = SCHEMA_WITH_UNIQUE_IMPORT_ID + NODES_UNWIND + RELS_UNWIND_MULTI_RELS + CLEANUP_SMALL_BATCH;
         final Map<String, Object> map = withOptimizationSmallBatch(
                 map("cypherFormat", "create"));
 
@@ -227,8 +228,8 @@ public class ExportCypherTest {
         
         multiRelConsistencyCheck(false);
 
-        // all test with batch size, to ensure it works and with uniqueIdRels: true
-        final Map<String, Object> config = map("stream", true, "uniqueIdRels", true, "batchSize", 5);
+        // all test with batch size, to ensure it works correctly and with multipleRelationshipsWithType: true
+        final Map<String, Object> config = map("stream", true, RELS_WITH_TYPE_KEY, true, "batchSize", 5);
         config.putAll(otherConfigs);
         final String cypherStatements = db.executeTransactionally("CALL apoc.export.cypher.all(null, $config)", 
                 map("config",  config), 

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
@@ -76,78 +76,38 @@ public class ExportCypherTestUtils {
             ":commit\n";
 
     protected final static String RELS_UNWIND_MULTI_RELS = ":begin\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:5}}] AS row\n" +
+            "UNWIND [{start: {_id:0}, id: 6, end: {_id:2}, properties:{name:\"aaa\"}}, {start: {_id:0}, id: 7, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:1}}] AS row\n" +
+            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, id: 0, end: {_id:1}, properties:{id:1}}, {start: {_id:0}, id: 1, end: {_id:1}, properties:{id:2}}, {start: {_id:0}, id: 2, end: {_id:1}, properties:{id:2}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:3}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:4}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(end) SET r += row.properties;\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
             ":commit\n" +
             ":begin\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}] AS row\n" +
+            "UNWIND [{start: {_id:0}, id: 3, end: {_id:1}, properties:{id:3}}, {start: {_id:0}, id: 4, end: {_id:1}, properties:{id:4}}, {start: {_id:0}, id: 5, end: {_id:1}, properties:{id:5}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(end) SET r += row.properties;\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
             ":commit\n" +
             "\n";
 
     protected final static String RELS_UNWIND_UPDATE_ALL_MULTI_RELS = ":begin\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:5}}] AS row\n" +
+            "UNWIND [{start: {_id:0}, id: 6, end: {_id:2}, properties:{name:\"aaa\"}}, {start: {_id:0}, id: 7, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:1}}] AS row\n" +
+            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, id: 0, end: {_id:1}, properties:{id:1}}, {start: {_id:0}, id: 1, end: {_id:1}, properties:{id:2}}, {start: {_id:0}, id: 2, end: {_id:1}, properties:{id:2}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:3}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:4}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(end) SET r += row.properties;\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
             ":commit\n" +
             ":begin\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}] AS row\n" +
+            "UNWIND [{start: {_id:0}, id: 3, end: {_id:1}, properties:{id:3}}, {start: {_id:0}, id: 4, end: {_id:1}, properties:{id:4}}, {start: {_id:0}, id: 5, end: {_id:1}, properties:{id:5}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(end) SET r += row.properties;\n" +
-            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
-            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
-            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(end) SET r += row.properties;\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
             ":commit\n\n";
 
     protected final static String RELS_ADD_STRUCTURE_MULTI_RELS = ":begin\n" +

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
@@ -1,0 +1,199 @@
+package apoc.export.cypher;
+
+public class ExportCypherTestUtils {
+    protected final static String NODES_MULTI_RELS = ":begin\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) SET n.name=\"MyName\", n:Person;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) SET n.a=1, n:Project;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) SET n.name=\"one\", n:Team;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) SET n.name=\"two\", n:Team;\n" +
+            ":commit\n";
+
+    protected final static String NODES_MULTI_RELS_ADD_STRUCTURE = ":begin\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) ON CREATE SET n.name=\"MyName\", n:Person;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) ON CREATE SET n.a=1, n:Project;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) ON CREATE SET n.name=\"one\", n:Team;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) ON CREATE SET n.name=\"two\", n:Team;\n" +
+            ":commit\n";
+
+    protected final static String NODES_UNWIND = ":begin\n" +
+            "UNWIND [{_id:1, properties:{a:1}}] AS row\n" +
+            "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Project;\n" +
+            "UNWIND [{_id:2, properties:{name:\"one\"}}, {_id:3, properties:{name:\"two\"}}] AS row\n" +
+            "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Team;\n" +
+            "UNWIND [{_id:0, properties:{name:\"MyName\"}}] AS row\n" +
+            "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Person;\n" +
+            ":commit\n";
+
+    protected final static String NODES_UNWIND_ADD_STRUCTURE = ":begin\n" +
+            "UNWIND [{_id:1, properties:{a:1}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Project;\n" +
+            "UNWIND [{_id:2, properties:{name:\"one\"}}, {_id:3, properties:{name:\"two\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Team;\n" +
+            "UNWIND [{_id:0, properties:{name:\"MyName\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Person;\n" +
+            ":commit\n";
+
+    protected final static String NODES_UNWIND_UPDATE_STRUCTURE = ":begin\n" +
+            "UNWIND [{_id:1, properties:{a:1}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Project;\n" +
+            "UNWIND [{_id:2, properties:{name:\"one\"}}, {_id:3, properties:{name:\"two\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Team;\n" +
+            "UNWIND [{_id:0, properties:{name:\"MyName\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Person;\n" +
+            ":commit\n";
+
+    protected final static String NODES_MULTI_REL_CREATE = ":begin\n" +
+            "CREATE (:Person:`UNIQUE IMPORT LABEL` {name:\"MyName\", `UNIQUE IMPORT ID`:0});\n" +
+            "CREATE (:Project:`UNIQUE IMPORT LABEL` {a:1, `UNIQUE IMPORT ID`:1});\n" +
+            "CREATE (:Team:`UNIQUE IMPORT LABEL` {name:\"one\", `UNIQUE IMPORT ID`:2});\n" +
+            "CREATE (:Team:`UNIQUE IMPORT LABEL` {name:\"two\", `UNIQUE IMPORT ID`:3});\n" +
+            ":commit\n";
+
+    protected final static String SCHEMA_MULTI_REL = ":begin\n" +
+            "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n" +
+            "CREATE INDEX IF NOT EXISTS FOR ()-[rel:WORKS_FOR]-() ON (rel.`UNIQUE IMPORT ID REL`);\n" +
+            "CREATE INDEX IF NOT EXISTS FOR ()-[rel:IS_TEAM_MEMBER_OF]-() ON (rel.`UNIQUE IMPORT ID REL`);\n" +
+            ":commit\n" +
+            "CALL db.awaitIndexes(300);\n";
+
+    protected final static String SCHEMA_UPDATE_STRUCTURE_MULTI_REL = ":begin\n" +
+            ":commit\n" +
+            "CALL db.awaitIndexes(300);\n";
+
+    protected final static String RELS_MULTI_RELS = ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(n2) SET r.id=1;\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(n2) SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(n2) SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(n2) SET r.id=3;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(n2) SET r.id=4;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(n2) SET r.id=5;\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(n2) SET r.name=\"aaa\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(n2) SET r.name=\"eee\";\n" +
+            ":commit\n";
+
+    protected final static String RELS_UNWIND_MULTI_RELS = ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:5}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:1}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:3}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:4}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(end) SET r += row.properties;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(end) SET r += row.properties;\n" +
+            ":commit\n" +
+            "\n";
+
+    protected final static String RELS_UNWIND_UPDATE_ALL_MULTI_RELS = ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:5}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:1}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:3}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:4}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(end) SET r += row.properties;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(end) SET r += row.properties;\n" +
+            ":commit\n\n";
+
+    protected final static String RELS_ADD_STRUCTURE_MULTI_RELS = ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:1}]->(n2);\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:2}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:2}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:3}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:4}]->(n2);\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:5}]->(n2);\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) CREATE (n1)-[r:IS_TEAM_MEMBER_OF {name:\"aaa\"}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) CREATE (n1)-[r:IS_TEAM_MEMBER_OF {name:\"eee\"}]->(n2);\n" +
+            ":commit\n";
+
+    protected final static String RELSUPDATE_STRUCTURE_2 = ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(n2) ON CREATE SET r.id=1;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(n2) ON CREATE SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(n2) ON CREATE SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(n2) ON CREATE SET r.id=3;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(n2) ON CREATE SET r.id=4;\n" +
+            "\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(n2) ON CREATE SET r.id=5;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(n2) ON CREATE SET r.name=\"aaa\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(n2) ON CREATE SET r.name=\"eee\";\n" +
+            ":commit\n";
+
+    protected final static String CLEANUP = ":begin\n" +
+            "MATCH (n:`UNIQUE IMPORT LABEL`) WITH n LIMIT 5 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH ()-[rel:WORKS_FOR]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH ()-[rel:WORKS_FOR]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH ()-[rel:IS_TEAM_MEMBER_OF]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
+            ":commit\n";
+
+    protected final static String CLEANUP_EMPTY = ":begin\n:commit\n:begin\n:commit\n";
+}

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
@@ -49,10 +49,8 @@ public class ExportCypherTestUtils {
             "CREATE (:Team:`UNIQUE IMPORT LABEL` {name:\"two\", `UNIQUE IMPORT ID`:3});\n" +
             ":commit\n";
 
-    protected final static String SCHEMA_MULTI_REL = ":begin\n" +
+    protected final static String SCHEMA_WITH_UNIQUE_IMPORT_ID = ":begin\n" +
             "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n" +
-            "CREATE INDEX IF NOT EXISTS FOR ()-[rel:WORKS_FOR]-() ON (rel.`UNIQUE IMPORT ID REL`);\n" +
-            "CREATE INDEX IF NOT EXISTS FOR ()-[rel:IS_TEAM_MEMBER_OF]-() ON (rel.`UNIQUE IMPORT ID REL`);\n" +
             ":commit\n" +
             "CALL db.awaitIndexes(300);\n";
 
@@ -71,15 +69,15 @@ public class ExportCypherTestUtils {
             ":begin\n" +
             "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(n2) SET r.id=5;\n" +
             "\n" +
-            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(n2) SET r.name=\"aaa\";\n" +
-            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(n2) SET r.name=\"eee\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF]->(n2) SET r.name=\"aaa\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF]->(n2) SET r.name=\"eee\";\n" +
             ":commit\n";
 
     protected final static String RELS_UNWIND_MULTI_RELS = ":begin\n" +
-            "UNWIND [{start: {_id:0}, id: 6, end: {_id:2}, properties:{name:\"aaa\"}}, {start: {_id:0}, id: 7, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}, {start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
+            "CREATE (start)-[r:IS_TEAM_MEMBER_OF]->(end) SET r += row.properties;\n" +
             "UNWIND [{start: {_id:0}, id: 0, end: {_id:1}, properties:{id:1}}, {start: {_id:0}, id: 1, end: {_id:1}, properties:{id:2}}, {start: {_id:0}, id: 2, end: {_id:1}, properties:{id:2}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
@@ -94,10 +92,10 @@ public class ExportCypherTestUtils {
             "\n";
 
     protected final static String RELS_UNWIND_UPDATE_ALL_MULTI_RELS = ":begin\n" +
-            "UNWIND [{start: {_id:0}, id: 6, end: {_id:2}, properties:{name:\"aaa\"}}, {start: {_id:0}, id: 7, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}, {start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
-            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:row.id}]->(end) SET r += row.properties;\n" +
+            "MERGE (start)-[r:IS_TEAM_MEMBER_OF]->(end) SET r += row.properties;\n" +
             "UNWIND [{start: {_id:0}, id: 0, end: {_id:1}, properties:{id:1}}, {start: {_id:0}, id: 1, end: {_id:1}, properties:{id:2}}, {start: {_id:0}, id: 2, end: {_id:1}, properties:{id:2}}] AS row\n" +
             "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
             "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
@@ -135,24 +133,15 @@ public class ExportCypherTestUtils {
             ":commit\n" +
             ":begin\n" +
             "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(n2) ON CREATE SET r.id=5;\n" +
-            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(n2) ON CREATE SET r.name=\"aaa\";\n" +
-            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(n2) ON CREATE SET r.name=\"eee\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF]->(n2) ON CREATE SET r.name=\"aaa\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF]->(n2) ON CREATE SET r.name=\"eee\";\n" +
             ":commit\n";
 
-    protected final static String CLEANUP = ":begin\n" +
+    protected final static String CLEANUP_SMALL_BATCH = ":begin\n" +
             "MATCH (n:`UNIQUE IMPORT LABEL`) WITH n LIMIT 5 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;\n" +
             ":commit\n" +
             ":begin\n" +
             "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n" +
-            ":commit\n" +
-            ":begin\n" +
-            "MATCH ()-[rel:WORKS_FOR]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
-            ":commit\n" +
-            ":begin\n" +
-            "MATCH ()-[rel:WORKS_FOR]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
-            ":commit\n" +
-            ":begin\n" +
-            "MATCH ()-[rel:IS_TEAM_MEMBER_OF]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
             ":commit\n";
 
     protected final static String CLEANUP_EMPTY = ":begin\n:commit\n:begin\n:commit\n";

--- a/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
@@ -65,6 +65,7 @@ The procedures support the following config parameters:
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
 | saveIndexNames | boolean | false | Save name indexes on export
 | saveConstraintNames | boolean | false | Save name constraints on export
+| multipleRelationshipsWithType | boolean | false | In case of multiple relationships of the same type between two nodes, add a `UNIQUE IMPORT ID REL` property in order to distinguish them when using `MERGE`.
 |===
 
 [[export-cypher-file-export]]
@@ -705,6 +706,70 @@ RETURN nodes, relationships, properties, nodeStatements, relationshipStatements,
 
 We can then copy/paste the content of each of these columns (excluding the double quotes) into a Cypher Shell session, or into a local file that we stream into a Cypher Shell session.
 If we want to export Cypher statements that can be pasted into the Neo4j Browser query editor, we need to use the config `format: "plain"`, as described in <<export-cypher-neo4j-browser>>.
+
+[[export-cypher-multiple-relationships]]
+=== Export with multiple relationships with the same type
+
+With the following dataset:
+
+[source,cypher]
+----
+create (pers:Person {name: 'MyName'})-[:WORKS_FOR {id: 1}]->(proj:Project {a: 1}),
+    (pers)-[:WORKS_FOR {id: 2}]->(proj),
+    (pers)-[:WORKS_FOR {id: 2}]->(proj),
+    (pers)-[:WORKS_FOR {id: 3}]->(proj),
+    (pers)-[:WORKS_FOR {id: 4}]->(proj),
+    (pers)-[:WORKS_FOR {id: 5}]->(proj),
+    (pers)-[:IS_TEAM_MEMBER_OF {name: 'aaa'}]->(:Team {name: 'one'}),
+    (pers)-[:IS_TEAM_MEMBER_OF {name: 'eee'}]->(:Team {name: 'two'})
+----
+
+we can see that between `:Person` and `:Project` nodes, there are several relationships with the same type (`WORKS_FOR`).
+
+In these cases, if we export relationships via a `MERGE` clause,
+we must use the config `{multipleRelationshipsWithType: true}`, otherwise we cannot distinguish them, and a script would be exported which would create only one `WORKS_FOR` relationship. 
+
+For example, we can execute:
+[source,cypher]
+----
+CALL apoc.export.cypher.all(null, {stream: true, multipleRelationshipsWithType: true}) YIELD cypherStatements
+----
+
+.Results
+[opts="header"]
+|===
+| cypherStatements
+| ":begin
+CREATE CONSTRAINT ON (node:&#96;UNIQUE IMPORT LABEL&#96;) ASSERT (node.&#96;UNIQUE IMPORT ID&#96;) IS UNIQUE;
+:commit
+CALL db.awaitIndexes(300);
+:begin
+UNWIND [{_id:1, properties:{a:1}}] AS row
+CREATE (n:&#96;UNIQUE IMPORT LABEL&#96;{&#96;UNIQUE IMPORT ID&#96;: row._id}) SET n += row.properties SET n:Project;
+UNWIND [{_id:2, properties:{name:"one"}}, {_id:3, properties:{name:"two"}}] AS row
+CREATE (n:&#96;UNIQUE IMPORT LABEL&#96;{&#96;UNIQUE IMPORT ID&#96;: row._id}) SET n += row.properties SET n:Team;
+UNWIND [{_id:0, properties:{name:"MyName"}}] AS row
+CREATE (n:&#96;UNIQUE IMPORT LABEL&#96;{&#96;UNIQUE IMPORT ID&#96;: row._id}) SET n += row.properties SET n:Person;
+:commit
+:begin
+UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:"aaa"}}, {start: {_id:0}, end: {_id:3}, properties:{name:"eee"}}] AS row
+MATCH (start:&#96;UNIQUE IMPORT LABEL&#96;{&#96;UNIQUE IMPORT ID&#96;: row.start._id})
+MATCH (end:&#96;UNIQUE IMPORT LABEL&#96;{&#96;UNIQUE IMPORT ID&#96;: row.end._id})
+CREATE (start)-[r:IS_TEAM_MEMBER_OF]->(end) SET r += row.properties;
+UNWIND [{start: {_id:0}, id: 0, end: {_id:1}, properties:{id:1}}, {start: {_id:0}, id: 1, end: {_id:1}, properties:{id:2}}, {start: {_id:0}, id: 2, end: {_id:1}, properties:{id:2}}, {start: {_id:0}, id: 3, end: {_id:1}, properties:{id:3}}, {start: {_id:0}, id: 4, end: {_id:1}, properties:{id:4}}, {start: {_id:0}, id: 5, end: {_id:1}, properties:{id:5}}] AS row
+MATCH (start:&#96;UNIQUE IMPORT LABEL&#96;{&#96;UNIQUE IMPORT ID&#96;: row.start._id})
+MATCH (end:&#96;UNIQUE IMPORT LABEL&#96;{&#96;UNIQUE IMPORT ID&#96;: row.end._id})
+CREATE (start)-[r:WORKS_FOR{&#96;UNIQUE IMPORT ID REL&#96;:row.id}]->(end) SET r += row.properties;
+:commit
+:begin
+MATCH (n:&#96;UNIQUE IMPORT LABEL&#96;)  WITH n LIMIT 20000 REMOVE n:&#96;UNIQUE IMPORT LABEL&#96; REMOVE n.&#96;UNIQUE IMPORT ID&#96;;
+:commit
+:begin
+DROP CONSTRAINT ON (node:&#96;UNIQUE IMPORT LABEL&#96;) ASSERT (node.&#96;UNIQUE IMPORT ID&#96;) IS UNIQUE;
+:commit
+"
+|===
+
 
 [[export-cypher-examples-roundtrip]]
 === Round trip


### PR DESCRIPTION
Export cypher overwrite in case of merge with multi-relationships

Added `multipleRelationshipsWithType` config, default `false, to distinguish (with true) multiple relationships with same start/end nodes and same rel-type.

Related trello issue: https://trello.com/c/qjfKSOqG/971-s4volvo-apocexportcypherquery-loses-relationships