### PR TITLE
The apoc.meta.graph is much slower in 4.x, compared to 3.5

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -1118,8 +1118,8 @@ public class Meta {
             long sample = getSampleForLabelCount(labelCount, metaConfig.getSample());
             while (nodes.hasNext()) {
                 count++;
+                Node node = nodes.next();
                 if(count % sample == 0) {
-                    Node node = nodes.next();
                     long maxRels = metaConfig.getMaxRels();
                     for (Relationship rel : node.getRelationships(direction, relationshipType)) {
                         Node otherNode = direction == Direction.OUTGOING ? rel.getEndNode() : rel.getStartNode();


### PR DESCRIPTION
UPDATE:

@conker84
In realtà il problema non sembra dovuto alle performance tra 3.5 e 4.4.
La 4.4 è più lenta perché utilizzando le stesse query per creare un dataset, quando in `relationshipExists(Label labelFromLabel, Label labelToLabel, RelationshipType relationshipType, Direction direction, MetaConfig metaConfig` si va a fare la `findNodes(labelFromLabel)` per trovare le relazioni extra, i nodi vengono estrapolati con un ordine diverso e quindi la condizione `if (otherNode.hasLabel(labelToLabel)) return true;` avviene dopo parecchie iterazioni nel caso della 4.4, assolutamente per pura casualità.

Comunque, magari potrebbe sfuggirmi qualcosa, ma credo che si possa semplificare/alleggerire di parecchio la procedura semplicemente eseguendo una query cypher per trovare una certo relazione con una label start/end. 
Se si trova allora si restituisce `true`.
Tutto il resto, ovvero `sample` e `maxRels` credo non serva, visto che si vuole solo verificare l'esistenza o meno della relazione.

Per ora l'ho messo con una config (default il comportamento corrente), anche se l'ho testato e sembra funzionare.



