### PR TITLE
[qwJFy8pp] Add admin check

### DIFF
--- a/core/src/main/java/apoc/trigger/Trigger.java
+++ b/core/src/main/java/apoc/trigger/Trigger.java
@@ -4,6 +4,7 @@ import apoc.util.Util;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -43,6 +44,7 @@ public class Trigger {
         }
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.install")
     @Description("add a trigger kernelTransaction under a name, in the kernelTransaction you can use {createdNodes}, {deletedNodes} etc., the selector is {phase:'before/after/rollback/afterAsync'} returns previous and new trigger information. Takes in an optional configuration.")
@@ -60,6 +62,7 @@ public class Trigger {
         return Stream.of(new TriggerInfo(name,statement,selector, params,true, false));
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.drop")
     @Description("remove previously added trigger, returns trigger information")
@@ -73,6 +76,7 @@ public class Trigger {
         return Stream.of(new TriggerInfo(name,(String)removed.get("statement"), (Map<String, Object>) removed.get("selector"), (Map<String, Object>) removed.get("params"),false, false));
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.dropAll")
     @Description("removes all previously added trigger, returns trigger information")
@@ -112,6 +116,7 @@ public class Trigger {
                 );
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.stop")
     @Description("CALL apoc.trigger.pause(name) | it pauses the trigger")
@@ -126,6 +131,7 @@ public class Trigger {
                 (Map<String,Object>) paused.get("params"),true, true));
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.start")
     @Description("CALL apoc.trigger.resume(name) | it resumes the paused trigger")

--- a/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
@@ -5,6 +5,7 @@ import apoc.util.Util;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.api.procedure.SystemProcedure;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -75,6 +76,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.install(databaseName, name, statement, selector, config) | add a trigger kernelTransaction under a name, in the kernelTransaction you can use $createdNodes, $deletedNodes etc., the selector is {phase:'before/after/rollback/afterAsync'} returns previous and new trigger information. Takes in an optional configuration.")
     public Stream<TriggerInfo> install(@Name("databaseName") String databaseName, @Name("name") String name, @Name("kernelTransaction") String statement, @Name(value = "selector")  Map<String,Object> selector, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
@@ -96,6 +98,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.drop(databaseName, name) | remove previously added trigger, returns trigger information")
     public Stream<TriggerInfo> drop(@Name("databaseName") String databaseName, @Name("name")String name) {
@@ -110,6 +113,7 @@ public class TriggerNewProcedures {
     
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.dropAll(databaseName) | removes all previously added trigger, returns trigger information")
     public Stream<TriggerInfo> dropAll(@Name("databaseName") String databaseName) {
@@ -120,6 +124,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.stop(databaseName, name) | it pauses the trigger")
     public Stream<TriggerInfo> stop(@Name("databaseName") String databaseName, @Name("name")String name) {
@@ -134,6 +139,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.start(databaseName, name) | it resumes the paused trigger")
     public Stream<TriggerInfo> start(@Name("databaseName") String databaseName, @Name("name")String name) {

--- a/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
@@ -7,7 +7,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
 
@@ -15,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 import static apoc.trigger.Trigger.SYS_NON_LEADER_ERROR;
 import static apoc.trigger.TriggerNewProcedures.TRIGGER_NOT_ROUTED_ERROR;
@@ -106,4 +109,60 @@ public class TriggerClusterRoutingTest {
         final String systemRole = TestContainerUtil.singleResultFirstColumn(session, "CALL dbms.cluster.role('system')");
         return "LEADER".equals(systemRole);
     }
+    
+    @Test
+    public void testTriggerNewProcsAllowedOnlyWithAdmin() {
+        cluster.getSession().run("CREATE USER nonadmin SET PASSWORD \"test\" SET PASSWORD CHANGE NOT REQUIRED");
+
+        for (Neo4jContainerExtension container: cluster.getClusterMembers()) {
+            // todo - in this way if it works
+//            withDbSession(container, "neo4j", session -> {
+//                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
+//                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
+//                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
+//                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
+//                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
+//            });
+            
+            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test")); 
+                 Session session = driver.session(SessionConfig.forDatabase("neo4j"))) {
+
+                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
+                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
+                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
+                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
+                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
+            }
+            
+            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test")); 
+                 Session session = driver.session(SessionConfig.forDatabase("system"))) {
+
+                failsWithNonAdminUser(session, "apoc.trigger.install", "call apoc.trigger.install('neo4j', 'qwe', 'return 1', {})");
+                failsWithNonAdminUser(session, "apoc.trigger.drop", "call apoc.trigger.drop('neo4j', 'qwe')");
+                failsWithNonAdminUser(session, "apoc.trigger.dropAll", "call apoc.trigger.dropAll('neo4j', )");
+                failsWithNonAdminUser(session, "apoc.trigger.stop", "call apoc.trigger.stop('neo4j', 'qwe')");
+                failsWithNonAdminUser(session, "apoc.trigger.start", "call apoc.trigger.start('neo4j', 'qwe')");
+            }
+        }
+    }
+    
+    private void withDbSession(Neo4jContainerExtension container, String dbName, Consumer<Session> runnable) {
+        try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
+             Session session = driver.session(SessionConfig.forDatabase(dbName))) {
+            runnable.accept(session);
+        }
+    }
+            
+    private void failsWithNonAdminUser(Session session, String procName, String query) {
+        try {
+            testCall(session, query, 
+                    row -> fail("Should fail because of non admin user") );
+        } catch (Exception e) {
+            String actual = e.getMessage();
+            final String expected = String.format("Executing admin procedure '%s' permission has not been granted for user 'nonadmin'",
+                    procName);
+            assertTrue(actual.contains(expected));
+        }
+    }
+
 }

--- a/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
@@ -6,8 +6,9 @@ import apoc.util.TestcontainersCausalCluster;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
 
@@ -22,6 +23,8 @@ import static apoc.util.TestContainerUtil.testCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
+import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 
 public class TriggerClusterRoutingTest {
 
@@ -52,25 +55,25 @@ public class TriggerClusterRoutingTest {
     @Test
     public void testTriggerAddAllowedOnlyInSysLeaderMember() {
         final String query = "CALL apoc.trigger.add($name, 'RETURN 1', {})";
-        triggerInSysLeaderMemberCommon(query, SYS_NON_LEADER_ERROR, GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        triggerInSysLeaderMemberCommon(query, SYS_NON_LEADER_ERROR, DEFAULT_DATABASE_NAME);
     }
 
     @Test
     public void testTriggerRemoveAllowedOnlyInSysLeaderMember() {
         final String query = "CALL apoc.trigger.remove($name)";
-        triggerInSysLeaderMemberCommon(query, SYS_NON_LEADER_ERROR, GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        triggerInSysLeaderMemberCommon(query, SYS_NON_LEADER_ERROR, DEFAULT_DATABASE_NAME);
     }
 
     @Test
     public void testTriggerInstallAllowedOnlyInSysLeaderMember() {
         final String query = "CALL apoc.trigger.install('neo4j', $name, 'RETURN 1', {})";
-        triggerInSysLeaderMemberCommon(query, TRIGGER_NOT_ROUTED_ERROR, GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
+        triggerInSysLeaderMemberCommon(query, TRIGGER_NOT_ROUTED_ERROR, SYSTEM_DATABASE_NAME);
     }
 
     @Test
     public void testTriggerDropAllowedOnlyInSysLeaderMember() {
         final String query = "CALL apoc.trigger.drop('neo4j', $name)";
-        triggerInSysLeaderMemberCommon(query, TRIGGER_NOT_ROUTED_ERROR, GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
+        triggerInSysLeaderMemberCommon(query, TRIGGER_NOT_ROUTED_ERROR, SYSTEM_DATABASE_NAME);
     }
 
     private static void triggerInSysLeaderMemberCommon(String query, String triggerNotRoutedError, String dbName) {
@@ -102,9 +105,54 @@ public class TriggerClusterRoutingTest {
         }
     }
 
+    @Test
+    public void testTriggersAllowedOnlyWithAdmin() {
+        for (Neo4jContainerExtension container: cluster.getClusterMembers()) {
+            
+            try (Session sysSession = container.getDriver().session(SessionConfig.forDatabase(SYSTEM_DATABASE_NAME))) {
+                if (!sysIsLeader(sysSession)) {
+                    return;
+                }
+                sysSession.run("CREATE USER nonadmin SET PASSWORD 'test' SET PASSWORD CHANGE NOT REQUIRED");
+            }
+
+            try (Driver userDriver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("nonadmin", "test"))) {
+                
+                try (Session sysUserSession = userDriver.session(SessionConfig.forDatabase(SYSTEM_DATABASE_NAME))) {
+                    failsWithNonAdminUser(sysUserSession, "apoc.trigger.install", "call apoc.trigger.install('neo4j', 'qwe', 'return 1', {})");
+                    failsWithNonAdminUser(sysUserSession, "apoc.trigger.drop", "call apoc.trigger.drop('neo4j', 'qwe')");
+                    failsWithNonAdminUser(sysUserSession, "apoc.trigger.dropAll", "call apoc.trigger.dropAll('neo4j')");
+                    failsWithNonAdminUser(sysUserSession, "apoc.trigger.stop", "call apoc.trigger.stop('neo4j', 'qwe')");
+                    failsWithNonAdminUser(sysUserSession, "apoc.trigger.start", "call apoc.trigger.start('neo4j', 'qwe')");
+                }
+                
+                try (Session neo4jUserSession = userDriver.session(SessionConfig.forDatabase(DEFAULT_DATABASE_NAME))) {
+                    failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
+                    failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
+                    failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.removeAll", "call apoc.trigger.removeAll");
+                    failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
+                    failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
+                }
+            }
+            
+        }
+    }
+
     private static boolean sysIsLeader(Session session) {
         final String systemRole = TestContainerUtil.singleResultFirstColumn(session, "CALL dbms.cluster.role('system')");
         return "LEADER".equals(systemRole);
+    }
+    
+    private void failsWithNonAdminUser(Session session, String procName, String query) {
+        try {
+            testCall(session, query,
+                    row -> fail("Should fail because of non admin user") );
+        } catch (Exception e) {
+            String actual = e.getMessage();
+            final String expected = String.format("Executing admin procedure '%s' permission has not been granted for user 'nonadmin'",
+                    procName);
+            assertTrue("Actual error message is: " + actual, actual.contains(expected));
+        }
     }
 
 

--- a/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
@@ -7,9 +7,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
-import org.neo4j.driver.AuthTokens;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.SessionConfig;
 
@@ -17,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static apoc.trigger.Trigger.SYS_NON_LEADER_ERROR;
 import static apoc.trigger.TriggerNewProcedures.TRIGGER_NOT_ROUTED_ERROR;
@@ -109,60 +106,6 @@ public class TriggerClusterRoutingTest {
         final String systemRole = TestContainerUtil.singleResultFirstColumn(session, "CALL dbms.cluster.role('system')");
         return "LEADER".equals(systemRole);
     }
-    
-    @Test
-    public void testTriggerNewProcsAllowedOnlyWithAdmin() {
-        cluster.getSession().run("CREATE USER nonadmin SET PASSWORD \"test\" SET PASSWORD CHANGE NOT REQUIRED");
 
-        for (Neo4jContainerExtension container: cluster.getClusterMembers()) {
-            // todo - in this way if it works
-//            withDbSession(container, "neo4j", session -> {
-//                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
-//                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
-//                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
-//                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
-//                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
-//            });
-            
-            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test")); 
-                 Session session = driver.session(SessionConfig.forDatabase("neo4j"))) {
-
-                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
-                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
-                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
-                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
-                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
-            }
-            
-            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test")); 
-                 Session session = driver.session(SessionConfig.forDatabase("system"))) {
-
-                failsWithNonAdminUser(session, "apoc.trigger.install", "call apoc.trigger.install('neo4j', 'qwe', 'return 1', {})");
-                failsWithNonAdminUser(session, "apoc.trigger.drop", "call apoc.trigger.drop('neo4j', 'qwe')");
-                failsWithNonAdminUser(session, "apoc.trigger.dropAll", "call apoc.trigger.dropAll('neo4j', )");
-                failsWithNonAdminUser(session, "apoc.trigger.stop", "call apoc.trigger.stop('neo4j', 'qwe')");
-                failsWithNonAdminUser(session, "apoc.trigger.start", "call apoc.trigger.start('neo4j', 'qwe')");
-            }
-        }
-    }
-    
-    private void withDbSession(Neo4jContainerExtension container, String dbName, Consumer<Session> runnable) {
-        try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
-             Session session = driver.session(SessionConfig.forDatabase(dbName))) {
-            runnable.accept(session);
-        }
-    }
-            
-    private void failsWithNonAdminUser(Session session, String procName, String query) {
-        try {
-            testCall(session, query, 
-                    row -> fail("Should fail because of non admin user") );
-        } catch (Exception e) {
-            String actual = e.getMessage();
-            final String expected = String.format("Executing admin procedure '%s' permission has not been granted for user 'nonadmin'",
-                    procName);
-            assertTrue(actual.contains(expected));
-        }
-    }
 
 }

--- a/full/src/test/java/apoc/trigger/TriggerClusterTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerClusterTest.java
@@ -1,28 +1,24 @@
 package apoc.trigger;
 
-import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
+import apoc.util.TestUtil;
 import apoc.util.TestcontainersCausalCluster;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.types.Node;
 import org.neo4j.internal.helpers.collection.MapUtil;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
-import static apoc.util.TestContainerUtil.testCall;
+import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 import static org.neo4j.driver.SessionConfig.forDatabase;
@@ -34,15 +30,15 @@ public class TriggerClusterTest {
 
     @BeforeClass
     public static void setupCluster() {
-//        assumeFalse(isRunningInCI());
-        /*TestUtil.ignoreException(() ->  */cluster = TestContainerUtil
+        assumeFalse(isRunningInCI());
+        TestUtil.ignoreException(() ->  cluster = TestContainerUtil
                 .createEnterpriseCluster(3, 1, Collections.emptyMap(), MapUtil.stringMap(
                         "apoc.trigger.refresh", "100",
                         "apoc.trigger.enabled", "true"
-                ))/*,
-                Exception.class)*/;
-//        Assume.assumeNotNull(cluster);
-//        Assume.assumeTrue(cluster.isRunning());
+                )),
+                Exception.class);
+        Assume.assumeNotNull(cluster);
+        Assume.assumeTrue(cluster.isRunning());
     }
 
     @AfterClass
@@ -213,60 +209,5 @@ public class TriggerClusterTest {
                                 .single().get("name").asString()),
                 name::equals,
                 30, TimeUnit.SECONDS);
-    }
-
-    @Test
-    public void testTriggerNewProcsAllowedOnlyWithAdmin() {
-        cluster.getSession().run("CREATE USER nonadmin SET PASSWORD \"test\" SET PASSWORD CHANGE NOT REQUIRED");
-
-        for (Neo4jContainerExtension container: cluster.getClusterMembers()) {
-            // todo - in this way if it works
-//            withDbSession(container, "neo4j", session -> {
-//                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
-//                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
-//                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
-//                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
-//                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
-//            });
-
-            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
-                 Session session = driver.session(SessionConfig.forDatabase("neo4j"))) {
-
-                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
-                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
-                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
-                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
-                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
-            }
-
-            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
-                 Session session = driver.session(SessionConfig.forDatabase("system"))) {
-
-                failsWithNonAdminUser(session, "apoc.trigger.install", "call apoc.trigger.install('neo4j', 'qwe', 'return 1', {})");
-                failsWithNonAdminUser(session, "apoc.trigger.drop", "call apoc.trigger.drop('neo4j', 'qwe')");
-                failsWithNonAdminUser(session, "apoc.trigger.dropAll", "call apoc.trigger.dropAll('neo4j', )");
-                failsWithNonAdminUser(session, "apoc.trigger.stop", "call apoc.trigger.stop('neo4j', 'qwe')");
-                failsWithNonAdminUser(session, "apoc.trigger.start", "call apoc.trigger.start('neo4j', 'qwe')");
-            }
-        }
-    }
-
-    private void withDbSession(Neo4jContainerExtension container, String dbName, Consumer<Session> runnable) {
-        try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
-             Session session = driver.session(SessionConfig.forDatabase(dbName))) {
-            runnable.accept(session);
-        }
-    }
-
-    private void failsWithNonAdminUser(Session session, String procName, String query) {
-        try {
-            testCall(session, query,
-                    row -> fail("Should fail because of non admin user") );
-        } catch (Exception e) {
-            String actual = e.getMessage();
-            final String expected = String.format("Executing admin procedure '%s' permission has not been granted for user 'nonadmin'",
-                    procName);
-            assertTrue(actual.contains(expected));
-        }
     }
 }

