### PR TITLE
changed artifactId, added mvn repository documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : '5.0.0'
+    version = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : '5.3.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.1.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.1.0',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.3.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.3.0',
                 'coreDir': 'apoc-core/core'
 
         maxHeapSize = "8G"
@@ -130,7 +130,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.1.0"
+    neo4jVersion = "5.3.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.16.2'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -7,5 +7,5 @@ asciidoc:
   attributes:
     docs-version: "5.0"
     branch: "5.0"
-    apoc-release-absolute: "5.0"
-    apoc-release: "5.0.0-rc01"
+    apoc-release-absolute: "5.3"
+    apoc-release: "5.3.0"

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -7,5 +7,5 @@ asciidoc:
   attributes:
     docs-version: "5.0"
     branch: "5.0"
-    apoc-release-absolute: "5.3"
+    apoc-release-absolute: "5.0"
     apoc-release: "5.3.0"

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -66,15 +66,11 @@ In a `pom.xml` of a maven project, you can add these two dependencies from https
     &lt;groupId&gt;org.neo4j.procedure&lt;/groupId&gt;
     &lt;artifactId&gt;apoc-extended&lt;/artifactId&gt;
     &lt;version&gt;{apoc-release-absolute}&lt;/version&gt;
-&lt;/dependency&gt;
-&lt;dependency&gt;
-    &lt;groupId&gt;org.neo4j.procedure&lt;/groupId&gt;
-    &lt;artifactId&gt;apoc-common&lt;/artifactId&gt;
-    &lt;version&gt;{apoc-release-absolute}&lt;/version&gt;
+    &lt;classifier&gt;extended&lt;/classifier&gt;
 &lt;/dependency&gt;
 ----
 
-Alternatively, you can download the two jars for https://mvnrepository.com/artifact/org.neo4j.procedure/apoc-extended/{apoc-release}[apoc-extended] and https://mvnrepository.com/artifact/org.neo4j.procedure/apoc-common/{apoc-release}[apoc-common] (if it is not already present via `apoc-core`)
+Alternatively, you can download the jar https://repo1.maven.org/maven2/org/neo4j/procedure/apoc-extended/{apoc-release}/apoc-extended-{apoc-release}-extended.jar[from here] (if it is not already present via `apoc-core`)
 and put them into `plugin` folder.
 
 

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -22,7 +22,9 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 [opts=header]
 |===
 |apoc version | neo4j version
-| http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.0.0.0[5.0.0.0^] | 5.0.0 (5.0.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
+| http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.0.0[5.0.0^] | 5.0.0 (5.0.x)
 | http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.1[4.4.0.1^] | 4.4.0 (4.3.x)
 | http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.3.0.4[4.3.0.4^] | 4.3.7 (4.3.x)
 | http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.2.0.9[4.2.0.9^] | 4.2.11 (4.2.x)
@@ -65,7 +67,7 @@ In a `pom.xml` of a maven project, you can add these two dependencies from https
 &lt;dependency&gt;
     &lt;groupId&gt;org.neo4j.procedure&lt;/groupId&gt;
     &lt;artifactId&gt;apoc-extended&lt;/artifactId&gt;
-    &lt;version&gt;{apoc-release-absolute}&lt;/version&gt;
+    &lt;version&gt;{apoc-release}&lt;/version&gt;
     &lt;classifier&gt;extended&lt;/classifier&gt;
 &lt;/dependency&gt;
 ----

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -54,6 +54,30 @@ See the compatibility matrix in https://neo4j.com/labs/apoc/4.4/installation/ to
 
 include::partial$docker.adoc[tags=docker,leveloffset=1]
 
+
+[[mvnrepository]]
+== Maven Repository
+
+In a `pom.xml` of a maven project, you can add these two dependencies from https://mvnrepository.com/artifact/org.neo4j.procedure[Maven Repository]:
+
+[source,subs=attributes]
+----
+&lt;dependency&gt;
+    &lt;groupId&gt;org.neo4j.procedure&lt;/groupId&gt;
+    &lt;artifactId&gt;apoc-extended&lt;/artifactId&gt;
+    &lt;version&gt;{apoc-release-absolute}&lt;/version&gt;
+&lt;/dependency&gt;
+&lt;dependency&gt;
+    &lt;groupId&gt;org.neo4j.procedure&lt;/groupId&gt;
+    &lt;artifactId&gt;apoc-common&lt;/artifactId&gt;
+    &lt;version&gt;{apoc-release-absolute}&lt;/version&gt;
+&lt;/dependency&gt;
+----
+
+Alternatively, you can download the two jars for https://mvnrepository.com/artifact/org.neo4j.procedure/apoc-extended/{apoc-release}[apoc-extended] and https://mvnrepository.com/artifact/org.neo4j.procedure/apoc-common/{apoc-release}[apoc-common] (if it is not already present via `apoc-core`)
+and put them into `plugin` folder.
+
+
 [[restricted]]
 == Restricted procedures/functions
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.0.0.0-rc01' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.3.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -149,7 +149,7 @@ publishing {
     }
     publications {
         shadow(MavenPublication) { publication ->
-            artifactId("apoc")
+            artifactId("apoc-extended")
             project.shadow.component(publication)
             artifact(mySourcesJar)
             artifact(myJavadocJar)
@@ -157,8 +157,8 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
-                root.appendNode("name", "neo4j-apoc-procedure")
-                root.appendNode("description", "A collection of useful Neo4j Procedures")
+                root.appendNode("name", "neo4j-apoc-extended")
+                root.appendNode("description", "Extended package for Neo4j Procedures")
                 root.appendNode("url", "http://github.com/neo4j-contrib/neo4j-apoc-procedures")
 
                 def scmNode = root.appendNode("scm")

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -12,7 +12,7 @@ configure(subprojects) {
 
 
 subprojects {
-    version = '5.0.0.0-rc01'
+    version = '5.3.0'
     group = 'org.neo4j.contrib'
 }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -183,6 +183,9 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.0.0[5.0.0^] | 5.0.0 (5.0.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.1[4.4.0.1^] | 4.4.0 (4.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.3.0.4[4.3.0.4^] | 4.3.7 (4.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.2.0.9[4.2.0.9^] | 4.2.11 (4.2.x)


### PR DESCRIPTION
- Changed `artifactId` to `apoc-extended`.
- Changed, in `build.gradle`, `root.appendNode("name"` consistent with https://github.com/neo4j/apoc/blob/dev/core/build.gradle#L118

- Changed vars `build.gradle` with the same version as https://github.com/neo4j/apoc/blob/dev/build.gradle

- Added docs about mvn repository.
- Updated `apoc-release-absolute` and `readme.adoc` consistent with https://raw.githubusercontent.com/neo4j/apoc/dev/readme.adoc (to be changed in 5.1 and 5.2 branches).

- Updated git submodule.

