### PR TITLE
issue 2909: Apoc Procedures can't return empty map

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -41,6 +41,7 @@ import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.ValueMapper;
 import org.neo4j.values.storable.Values;
+import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.MapValueBuilder;
 import org.neo4j.values.virtual.VirtualValues;
 
@@ -585,6 +586,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     return VirtualValues.list(objects);
                 } else if (toConvert instanceof Map) {
                     Map<String, Object> map = (Map) toConvert;
+                    if (map.isEmpty()) {
+                        return MapValue.EMPTY;
+                    }
                     MapValueBuilder builder = new MapValueBuilder(map.size());
                     map.entrySet().stream().forEach(e -> {
                         builder.add(e.getKey(), convertToValueRecursive(e.getValue()));

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -703,6 +703,17 @@ public class CypherProceduresTest  {
         assertProcedureFails(String.format(SIGNATURE_SYNTAX_ERROR, procedureSignature), 
                 "call apoc.custom.declareProcedure('" + procedureSignature + "','RETURN $first + $s AS answer')");
     }
+
+    @Test
+    public void testIssue2909() {
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('emptyProc() :: (answer::MAP)','RETURN {} as answer')");
+        TestUtil.testCall(db, "call custom.emptyProc", 
+                (row) -> assertEquals(Collections.emptyMap(), row.get("answer")));
+        
+        db.executeTransactionally("CALL apoc.custom.declareFunction('emptyFun() :: MAP', 'RETURN {} AS row')");
+        TestUtil.testCall(db, "return custom.emptyFun() AS answer", 
+                (row) -> assertEquals(Collections.emptyMap(), ((Map) row.get("answer")).get("row")));
+    }
     
 
     private void assertProcedureFails(String expectedMessage, String query) {


### PR DESCRIPTION
issue 2909

Applied logic similar to `Neo4jPackV1.unpackMap()`:
```
            int size = (int) unpackMapHeader();
            if ( size == 0 )
            {
                return EMPTY_MAP;
            }

            sizeSanityCheck( size, in );

            MapValueBuilder map = new MapValueBuilder( size );
            ...
```