### PR TITLE
fixes 2886: The apoc.export.cypher.* procedures don't create relationships with start/end node without properties

### DIFF
--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -105,15 +105,13 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		StringBuilder result = new StringBuilder(1000);
 		result.append("MERGE ");
 		result.append(CypherFormatterUtils.formatNodeLookup("n", node, uniqueConstraints, indexNames));
-		if (node.getPropertyKeys().iterator().hasNext()) {
-			String notUniqueProperties = CypherFormatterUtils.formatNotUniqueProperties("n", node, uniqueConstraints, indexedProperties, false);
-			String notUniqueLabels = CypherFormatterUtils.formatNotUniqueLabels("n", node, uniqueConstraints);
-			if (!"".equals(notUniqueProperties) || !"".equals(notUniqueLabels)) {
-				result.append(cypherFormat.equals(CypherFormat.ADD_STRUCTURE) ? " ON CREATE SET " : " SET ");
-				result.append(notUniqueProperties);
-				result.append(!"".equals(notUniqueProperties) && !"".equals(notUniqueLabels) ? ", " : "");
-				result.append(notUniqueLabels);
-			}
+		String notUniqueProperties = CypherFormatterUtils.formatNotUniqueProperties("n", node, uniqueConstraints, indexedProperties, false);
+		String notUniqueLabels = CypherFormatterUtils.formatNotUniqueLabels("n", node, uniqueConstraints);
+		if (!"".equals(notUniqueProperties) || !"".equals(notUniqueLabels)) {
+			result.append(cypherFormat.equals(CypherFormat.ADD_STRUCTURE) ? " ON CREATE SET " : " SET ");
+			result.append(notUniqueProperties);
+			result.append(!"".equals(notUniqueProperties) && !"".equals(notUniqueLabels) ? ", " : "");
+			result.append(notUniqueLabels);
 		}
 		result.append(";");
 		return result.toString();

--- a/core/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
@@ -26,11 +26,9 @@ public class CreateCypherFormatter extends AbstractCypherFormatter implements Cy
         if (!labels.isEmpty()) {
             result.append(labels);
         }
-        if (node.getPropertyKeys().iterator().hasNext()) {
-            result.append(" {");
-            result.append(CypherFormatterUtils.formatNodeProperties("", node, uniqueConstraints, indexNames, true));
-            result.append("}");
-        }
+        result.append(" {");
+        result.append(CypherFormatterUtils.formatNodeProperties("", node, uniqueConstraints, indexNames, true));
+        result.append("}");
         result.append(");");
         return result.toString();
     }

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -2,6 +2,7 @@ package apoc.export.cypher.formatter;
 
 import apoc.export.util.FormatUtils;
 import apoc.util.Util;
