### PR TITLE
Issue 3358: apoc extended on 5.2 throws errors for missing config values

### DIFF
--- a/extended/src/main/java/apoc/TTLConfig.java
+++ b/extended/src/main/java/apoc/TTLConfig.java
@@ -23,7 +23,7 @@ public class TTLConfig extends LifecycleAdapter {
         String apocTTLEnabledDb = String.format(ExtendedApocConfig.APOC_TTL_ENABLED_DB, db.databaseName());
         String apocTTLScheduleDb = String.format(ExtendedApocConfig.APOC_TTL_SCHEDULE_DB, db.databaseName());
         String apocTTLLimitDb = String.format(ExtendedApocConfig.APOC_TTL_LIMIT_DB, db.databaseName());
-        boolean enabled = apocConfig.getBoolean(ExtendedApocConfig.APOC_TTL_ENABLED);
+        boolean enabled = apocConfig.getBoolean(ExtendedApocConfig.APOC_TTL_ENABLED, false);
         boolean dbEnabled = apocConfig.getBoolean(apocTTLEnabledDb, enabled);
 
         if (dbEnabled) {

--- a/extended/src/main/java/apoc/uuid/UuidHandler.java
+++ b/extended/src/main/java/apoc/uuid/UuidHandler.java
@@ -67,7 +67,7 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
 
     private boolean isEnabled() {
         String apocUUIDEnabledDb = String.format(APOC_UUID_ENABLED_DB, this.db.databaseName());
-        return apocConfig.getConfig().getBoolean(apocUUIDEnabledDb, apocConfig.getBoolean(APOC_UUID_ENABLED));
+        return apocConfig.getConfig().getBoolean(apocUUIDEnabledDb, apocConfig.getBoolean(APOC_UUID_ENABLED, false));
     }
 
     @Override

--- a/extended/src/main/java/apoc/uuid/UuidHandler.java
+++ b/extended/src/main/java/apoc/uuid/UuidHandler.java
@@ -67,7 +67,8 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
 
     private boolean isEnabled() {
         String apocUUIDEnabledDb = String.format(APOC_UUID_ENABLED_DB, this.db.databaseName());
-        return apocConfig.getConfig().getBoolean(apocUUIDEnabledDb, apocConfig.getBoolean(APOC_UUID_ENABLED, false));
+        final boolean enabled = apocConfig.getBoolean(APOC_UUID_ENABLED, false);
+        return apocConfig.getConfig().getBoolean(apocUUIDEnabledDb, enabled);
     }
 
     @Override


### PR DESCRIPTION
Issue 3358: apoc extended on 5.2 throws errors for missing config values