### PR TITLE
[WIP] Issue neo4j/apoc 33: - waiting for extended compiling fix

### DIFF
--- a/extended/src/main/java/apoc/coll/CollExtended.java
+++ b/extended/src/main/java/apoc/coll/CollExtended.java
@@ -6,9 +6,11 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.UserFunction;
 import org.neo4j.values.storable.DurationValue;
+import com.google.common.util.concurrent.AtomicDouble;
 
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Extended
 public class CollExtended {
@@ -16,9 +18,22 @@ public class CollExtended {
     @UserFunction
     @Description("apoc.coll.avgDuration([duration('P2DT3H'), duration('PT1H45S'), ...]) -  returns the average of a list of duration values")
     public DurationValue avgDuration(@Name("durations") List<DurationValue> list) {
+        AtomicDouble sum = new AtomicDouble();
+
+        List<Number> list1 = List.of(12, 123, 128746);
+        
+        final List<Number> collect = list1.stream().map(i -> {
+            System.out.println("CollExtended.avgDuration");
+            double value = sum.addAndGet(i.doubleValue());
+            if (value == sum.longValue()) return Long.valueOf(sum.longValue());
+            return Double.valueOf(value);
+        }).collect(Collectors.toList());
+
         if (CollectionUtils.isEmpty(list)) return null;
 
         long count = 0;
+        
+        sum.addAndGet(1D);
 
         double monthsRunningAvg = 0;
         double daysRunningAvg = 0;
@@ -31,6 +46,8 @@ public class CollExtended {
             secondsRunningAvg  += (duration.get(ChronoUnit.SECONDS) - secondsRunningAvg) / count;
             nanosRunningAvg  += (duration.get(ChronoUnit.NANOS) - nanosRunningAvg) / count;
         }
+
+        System.out.println("sum = " + sum.get());
 
         return DurationValue.approximate(monthsRunningAvg, daysRunningAvg, secondsRunningAvg, nanosRunningAvg)
                 .normalize();

--- a/extended/src/test/java/apoc/CoreExtendedTest.java
+++ b/extended/src/test/java/apoc/CoreExtendedTest.java
@@ -1,13 +1,17 @@
 package apoc;
 
+import apoc.help.HelpExtendedTest;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import apoc.util.TestContainerUtil.ApocPackage;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,22 +28,38 @@ import static org.junit.Assert.fail;
  into a Neo4j instance without any startup issue.
  If you don't have docker installed it will fail, and you can simply ignore it.
  */
-public class CoreExtendedTest {
+public class CoreExtendedTest extends HelpExtendedTest {
     @Test
     public void checkForCoreAndExtended() {
         try {
-            Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(ApocPackage.CORE, ApocPackage.EXTENDED), true)
-                    .withNeo4jConfig("dbms.transaction.timeout", "60s")
-                    .withEnv(APOC_IMPORT_FILE_ENABLED, "true");
+            Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(/*ApocPackage.CORE, */ApocPackage.EXTENDED), true)
+                    .withNeo4jConfig("dbms.transaction.timeout", "60s");
+//                    .withNeo4jConfig(APOC_IMPORT_FILE_ENABLED, "true");
 
             neo4jContainer.start();
 
+            
             Session session = neo4jContainer.getSession();
-            int coreCount = session.run("CALL apoc.help('') YIELD core WHERE core = true RETURN count(*) AS count").peek().get("count").asInt();
-            int extendedCount = session.run("CALL apoc.help('') YIELD core WHERE core = false RETURN count(*) AS count").peek().get("count").asInt();
+            // todo - common with StartupTest.compare_with_sources (in core)
+//            final List<String> functionNames = session.run("CALL apoc.help('') YIELD core, type, name WHERE core = true and type = 'function' RETURN name")
+//                    .list(record -> record.get("name").asString());
+//            final List<String> procedureNames = session.run("CALL apoc.help('') YIELD core, type, name WHERE core = true and type = 'procedure' RETURN name")
+//                    .list(record -> record.get("name").asString());
+//
+//
+//            assertEquals(sorted(ApocSignatures.PROCEDURES), procedureNames);
+//            assertEquals(sorted(ApocSignatures.FUNCTIONS), functionNames);
+            final List<String> totalExtendedNames = session.run("CALL apoc.help('') YIELD core, type, name WHERE core = false and type = 'procedure' RETURN name")
+                    .list(record -> record.get("name").asString());
+            final List<String> functionExtendedNames = session.run("CALL apoc.help('') YIELD core, type, name WHERE core = false and type = 'function' RETURN name")
+                    .list(record -> record.get("name").asString());
 
-            assertTrue(coreCount > 0);
-            assertTrue(extendedCount > 0);
+            totalExtendedNames.addAll(functionExtendedNames);
+            final String actualExtended = totalExtendedNames.stream()
+                    .collect(Collectors.joining("\n"));
+
+            final String expectedExtended = FileUtils.readFileToString(EXTENDED_FILE, StandardCharsets.UTF_8);
+            assertEquals(expectedExtended, actualExtended);
 
             neo4jContainer.close();
         } catch (Exception ex) {
@@ -50,6 +70,12 @@ public class CoreExtendedTest {
         }
     }
 
+
+    private List<String> sorted(List<String> signatures) {
+        return signatures.stream().sorted().collect(Collectors.toList());
+    }
+
+    // TODO [Nacho] Ignored for the moment because we cannot build core from here anymore. This needs rethinking
     @Test
     public void matchesSpreadsheet() {
         try {

--- a/extended/src/test/java/apoc/help/HelpExtendedTest.java
+++ b/extended/src/test/java/apoc/help/HelpExtendedTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertFalse;
  * @since 06.11.16
  */
 public class HelpExtendedTest {
+    public static final File EXTENDED_FILE = new File("src/main/resources/extended.txt");
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
@@ -62,8 +63,8 @@ public class HelpExtendedTest {
 
     @Test
     public void indicateNotCore() throws IOException {
-        File extendedFile = new File("src/main/resources/extended.txt");
-        FileOutputStream fos = new FileOutputStream(extendedFile);
+        System.out.println("HelpExtendedTest.indicateNotCore");
+        FileOutputStream fos = new FileOutputStream(EXTENDED_FILE);
 
         try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos))) {
             db.executeTransactionally("SHOW PROCEDURES YIELD name WHERE name STARTS WITH 'apoc' AND name <> 'apoc.help' RETURN name", Collections.emptyMap(),


### PR DESCRIPTION
Waiting for `https://github.com/neo4j/apoc/pull/187` extended fix

Added some guava code in `extended/src/main/java/apoc/coll/CollExtended.java` to emulate missing function. 
I need to change `guava` from implementation to  both testimplementation and compileOnly to execute the tests