### PR TITLE
apoc.meta.data count adoc/test

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.data.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.data.adoc
@@ -46,3 +46,20 @@ CALL apoc.meta.data();
 | "Movie"    | "tagline"  | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
 | "Movie"    | "released" | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
 |===
+
+The `unique` column shows if there is an unique constraint in that specific label and property.
+Similarly, the `index` column show if there is an index or not, while the `existence` looks for an existence constraint.
+
+The `array` column check if the row is of type array and, in case `type` columns is `"RELATIONSHIP"`,
+the result will be `true` if there is at least one node with 2 outgoing relationships with the type of relation given by `label` or `property` column, 
+so `ACTED_IN` in the example above.
+
+The `leftCount`, rightCount, `left` and `right` columns regard only rows with column `type` equals to `"RELATIONSHIP"` (otherwise they are equal to `0`)
+In particular, `leftCount`, `rightCount` are "weighted" counts of respectively outgoing and incoming relationships, 
+which for each node it will increase the count with the number of outgoing relations of that type for itself.
+That is, if the node has 1 outgoing relationship with the provided type, the count will be increased by 1,
+if it has 2 outgoing relationships, increased by 3, with 3 relationships, increased by 9, and so on.
+Same thing for `rightCount`, but with incoming relationships instead.
+So, with the above dataset, ...Person {name:'Keanu Reeves' TODO
+
+The `right` and `left` results are the ratio (rounded down) of respectively `rightCount` and `leftCount` to `count`.


### PR DESCRIPTION
Trello issue: https://trello.com/c/yyENTOdy/977-s4pfizer-manufacturing-excellence-solutions-requesting-info-and-fix-for-apocmetadata-left-right-leftcount-rightcount-fields

La issue chiede di capire cosa sono `left`, `right`, `leftCount` e `rightCount` ed, in caso, risolvere eventuali bug e documentare.

Sinceramente mi risulta difficile capire se il risultato che si ottiene è quello voluto o no e quindi non avrei idea su come risolvere eventuali bug.

Quello che vedo è che, se ci sono dei nodi con delle relazioni multiple dello stesso tipo, allora il `leftCount` o il `rightCount` fanno un elevamento a potenza del degree per se stesso (perché c'è un foreach `Relationship rel : node.getRelationships(Direction.OUTGOING, type)` e per ogni ciclo aggiungo al conteggio `node.getDegree(type, Direction.OUTGOING)` ).
Personalmente credo sia un effetto non voluto, ma non saprei...

Quindi per ora ho aggiornato la documentazione/unit test descrivendo cosa sono i campi, ma non sono sicuro sia la soluzione giusta.


----

non correlato: `MetaResult.sample` restituisce sempre null, perché non viene mai usato, quindi credo si possa togliere?