--- a/full/src/test/java/apoc/trigger/TriggerClusterTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerClusterTest.java
@@ -1,24 +1,28 @@
 package apoc.trigger;
 
+import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
-import apoc.util.TestUtil;
 import apoc.util.TestcontainersCausalCluster;
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.types.Node;
 import org.neo4j.internal.helpers.collection.MapUtil;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
-import static apoc.util.TestUtil.isRunningInCI;
+import static apoc.util.TestContainerUtil.testCall;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.Assert.fail;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 import static org.neo4j.driver.SessionConfig.forDatabase;
@@ -30,15 +34,15 @@ public class TriggerClusterTest {
 
     @BeforeClass
     public static void setupCluster() {
-        assumeFalse(isRunningInCI());
-        TestUtil.ignoreException(() ->  cluster = TestContainerUtil
+//        assumeFalse(isRunningInCI());
+        /*TestUtil.ignoreException(() ->  */cluster = TestContainerUtil
                 .createEnterpriseCluster(3, 1, Collections.emptyMap(), MapUtil.stringMap(
                         "apoc.trigger.refresh", "100",
                         "apoc.trigger.enabled", "true"
-                )),
-                Exception.class);
-        Assume.assumeNotNull(cluster);
-        Assume.assumeTrue(cluster.isRunning());
+                ))/*,
+                Exception.class)*/;
+//        Assume.assumeNotNull(cluster);
+//        Assume.assumeTrue(cluster.isRunning());
     }
 
     @AfterClass
