### PR TITLE
Add support for Duration to apoc.coll.avg

### DIFF
--- a/core/src/main/java/apoc/coll/Coll.java
+++ b/core/src/main/java/apoc/coll/Coll.java
@@ -2,7 +2,11 @@ package apoc.coll;
 
 import apoc.result.ListResult;
 import com.google.common.util.concurrent.AtomicDouble;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.commons.lang3.time.DurationUtils;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.apache.commons.math3.util.Combinations;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -17,9 +21,11 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.UserFunction;
+import org.neo4j.values.storable.DurationValue;
 
 import java.lang.reflect.Array;
 import java.text.Collator;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -35,6 +41,7 @@ import java.util.Random;
 import java.util.RandomAccess;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -122,6 +129,32 @@ public class Coll {
     }
 
     @UserFunction
+    @Description("apoc.coll.avgDuration([duration('P2DT3H'), duration('PT1H45S'), ...])")
+    public DurationValue avgDuration(@Name("numbers") List<DurationValue> list) {
+        if (CollectionUtils.isEmpty(list)) return null;
+
+        long count = list.size();
+        // todo - ma in effetti possono essere long credo...
+        final AtomicDouble monthsRunningAvg = new AtomicDouble();
+        final AtomicDouble daysRunningAvg = new AtomicDouble();
+        final AtomicDouble secondsRunningAvg = new AtomicDouble();
+        final AtomicDouble nanosRunningAvg = new AtomicDouble();
+        for (DurationValue duration : list) {
+            monthsRunningAvg.addAndGet(duration.get(ChronoUnit.MONTHS));
+            daysRunningAvg.addAndGet(duration.get(ChronoUnit.DAYS));
+            secondsRunningAvg.addAndGet(duration.get(ChronoUnit.SECONDS));
+            nanosRunningAvg.addAndGet(duration.get(ChronoUnit.NANOS));
+        }
+
+        return DurationValue.approximate(
+                monthsRunningAvg.get() / count,
+                daysRunningAvg.get() / count,
+                secondsRunningAvg.get() / count,
+                nanosRunningAvg.get() / count
+        ).normalize();
+    }
+
+    @UserFunction
     @Description("apoc.coll.avg([0.5,1,2.3])")
     public Double avg(@Name("numbers") List<Number> list) {
 		if (list == null || list.isEmpty()) return null;
@@ -131,6 +164,7 @@ public class Coll {
         }
         return (avg/(double)list.size());
     }
+    
     @UserFunction
     @Description("apoc.coll.min([0.5,1,2.3])")
     public Object min(@Name("values") List<Object> list) {

--- a/core/src/test/java/apoc/coll/CollTest.java
+++ b/core/src/test/java/apoc/coll/CollTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.Node;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.neo4j.values.storable.DurationValue;
 
 import java.util.*;
 
@@ -34,6 +35,13 @@ public class CollTest {
     public void testRunningTotal() throws Exception {
         testCall(db, "RETURN apoc.coll.runningTotal([1,2,3,4,5.5,1]) as value",
                 (row) -> assertEquals(asList(1L, 3L, 6L, 10L, 15.5D, 16.5D), row.get("value")));
+    }
+    
+    @Test
+    public void testAvgDuration() {
+        testCall(db, "with [duration('P2DT3H'), duration('PT1H45S')] AS dur " +
+                        "RETURN apoc.coll.avgDuration(dur) AS value",
+                (row) -> assertEquals(DurationValue.parse("P1DT2H22.5S"), row.get("value")));
     }
 
     @Test


### PR DESCRIPTION
Add support for Duration to apoc.coll.avg

Trello card: https://trello.com/c/2tfco9c9/791-add-support-for-duration-to-apoccollavg


Based on `org.neo4j.cypher.internal.runtime.interpreted.pipes.aggregation.AvgFunction`