+import org.apache.commons.collections.MapUtils;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -183,7 +184,7 @@ public class CypherFormatterUtils {
 
     public static StringBuilder formatProperties(String id, Map<String, Object> properties, boolean jsonStyle) {
         StringBuilder result = new StringBuilder(100);
-        if (properties != null) {
+        if (MapUtils.isNotEmpty(properties)) {
             List<String> keys = Iterables.asList(properties.keySet());
             Collections.sort(keys);
             for (String prop : keys) {

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1,5 +1,7 @@
 package apoc.export.cypher;
 
+import apoc.cypher.Cypher;
+import apoc.export.util.ExportConfig;
 import apoc.graph.Graphs;
 import apoc.util.BinaryTestUtil;
 import apoc.util.CompressionAlgo;
@@ -13,6 +15,8 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -29,7 +33,10 @@ import static apoc.export.util.ExportFormat.*;
 import static apoc.util.BinaryTestUtil.getDecompressedData;
 import static apoc.util.Util.map;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.configuration.SettingImpl.newBuilder;
 import static org.neo4j.configuration.SettingValueParsers.BOOL;
 
@@ -62,7 +69,7 @@ public class ExportCypherTest {
     @Before
     public void setUp() throws Exception {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
-        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
+        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class, Cypher.class);
         db.executeTransactionally("CREATE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name)");
         db.executeTransactionally("CREATE INDEX fooIndex FOR (n:Foo) ON (n.name)");
         db.executeTransactionally("CREATE CONSTRAINT consBar ON (n:Bar) ASSERT (n.name) IS UNIQUE");
@@ -859,6 +866,129 @@ public class ExportCypherTest {
         db.executeTransactionally("DROP INDEX rel_index_name");
     }
 
+    @Test
+    public void testIssue2886OptimizationsNoneAndCypherFormatCreate() {
+        String expected = "CREATE (:Person:`UNIQUE IMPORT LABEL` {name:\"First\", `UNIQUE IMPORT ID`:3});\n" +
+                "CREATE (:Project:`UNIQUE IMPORT LABEL` {`UNIQUE IMPORT ID`:4});\n" +
+                "CREATE (:Person:`UNIQUE IMPORT LABEL` {name:\"Second\", `UNIQUE IMPORT ID`:5});\n" +
+                "CREATE (:Project:`UNIQUE IMPORT LABEL` {`UNIQUE IMPORT ID`:6});\n" +
+                EXPECTED_2886_SCHEMA +
+                EXPECTED_2886_RELS_WITHOUT_OPTIMIZATION +
+                EXPECTED_2886_CLEANUP;
+
+        final Map<String, Object> config = map("cypherFormat", "create");
+        issue2886Common(expected, withoutOptimization(config), true);
+    }
+
+    @Test
+    public void testIssue2886OptimizationsNoneAndCypherFormatCreate2() {
+        String expected = "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) ON CREATE SET n.name=\"First\", n:Person;\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) ON CREATE SET n:Project;\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:5}) ON CREATE SET n.name=\"Second\", n:Person;\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:6}) ON CREATE SET n:Project;\n" +
+                EXPECTED_2886_RELS_WITHOUT_OPTIMIZATION;
+        final Map<String, Object> config = map("cypherFormat", "addStructure");
+        issue2886Common(expected, withoutOptimization(config), true);
+    }
+
+    @Test
+    public void testIssue2886OptimizationsNoneAndCypherFormatCreate23() {
+        String expected = "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) MERGE (n1)-[r:WORKS_FOR]->(n2) ON CREATE SET r.id=1;\n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:5}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:6}) MERGE (n1)-[r:WORKS_FOR]->(n2) ON CREATE SET r.id=2;\n";
+        final Map<String, Object> config = map("cypherFormat", "updateStructure");
+        issue2886Common(expected, withoutOptimization(config), false);
+    }
+
+    @Test
+    public void testIssue2886OptimizationsNoneAndCypherFormatCreate245() {
+        String expected = "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) SET n.name=\"First\", n:Person;\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) SET n:Project;\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:5}) SET n.name=\"Second\", n:Person;\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:6}) SET n:Project;\n" +
+                EXPECTED_2886_SCHEMA +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) MERGE (n1)-[r:WORKS_FOR]->(n2) SET r.id=1;\n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:5}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:6}) MERGE (n1)-[r:WORKS_FOR]->(n2) SET r.id=2;\n" +
+                EXPECTED_2886_CLEANUP;
+        final Map<String, Object> config = map("cypherFormat", "updateAll");
+        issue2886Common(expected, withoutOptimization(config), true);
+    }
+
+    @Test
+    public void testIssue2886CypherFormatCreate() {
+        final Map<String, Object> config = map("cypherFormat", "create");
+        String expected = String.format(EXPECTED_2886_UNWIND, "CREATE");
+        issue2886Common(expected, config, true);
+    }
+
+    @Test
+    public void testIssue2886CypherFormatCreate2() {
+        final Map<String, Object> config = map("cypherFormat", "addStructure");
+        issue2886Common(EXPECTED_2886_ADD_STRUCTURE, config, true);
+    }
+
+    @Test
+    public void testIssue2886CypherFormatCreate23() {
+        final Map<String, Object> config = map("cypherFormat", "updateStructure");
+        final String expected = String.format(EXPECTED_2886_UPDATE_STRUCTURE, "MERGE");
+        issue2886Common(expected, config, false);
+    }
+
+    @Test
+    public void testIssue2886CypherFormatCreate245() {
+        final Map<String, Object> config = map("cypherFormat", "updateAll");
+        String expected = String.format(EXPECTED_2886_UNWIND, "MERGE");
+        issue2886Common(expected, config, true);
+    }
+
+    private Map<String, Object> withoutOptimization(Map<String, Object> map) {
+        map.put("useOptimizations", map("type", ExportConfig.OptimizationType.NONE.name()));
+        return map;
+    }
+
+    private void issue2886Common(String expected, Map<String, Object> config, boolean isRountrip) {
+        db.executeTransactionally("match (n) detach delete n");
+
+        final String startOne = "First";
+        final long relOne = 1L;
+        final String startTwo = "Second";
+        final long relTwo = 2L;
+        db.executeTransactionally("create (:Person {name: $name})-[:WORKS_FOR {id: $id}]->(:Project)",
+                map("name", startOne, "id", relOne));
+        db.executeTransactionally("create (:Person {name: $name})-[:WORKS_FOR {id: $id}]->(:Project)",
+                map("name", startTwo, "id", relTwo));
+
+        final Map<String, Object> conf = map("format", "plain");
+        conf.putAll(config);
+        final String cypherStatements = db.executeTransactionally("CALL apoc.export.cypher.all(null, $config)",
+                map("config", conf),
+                r -> (String) r.next().get("cypherStatements"));
+
+        beforeAfterIssue2886(startOne, relOne, startTwo, relTwo);
+
+        assertEquals(expected, cypherStatements);
+
+        if (!isRountrip) {
+            return;
+        }
+        db.executeTransactionally("match (n) detach delete n");
+        db.executeTransactionally("call apoc.cypher.runMany($statements, {})", map("statements", cypherStatements));
+
+        beforeAfterIssue2886(startOne, relOne, startTwo, relTwo);
+    }
+
+    private void beforeAfterIssue2886(String startOne, long relOne, String startTwo, long relTwo) {
+        TestUtil.testResult(db, "MATCH (start:Person)-[rel:WORKS_FOR]->(end:Project) RETURN rel ORDER BY rel.id", r -> {
+            final ResourceIterator<Relationship> rels = r.columnAs("rel");
+            Relationship rel = rels.next();
+            assertEquals(startOne, rel.getStartNode().getProperty("name"));
+            assertEquals(relOne, rel.getProperty("id"));
+            rel = rels.next();
+            assertEquals(startTwo, rel.getStartNode().getProperty("name"));
+            assertEquals(relTwo, rel.getProperty("id"));
+            assertFalse(rels.hasNext());
+        });
+    }
+
     private void relIndexTestCommon(String fileName, String expectedSchema, Map<String, Object> config) throws FileNotFoundException {
         Map<String, Object> exportConfig = map("separateFiles", true, "format", "neo4j-shell");
         exportConfig.putAll(config);
@@ -1445,6 +1575,40 @@ public class ExportCypherTest {
                 "MATCH (start:Person{surname: row.start.surname, name: row.start.name})%n" +
                 "MATCH (end:Person{surname: row.end.surname, name: row.end.name})%n" +
                 "CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;%n");
+        
+        static final String EXPECTED_2886_SCHEMA = "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);\n" +
+                "CREATE INDEX FOR (node:Foo) ON (node.name);\n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;\n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n";
+
+        static final String EXPECTED_2886_CLEANUP = "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;\n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n";
+
+        static final String EXPECTED_2886_UPDATE_STRUCTURE = "UNWIND [{start: {_id:3}, end: {_id:4}, properties:{id:1}}, {start: {_id:5}, end: {_id:6}, properties:{id:2}}] AS row\n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+                "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+                "%1$s (start)-[r:WORKS_FOR]->(end) SET r += row.properties;\n";
+
+        static final String EXPECTED_2886_UNWIND = EXPECTED_2886_SCHEMA +
+                "UNWIND [{_id:4, properties:{}}, {_id:6, properties:{}}] AS row\n" +
+                "%1$s (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Project;\n" +
+                "UNWIND [{_id:3, properties:{name:\"First\"}}, {_id:5, properties:{name:\"Second\"}}] AS row\n" +
+                "%1$s (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Person;\n" +
+                EXPECTED_2886_UPDATE_STRUCTURE +
+                EXPECTED_2886_CLEANUP;
+
+        static final String EXPECTED_2886_ADD_STRUCTURE = "UNWIND [{_id:4, properties:{}}, {_id:6, properties:{}}] AS row\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Project;\n" +
+                "UNWIND [{_id:3, properties:{name:\"First\"}}, {_id:5, properties:{name:\"Second\"}}] AS row\n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Person;\n" +
+                "UNWIND [{start: {_id:3}, end: {_id:4}, properties:{id:1}}, {start: {_id:5}, end: {_id:6}, properties:{id:2}}] AS row\n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+                "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+                "CREATE (start)-[r:WORKS_FOR]->(end)  SET r += row.properties;\n";
+
+        static final String EXPECTED_2886_RELS_WITHOUT_OPTIMIZATION = "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) CREATE (n1)-[r:WORKS_FOR {id:1}]->(n2);\n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:5}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:6}) CREATE (n1)-[r:WORKS_FOR {id:2}]->(n2);\n";
+
     }
 
 }


### PR DESCRIPTION
fixes 2886