@@ -209,5 +213,60 @@ public class TriggerClusterTest {
                                 .single().get("name").asString()),
                 name::equals,
                 30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testTriggerNewProcsAllowedOnlyWithAdmin() {
+        cluster.getSession().run("CREATE USER nonadmin SET PASSWORD \"test\" SET PASSWORD CHANGE NOT REQUIRED");
+
+        for (Neo4jContainerExtension container: cluster.getClusterMembers()) {
+            // todo - in this way if it works
+//            withDbSession(container, "neo4j", session -> {
+//                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
+//                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
+//                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
+//                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
+//                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
+//            });
+
+            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
+                 Session session = driver.session(SessionConfig.forDatabase("neo4j"))) {
+
+                failsWithNonAdminUser(session, "apoc.trigger.add", "call apoc.trigger.add('abc', 'return 1', {})");
+                failsWithNonAdminUser(session, "apoc.trigger.remove", "call apoc.trigger.remove('abc')");
+                failsWithNonAdminUser(session, "apoc.trigger.removeAll", "call apoc.trigger.removeAll()");
+                failsWithNonAdminUser(session, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
+                failsWithNonAdminUser(session, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
+            }
+
+            try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
+                 Session session = driver.session(SessionConfig.forDatabase("system"))) {
+
+                failsWithNonAdminUser(session, "apoc.trigger.install", "call apoc.trigger.install('neo4j', 'qwe', 'return 1', {})");
+                failsWithNonAdminUser(session, "apoc.trigger.drop", "call apoc.trigger.drop('neo4j', 'qwe')");
+                failsWithNonAdminUser(session, "apoc.trigger.dropAll", "call apoc.trigger.dropAll('neo4j', )");
+                failsWithNonAdminUser(session, "apoc.trigger.stop", "call apoc.trigger.stop('neo4j', 'qwe')");
+                failsWithNonAdminUser(session, "apoc.trigger.start", "call apoc.trigger.start('neo4j', 'qwe')");
+            }
+        }
+    }
+
+    private void withDbSession(Neo4jContainerExtension container, String dbName, Consumer<Session> runnable) {
+        try (final Driver driver = GraphDatabase.driver(container.getBoltUrl(), AuthTokens.basic("neo4j", "test"));
+             Session session = driver.session(SessionConfig.forDatabase(dbName))) {
+            runnable.accept(session);
+        }
+    }
+
+    private void failsWithNonAdminUser(Session session, String procName, String query) {
+        try {
+            testCall(session, query,
+                    row -> fail("Should fail because of non admin user") );
+        } catch (Exception e) {
+            String actual = e.getMessage();
+            final String expected = String.format("Executing admin procedure '%s' permission has not been granted for user 'nonadmin'",
+                    procName);
+            assertTrue(actual.contains(expected));
+        }
     }
 }


### PR DESCRIPTION
https://trello.com/c/qwJFy8pp/1784-trigger-procedures-should-use-checkadmin

Better to use `@Admin` check instead of `Util.checkAdmin`, like [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/8a9d0ca3758817ad92dc61b39cc7e54451cfcc44) ,
because 
- it will most likely be compatible with future versions
- it doesn't require additional contexts:
```
    @Context
    public SecurityContext securityContext;

    @Context
    public ProcedureCallContext callContext;
```
- similar error, but with more details

```
// with Admin annotation
Executing admin procedure 'apoc.trigger.remove' permission has not been granted for user 'name' with roles [PUBLIC, editor, publisher] restricted to TOKEN_WRITE.
```

```
// with Util.checkAdmin
Failed to invoke procedure `apoc.trigger.add`: Caused by: java.lang.RuntimeException: This procedure apoc.trigger.install is only available to admin users
```

- we don't have to specify the procedure name, e.g. `Util.checkAdmin(securityContext, callContext,"apoc.trigger.install");`

