### PR TITLE
Issue 2612 review

### DIFF
--- a/core/src/main/antlr/apoc/custom/Signature.g4
+++ b/core/src/main/antlr/apoc/custom/Signature.g4
@@ -13,7 +13,7 @@ defaultValue: value;
 
 list_type:	'LIST''?'?' OF '+opt_type ;
 opt_type:	base_type'?'? ;
-base_type:	'MAP' | 'ANY' | 'NODE' | 'REL' | 'RELATIONSHIP' | 'EDGE' | 'PATH' | 'NUMBER' | 'LONG' | 'INT' | 'INTEGER' | 'FLOAT' | 'DOUBLE' | 'BOOL' | 'BOOLEAN' | 'DATE' | 'TIME' | 'LOCALTIME' | 'DATETIME' | 'LOCALDATETIME' | 'DURATION' | 'POINT' | 'GEO' | 'GEOMETRY' | 'STRING' | 'TEXT' ;
+base_type:	'MAP' | 'MAPRESULT' | 'ANY' | 'NODE' | 'REL' | 'RELATIONSHIP' | 'EDGE' | 'PATH' | 'NUMBER' | 'LONG' | 'INT' | 'INTEGER' | 'FLOAT' | 'DOUBLE' | 'BOOL' | 'BOOLEAN' | 'DATE' | 'TIME' | 'LOCALTIME' | 'DATETIME' | 'LOCALDATETIME' | 'DURATION' | 'POINT' | 'GEO' | 'GEOMETRY' | 'STRING' | 'TEXT' ;
 NEWLINE:	[\r\n]+ ;
 QUOTED_IDENTIFIER:	'`' [^`]+? '`' ;
 IDENTIFIER:	[a-zA-Z_][a-zA-Z0-9_]+ ;

--- a/core/src/main/java/apoc/SystemPropertyKeys.java
+++ b/core/src/main/java/apoc/SystemPropertyKeys.java
@@ -13,7 +13,7 @@ public enum SystemPropertyKeys  {
     outputs,
     output,
     forceSingle,
-    category,
+    mapResult,
     prefix,
 
     // triggers

--- a/core/src/main/java/apoc/SystemPropertyKeys.java
+++ b/core/src/main/java/apoc/SystemPropertyKeys.java
@@ -13,6 +13,7 @@ public enum SystemPropertyKeys  {
     outputs,
     output,
     forceSingle,
+    category,
     prefix,
 
     // triggers

--- a/full/src/main/java/apoc/custom/CypherProcedures.java
+++ b/full/src/main/java/apoc/custom/CypherProcedures.java
@@ -106,7 +106,7 @@ public class CypherProcedures {
                            @Name(value = "description", defaultValue = "") String description) throws ProcedureException {
         UserFunctionSignature signature = cypherProceduresHandler.functionSignature(name, output, inputs, description);
         validateFunction(statement, signature.inputSignature());
-        cypherProceduresHandler.storeFunction(signature, statement, forceSingle);
+        cypherProceduresHandler.storeFunction(signature, statement, forceSingle, false);
     }
 
     @Procedure(value = "apoc.custom.declareFunction", mode = Mode.WRITE)
@@ -114,12 +114,15 @@ public class CypherProcedures {
     public void declareFunction(@Name("signature") String signature, @Name("statement") String statement,
                            @Name(value = "forceSingle", defaultValue = "false") boolean forceSingle,
                            @Name(value = "description", defaultValue = "") String description) throws ProcedureException {
-        UserFunctionSignature userFunctionSignature = new Signatures(PREFIX).asFunctionSignature(signature, description);
+        final Signatures signatures = new Signatures(PREFIX);
+        final SignatureParser.FunctionContext functionContext = signatures.parseFunction(signature);
+        UserFunctionSignature userFunctionSignature = signatures.toFunctionSignature(functionContext, description);
         validateFunction(statement, userFunctionSignature.inputSignature());
-        if (!cypherProceduresHandler.registerFunction(userFunctionSignature, statement, forceSingle)) {
+        final boolean mapResultType = signatures.isMapResultType(functionContext);
+        if (!cypherProceduresHandler.registerFunction(userFunctionSignature, statement, forceSingle, mapResultType)) {
             throw new IllegalStateException("Error registering function " + signature + ", see log.");
         }
-        cypherProceduresHandler.storeFunction(userFunctionSignature, statement, forceSingle);
+        cypherProceduresHandler.storeFunction(userFunctionSignature, statement, forceSingle, mapResultType);
     }
 
 

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -195,7 +195,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         List<FieldSignature> inputs = deserializeSignatures(property);
 
         boolean forceSingle = (boolean) node.getProperty(SystemPropertyKeys.forceSingle.name(), false);
-        final String isMapResult = (String) node.getProperty(SystemPropertyKeys.category.name());
         return new UserFunctionDescriptor(new UserFunctionSignature(
                 new QualifiedName(prefix, name),
                 inputs,
@@ -203,7 +202,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 null,
                 new String[0],
                 description,
-                getCategory(isMapResult),
+                (String) node.getProperty(SystemPropertyKeys.category.name()),
                 false
         ), statement, forceSingle);
     }
@@ -251,7 +250,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));
             node.setProperty(SystemPropertyKeys.output.name(), signature.outputType().toString());
             node.setProperty(SystemPropertyKeys.forceSingle.name(), forceSingle);
-            node.setProperty(SystemPropertyKeys.category.name(), getCategory(signature.category().orElse(null)));
+            node.setProperty(SystemPropertyKeys.category.name(), signature.category().orElse(null));
 
             setLastUpdate(tx);
             registerFunction(signature, statement, forceSingle);

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -397,17 +397,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                             List<String> cols = result.columns();
                             if (cols.isEmpty()) return null;
                             if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
-                                Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
-                                Neo4jTypes.AnyType innerType = listType.innerType();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (innerType.getClass().equals(Neo4jTypes.MapType.class))
-                                    return ValueUtils.of(result.stream().collect(Collectors.toList()));
                                 if (cols.size() == 1)
                                     return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
                             } else {
                                 Map<String, Object> row = result.next();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
                                 if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
                             }
                             throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -58,8 +58,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.ApocConfig.apocConfig;
-import static apoc.custom.Signatures.APOC_CUSTOM_MAPRESULT;
-import static apoc.custom.Signatures.getCategory;
 import static java.util.Collections.singletonList;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.AnyType;
@@ -202,9 +200,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 null,
                 new String[0],
                 description,
-                (String) node.getProperty(SystemPropertyKeys.category.name()),
+                "apoc.custom",
                 false
-        ), statement, forceSingle);
+        ), statement, forceSingle, (boolean) node.getProperty(SystemPropertyKeys.mapResult.name()));
     }
 
     public void restoreProceduresAndFunctions() {
@@ -238,7 +236,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
-    public void storeFunction(UserFunctionSignature signature, String statement, boolean forceSingle) {
+    public void storeFunction(UserFunctionSignature signature, String statement, boolean forceSingle, boolean mapResult) {
         withSystemDb(tx -> {
             Node node = Util.mergeNode(tx, SystemLabels.ApocCypherProcedures, SystemLabels.Function,
                     Pair.of(SystemPropertyKeys.database.name(), api.databaseName()),
@@ -250,10 +248,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));
             node.setProperty(SystemPropertyKeys.output.name(), signature.outputType().toString());
             node.setProperty(SystemPropertyKeys.forceSingle.name(), forceSingle);
-            node.setProperty(SystemPropertyKeys.category.name(), signature.category().orElse(null));
+            node.setProperty(SystemPropertyKeys.mapResult.name(), mapResult);
 
             setLastUpdate(tx);
-            registerFunction(signature, statement, forceSingle);
+            registerFunction(signature, statement, forceSingle, mapResult);
             return null;
         });
     }
@@ -378,6 +376,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     }
 
     public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle) {
+        return registerFunction(signature, statement, forceSingle, false);
+    }
+
+    public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle, boolean mapResult) {
         try {
             final boolean isStatementNull = statement == null;
             globalProceduresRegistry.register(new CallableUserFunction.BasicUserFunction(signature) {
@@ -399,25 +401,17 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                             }
                             List<String> cols = result.columns();
                             if (cols.isEmpty()) return null;
-                            final boolean isNotMapResult = !APOC_CUSTOM_MAPRESULT.equals(
-                                    signature.category().orElse(null)
-                            );
                             if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
                                 Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
-                                Neo4jTypes.AnyType innerType = listType.innerType();
-                                // We wrap the result only if we have a "true" map, 
-                                // so neither NodeType or RelationshipType that extends MapType
-                                // nor a signature with a `MAPRESULT` / `LIST OF MAPRESULT` output
-                                if (isNotMapResult && innerType.getClass().equals(Neo4jTypes.MapType.class))
+                                AnyType innerType = listType.innerType();
+
+                                if (isWrapped(innerType, mapResult))
                                     return ValueUtils.of(result.stream().collect(Collectors.toList()));
                                 if (cols.size() == 1)
                                     return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
                             } else {
                                 Map<String, Object> row = result.next();
-                                // We wrap the result only if we have a "true" map, 
-                                // so neither NodeType or RelationshipType that extends MapType
-                                // nor a signature with a `MAPRESULT` / `LIST OF MAPRESULT` output
-                                if (isNotMapResult && outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
+                                if (isWrapped(outType, mapResult)) return ValueUtils.of(row);
                                 if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
                             }
                             throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
@@ -436,6 +430,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             log.error("Could not register function: " + signature + "\nwith: " + statement + "\n single result " + forceSingle, e);
             return false;
         }
+    }
+
+    private static boolean isWrapped(AnyType outType, boolean mapResult) {
+        // We wrap the result only if we have a "true" map, 
+        // so neither NodeType or RelationshipType that extends MapType
+        // nor a signature with a `MAPRESULT` / `LIST OF MAPRESULT` output
+        return !mapResult && outType.getClass().equals(Neo4jTypes.MapType.class);
     }
 
     public static QualifiedName qualifiedName(@Name("name") String name) {
@@ -695,11 +696,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     public class UserFunctionDescriptor extends ProcedureOrFunctionDescriptor {
         private final UserFunctionSignature signature;
         private final boolean forceSingle;
+        private final boolean mapResult;
 
-        public UserFunctionDescriptor(UserFunctionSignature signature, String statement, boolean forceSingle) {
+        public UserFunctionDescriptor(UserFunctionSignature signature, String statement, boolean forceSingle, boolean mapResult) {
             super(statement);
             this.signature = signature;
             this.forceSingle = forceSingle;
+            this.mapResult = mapResult;
         }
 
         public UserFunctionSignature getSignature() {
@@ -710,9 +713,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             return forceSingle;
         }
 
+        public boolean isMapResult() {
+            return mapResult;
+        }
+
         @Override
         public void register() {
-            registerFunction(getSignature(), getStatement(), isForceSingle());
+            registerFunction(getSignature(), getStatement(), isForceSingle(), isMapResult());
         }
     }
 }

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -58,6 +58,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.ApocConfig.apocConfig;
+import static apoc.custom.Signatures.APOC_CUSTOM_MAPRESULT;
+import static apoc.custom.Signatures.getCategory;
 import static java.util.Collections.singletonList;
 import static org.neo4j.internal.helpers.collection.MapUtil.map;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.AnyType;
@@ -193,6 +195,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         List<FieldSignature> inputs = deserializeSignatures(property);
 
         boolean forceSingle = (boolean) node.getProperty(SystemPropertyKeys.forceSingle.name(), false);
+        final String isMapResult = (String) node.getProperty(SystemPropertyKeys.category.name());
         return new UserFunctionDescriptor(new UserFunctionSignature(
                 new QualifiedName(prefix, name),
                 inputs,
@@ -200,7 +203,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 null,
                 new String[0],
                 description,
-                "apoc.custom",
+                getCategory(isMapResult),
                 false
         ), statement, forceSingle);
     }
@@ -248,6 +251,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));
             node.setProperty(SystemPropertyKeys.output.name(), signature.outputType().toString());
             node.setProperty(SystemPropertyKeys.forceSingle.name(), forceSingle);
+            node.setProperty(SystemPropertyKeys.category.name(), getCategory(signature.category().orElse(null)));
 
             setLastUpdate(tx);
             registerFunction(signature, statement, forceSingle);
@@ -396,11 +400,25 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                             }
                             List<String> cols = result.columns();
                             if (cols.isEmpty()) return null;
+                            final boolean isNotMapResult = !APOC_CUSTOM_MAPRESULT.equals(
+                                    signature.category().orElse(null)
+                            );
                             if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
+                                Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
+                                Neo4jTypes.AnyType innerType = listType.innerType();
+                                // We wrap the result only if we have a "true" map, 
+                                // so neither NodeType or RelationshipType that extends MapType
+                                // nor a signature with a `MAPRESULT` / `LIST OF MAPRESULT` output
+                                if (isNotMapResult && innerType.getClass().equals(Neo4jTypes.MapType.class))
+                                    return ValueUtils.of(result.stream().collect(Collectors.toList()));
                                 if (cols.size() == 1)
                                     return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
                             } else {
                                 Map<String, Object> row = result.next();
+                                // We wrap the result only if we have a "true" map, 
+                                // so neither NodeType or RelationshipType that extends MapType
+                                // nor a signature with a `MAPRESULT` / `LIST OF MAPRESULT` output
+                                if (isNotMapResult && outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
                                 if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
                             }
                             throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);

--- a/full/src/main/java/apoc/custom/Signatures.java
+++ b/full/src/main/java/apoc/custom/Signatures.java
@@ -10,12 +10,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-<<<<<<< HEAD
-import java.util.function.Supplier;
-=======
-import java.util.Optional;
->>>>>>> 10bd4fb8a (change getCategory(..) handling)
 import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.*;
 
@@ -23,7 +19,6 @@ public class Signatures {
 
     public static final String SIGNATURE_SYNTAX_ERROR = "Syntax error(s) in signature definition %s. " +
             "\nNote that procedure/function name, possible map keys, input and output names must have at least 2 character:\n";
-    public static final String APOC_CUSTOM_MAPRESULT = "apoc.custom (MAPRESULT)";
     private static final String MAP_RESULT_TYPE = "MAPRESULT";
     private final String prefix;
 
@@ -123,27 +118,7 @@ public class Signatures {
         String[] allowed = new String[0];
         boolean caseInsensitive = true;
 
-        final String category = getCategory(outputType);
-        return new UserFunctionSignature(name, inputSignatures, type, deprecated, allowed, description, category, caseInsensitive);
-    }
-
-    public static String getCategory(SignatureParser.TypeContext typeContext) {
-        final SignatureParser.List_typeContext list_typeContext = typeContext.list_type();
-        
-        // return output type of list_typeContext (i.e. return type contains `LIST OF `) or typeContext (otherwise)
-        final SignatureParser.Opt_typeContext opt_typeContext = Optional.ofNullable(list_typeContext)
-                .map(SignatureParser.List_typeContext::opt_type)
-                .orElse(typeContext.opt_type());
-
-        // if return type is `LIST OF MAPRESULT` or `MAPRESULT`
-        if (isMapResult(opt_typeContext)) {
-            return APOC_CUSTOM_MAPRESULT;
-        }
-        return "apoc.custom";
-    }
-
-    private static boolean isMapResult(SignatureParser.Opt_typeContext outTypeContext) {
-        return outTypeContext.base_type().getText().equals(MAP_RESULT_TYPE);
+        return new UserFunctionSignature(name, inputSignatures, type, deprecated, allowed, description, "apoc.custom",caseInsensitive);
     }
 
     private DefaultParameterValue defaultValue(SignatureParser.DefaultValueContext defaultValue, Neo4jTypes.AnyType type) {
@@ -215,6 +190,12 @@ public class Signatures {
             return type(typeContext.opt_type());
         }
         return Neo4jTypes.NTAny;
+    }
+
+    public boolean isMapResultType(SignatureParser.FunctionContext functionContext) {
+        final SignatureParser.TypeContext outputType = functionContext.type();
+
+        return outputType.getText().contains(MAP_RESULT_TYPE);
     }
 
     private Neo4jTypes.AnyType type(SignatureParser.Opt_typeContext opt_type) {

--- a/full/src/main/java/apoc/custom/Signatures.java
+++ b/full/src/main/java/apoc/custom/Signatures.java
@@ -10,7 +10,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+<<<<<<< HEAD
 import java.util.function.Supplier;
+=======
+import java.util.Optional;
+>>>>>>> 10bd4fb8a (change getCategory(..) handling)
 import java.util.stream.Collectors;
 
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.*;
@@ -20,6 +24,7 @@ public class Signatures {
     public static final String SIGNATURE_SYNTAX_ERROR = "Syntax error(s) in signature definition %s. " +
             "\nNote that procedure/function name, possible map keys, input and output names must have at least 2 character:\n";
     public static final String APOC_CUSTOM_MAPRESULT = "apoc.custom (MAPRESULT)";
+    private static final String MAP_RESULT_TYPE = "MAPRESULT";
     private final String prefix;
 
     public Signatures(String prefix) {
@@ -109,7 +114,8 @@ public class Signatures {
     public UserFunctionSignature toFunctionSignature(SignatureParser.FunctionContext signature, String description) {
         QualifiedName name = new QualifiedName(namespace(signature.namespace()), name(signature.name()));
 
-        Neo4jTypes.AnyType type = type(signature.type());
+        final SignatureParser.TypeContext outputType = signature.type();
+        Neo4jTypes.AnyType type = type(outputType);
 
         List<FieldSignature> inputSignatures = signature.parameter().stream().map(p -> getInputField(name(p.name()), type(p.type()), defaultValue(p.defaultValue(), type(p.type())))).collect(Collectors.toList());
 
@@ -117,15 +123,27 @@ public class Signatures {
         String[] allowed = new String[0];
         boolean caseInsensitive = true;
 
-        final String category = getCategory(signature.type().getText());
+        final String category = getCategory(outputType);
         return new UserFunctionSignature(name, inputSignatures, type, deprecated, allowed, description, category, caseInsensitive);
     }
 
-    public static String getCategory(String isMapResult) {
-        if (isMapResult != null && isMapResult.contains("MAPRESULT")) {
+    public static String getCategory(SignatureParser.TypeContext typeContext) {
+        final SignatureParser.List_typeContext list_typeContext = typeContext.list_type();
+        
+        // return output type of list_typeContext (i.e. return type contains `LIST OF `) or typeContext (otherwise)
+        final SignatureParser.Opt_typeContext opt_typeContext = Optional.ofNullable(list_typeContext)
+                .map(SignatureParser.List_typeContext::opt_type)
+                .orElse(typeContext.opt_type());
+
+        // if return type is `LIST OF MAPRESULT` or `MAPRESULT`
+        if (isMapResult(opt_typeContext)) {
             return APOC_CUSTOM_MAPRESULT;
         }
         return "apoc.custom";
+    }
+
+    private static boolean isMapResult(SignatureParser.Opt_typeContext outTypeContext) {
+        return outTypeContext.base_type().getText().equals(MAP_RESULT_TYPE);
     }
 
     private DefaultParameterValue defaultValue(SignatureParser.DefaultValueContext defaultValue, Neo4jTypes.AnyType type) {
@@ -204,6 +222,7 @@ public class Signatures {
             case "ANY":
                 return NTAny;
             case "MAP":
+            case MAP_RESULT_TYPE:
                 return NTMap;
             case "NODE":
                 return NTNode;

--- a/full/src/main/java/apoc/custom/Signatures.java
+++ b/full/src/main/java/apoc/custom/Signatures.java
@@ -19,6 +19,7 @@ public class Signatures {
 
     public static final String SIGNATURE_SYNTAX_ERROR = "Syntax error(s) in signature definition %s. " +
             "\nNote that procedure/function name, possible map keys, input and output names must have at least 2 character:\n";
+    public static final String APOC_CUSTOM_MAPRESULT = "apoc.custom (MAPRESULT)";
     private final String prefix;
 
     public Signatures(String prefix) {
@@ -115,7 +116,16 @@ public class Signatures {
         String deprecated = "";
         String[] allowed = new String[0];
         boolean caseInsensitive = true;
-        return new UserFunctionSignature(name, inputSignatures, type, deprecated, allowed, description, "apoc.custom",caseInsensitive);
+
+        final String category = getCategory(signature.type().getText());
+        return new UserFunctionSignature(name, inputSignatures, type, deprecated, allowed, description, category, caseInsensitive);
+    }
+
+    public static String getCategory(String isMapResult) {
+        if (isMapResult != null && isMapResult.contains("MAPRESULT")) {
+            return APOC_CUSTOM_MAPRESULT;
+        }
+        return "apoc.custom";
     }
 
     private DefaultParameterValue defaultValue(SignatureParser.DefaultValueContext defaultValue, Neo4jTypes.AnyType type) {
@@ -129,7 +139,7 @@ public class Signatures {
             return DefaultParameterValue.ntBoolean(Boolean.parseBoolean(v.boolValue().getText()));
         final SignatureParser.StringValueContext stringCxt = v.stringValue();
         if (stringCxt != null) {
-            
+
             String text = stringCxt.getText();
             if (stringCxt.SINGLE_QUOTED_STRING_VALUE() != null || stringCxt.QUOTED_STRING_VALUE() != null) {
                 text = text.substring(1, text.length() - 1);
@@ -157,18 +167,18 @@ public class Signatures {
                         .collect(Collectors.toList());
             }
             return DefaultParameterValue.ntList(list, inner);
-            
+
         }
         return DefaultParameterValue.nullValue(type);
     }
 
     private DefaultParameterValue getDefaultParameterValue(AnyType type, String text, Supplier<DefaultParameterValue> fun) {
-        // to differentiate e.g. null (nullValue) from null as a plain string, or 1 (integer) from 1 as a plain text 
-        // we have to obtain the actual data type from type. 
+        // to differentiate e.g. null (nullValue) from null as a plain string, or 1 (integer) from 1 as a plain text
+        // we have to obtain the actual data type from type.
         // Otherwise we could we can remove the possibility of having plainText string and explicit them via quotes/double-quotes
         // or document that null/numbers/boolean as a plain string are not possible.
-        return type instanceof TextType 
-                ? DefaultParameterValue.ntString(text) 
+        return type instanceof TextType
+                ? DefaultParameterValue.ntString(text)
                 : fun.get();
     }
 

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -69,13 +69,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleFunctionWithDotInName() {
         db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
         });
         restartDb();
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
@@ -137,9 +137,9 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunction() {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, (((List)row.get("row"))).get(0)));
         restartDb();
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, (((List)row.get("row"))).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("answer", row.get("name"));
             assertEquals("function", row.get("type"));
@@ -149,13 +149,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunctionWithDotInName() {
         db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
         });
         restartDb();
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertEquals;
@@ -69,13 +70,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleFunctionWithDotInName() {
         db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
         });
         restartDb();
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
@@ -137,9 +138,9 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunction() {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, (((List)row.get("row"))).get(0)));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         restartDb();
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, (((List)row.get("row"))).get(0)));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("answer", row.get("name"));
             assertEquals("function", row.get("type"));
@@ -149,13 +150,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunctionWithDotInName() {
         db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
         });
         restartDb();
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
@@ -264,6 +265,69 @@ public class CypherProceduresStorageTest {
         db.executeTransactionally("call apoc.custom.declareFunction('sumFun1(input1 = null::INT, input2 = null::INT) :: INT',$query)",
                 map("query", QUERY_OVERWRITE));
         functionAssertions();
+    }
+
+
+    @Test
+    public void functionSignatureShouldNotChangeBeforeAndAfterRestartAndOverwriteMap() {
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map(val :: INTEGER) :: MAP ', 'RETURN {value : $val} as value')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_list(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result(val :: INTEGER) :: MAPRESULT ', 'RETURN {value : $val} as value')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result_list(val :: INTEGER) :: LIST OF MAPRESULT ', 'RETURN [{value : $val}] as value')");
+        
+        functionMapAssertions();
+        
+        restartDb();
+        functionMapAssertions();
+    }
+
+    private void functionMapAssertions() {
+        // check that both `MAP` and `MAPRESULT` have signature `MAP?` when it runs `SHOW FUNCTIONS` command
+        TestUtil.testResult(db, "SHOW FUNCTIONS YIELD signature, name WHERE name STARTS WITH 'custom.map' RETURN DISTINCT name, signature ORDER BY name",
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEquals("custom.map(val :: INTEGER?) :: (MAP?)", row.get("signature"));
+                    row = r.next();
+                    assertEquals("custom.map_list(val :: INTEGER?) :: (LIST? OF MAP?)", row.get("signature"));
+                    row = r.next();
+                    assertEquals("custom.map_result(val :: INTEGER?) :: (MAP?)", row.get("signature"));
+                    row = r.next();
+                    assertEquals("custom.map_result_list(val :: INTEGER?) :: (LIST? OF MAP?)", row.get("signature"));
+                    assertFalse(r.hasNext());
+                });
+
+        TestUtil.testResult(db, "call apoc.custom.list",
+                row -> {
+                    final Set<String> sumFun1 = Set.of("map", "map_list", "map_result", "map_result_list");
+                    assertEquals(sumFun1, Iterators.asSet(row.columnAs("name")));
+                });
+
+        // then
+        TestUtil.testResult(db, "RETURN custom.map_result(3) AS val", (result) -> {
+            Map<String, Object> map = result.<Map<String, Object>>columnAs("val").next();
+            assertEquals(1, map.size());
+            assertEquals(3L, map.get("value"));
+        });
+        TestUtil.testResult(db, "RETURN custom.map_result_list(4) AS val", (result) -> {
+            List<List<Map<String, Object>>> list = result.<List<List<Map<String, Object>>>>columnAs("val").next();
+            assertEquals(1, list.size());
+            List<Map<String, Object>> map = list.get(0);
+            assertEquals(1, map.size());
+            assertEquals(4L, map.get(0).get("value"));
+        });
+
+        TestUtil.testResult(db, "RETURN custom.map(3) AS val", (result) -> {
+            Map<String, Map<String, Object>> map = result.<Map<String, Map<String, Object>>>columnAs("val").next();
+            assertEquals(1, map.size());
+            assertEquals(3L, map.get("value").get("value"));
+        });
+        TestUtil.testResult(db, "RETURN custom.map_list(4) AS val", (result) -> {
+            List<Map<String, List<Map<String, Object>>>> list = result.<List<Map<String, List<Map<String, Object>>>>>columnAs("val").next();
+            assertEquals(1, list.size());
+            assertEquals(1, list.get(0).size());
+            assertEquals(4L, list.get(0).get("value").get(0).get("value"));
+        });
+
     }
 
     @Test

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -193,15 +193,16 @@ public class CypherProceduresTest  {
             assertEquals(2L, node.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map(3) AS val", (result) -> {
-            Map<String, Map<String, Object>> map = result.<Map<String, Map<String, Object>>>columnAs("val").next();
+            Map<String, Object> map = result.<Map<String, Object>>columnAs("val").next();
             assertEquals(1, map.size());
-            assertEquals(3L, map.get("value").get("value"));
+            assertEquals(3L, map.get("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map_list(4) AS val", (result) -> {
-            List<Map<String, List<Map<String, Object>>>> list = result.<List<Map<String, List<Map<String, Object>>>>>columnAs("val").next();
+            List<List<Map<String, Object>>> list = result.<List<List<Map<String, Object>>>>columnAs("val").next();
             assertEquals(1, list.size());
-            assertEquals(1, list.get(0).size());
-            assertEquals(4L, list.get(0).get("value").get(0).get("value"));
+            List<Map<String, Object>> map = list.get(0);
+            assertEquals(1, map.size());
+            assertEquals(4L, map.get(0).get("value"));
         });
     }
 
@@ -229,18 +230,16 @@ public class CypherProceduresTest  {
             assertEquals(2L, t.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map(3) AS val", (result) -> {
-            Map<String,Node> map = result.<Map<String, Node>>columnAs("val").next();
-            assertEquals(1, map.size());
-            Node t = map.get("t");
-            assertTrue(t.hasLabel(Label.label("Target")));
-            assertEquals(3L, t.getProperty("value"));
+            Node node = result.<Node>columnAs("val").next();
+            assertTrue(node.hasLabel(Label.label("Target")));
+            assertEquals(3L, node.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map_list(4) AS val", (result) -> {
-            List<Map<String, Node>> nodes = result.<List<Map<String, Node>>>columnAs("val").next();
+            List<Node> nodes = result.<List<Node>>columnAs("val").next();
             assertEquals(1, nodes.size());
-            Node t = nodes.get(0).get("t");
-            assertTrue(t.hasLabel(Label.label("Target")));
-            assertEquals(4L, t.getProperty("value"));
+            Node node = nodes.get(0);
+            assertTrue(node.hasLabel(Label.label("Target")));
+            assertEquals(4L, node.getProperty("value"));
         });
     }
 

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -193,16 +193,15 @@ public class CypherProceduresTest  {
             assertEquals(2L, node.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map(3) AS val", (result) -> {
-            Map<String, Object> map = result.<Map<String, Object>>columnAs("val").next();
+            Map<String, Map<String, Object>> map = result.<Map<String, Map<String, Object>>>columnAs("val").next();
             assertEquals(1, map.size());
-            assertEquals(3L, map.get("value"));
+            assertEquals(3L, map.get("value").get("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map_list(4) AS val", (result) -> {
-            List<List<Map<String, Object>>> list = result.<List<List<Map<String, Object>>>>columnAs("val").next();
+            List<Map<String, List<Map<String, Object>>>> list = result.<List<Map<String, List<Map<String, Object>>>>>columnAs("val").next();
             assertEquals(1, list.size());
-            List<Map<String, Object>> map = list.get(0);
-            assertEquals(1, map.size());
-            assertEquals(4L, map.get(0).get("value"));
+            assertEquals(1, list.get(0).size());
+            assertEquals(4L, list.get(0).get("value").get(0).get("value"));
         });
     }
 
@@ -230,16 +229,18 @@ public class CypherProceduresTest  {
             assertEquals(2L, t.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map(3) AS val", (result) -> {
-            Node node = result.<Node>columnAs("val").next();
-            assertTrue(node.hasLabel(Label.label("Target")));
-            assertEquals(3L, node.getProperty("value"));
+            Map<String,Node> map = result.<Map<String, Node>>columnAs("val").next();
+            assertEquals(1, map.size());
+            Node t = map.get("t");
+            assertTrue(t.hasLabel(Label.label("Target")));
+            assertEquals(3L, t.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map_list(4) AS val", (result) -> {
-            List<Node> nodes = result.<List<Node>>columnAs("val").next();
+            List<Map<String, Node>> nodes = result.<List<Map<String, Node>>>columnAs("val").next();
             assertEquals(1, nodes.size());
-            Node node = nodes.get(0);
-            assertTrue(node.hasLabel(Label.label("Target")));
-            assertEquals(4L, node.getProperty("value"));
+            Node t = nodes.get(0).get("t");
+            assertTrue(t.hasLabel(Label.label("Target")));
+            assertEquals(4L, t.getProperty("value"));
         });
     }
 
@@ -259,7 +260,7 @@ public class CypherProceduresTest  {
     @Test
     public void registerSimpleStatementFunction() throws Exception {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         db.executeTransactionally("CALL apoc.custom.declareFunction('answer2() :: STRING','RETURN 42 as answer')");
         TestUtil.testCall(db, "return custom.answer2() as row", (row) -> assertEquals(42L, row.get("row")));
     }
@@ -267,7 +268,7 @@ public class CypherProceduresTest  {
     @Test
     public void registerSimpleStatementFunctionWithOneChar() throws Exception {
         db.executeTransactionally("call apoc.custom.asFunction('a','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.a() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         final String procedureSignature = "b() :: STRING";
         assertProcedureFails(String.format(SIGNATURE_SYNTAX_ERROR, procedureSignature),
                 "CALL apoc.custom.declareFunction('" + procedureSignature + "','RETURN 42 as answer')");
@@ -325,7 +326,7 @@ public class CypherProceduresTest  {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer', '', null, false, 'Answer to the Ultimate Question of Life, the Universe, and Everything')");
 
         // when
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
 
         // then
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
@@ -407,10 +408,10 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         db.executeTransactionally("call db.clearQueryCaches()");
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 43 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(43L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(43L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         // when
@@ -452,7 +453,7 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
 
         // when
         db.executeTransactionally("call apoc.custom.removeFunction('a.b.c')");
@@ -486,16 +487,16 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("call apoc.custom.asFunction('a.b.name','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         db.executeTransactionally("call apoc.custom.asFunction('a.b.name','RETURN 34 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, (((List)row.get("row")).get(0))));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         db.executeTransactionally("call apoc.custom.asFunction('x.z.name','RETURN 12 as answer')");
-        TestUtil.testCall(db, "return custom.x.z.name() as row", (row) -> assertEquals(12L, ((List)row.get("row")).get(0)));
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.x.z.name() as row", (row) -> assertEquals(12L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         TestUtil.testResult(db, "call apoc.custom.list", (row) -> {

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -260,7 +260,7 @@ public class CypherProceduresTest  {
     @Test
     public void registerSimpleStatementFunction() throws Exception {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("CALL apoc.custom.declareFunction('answer2() :: STRING','RETURN 42 as answer')");
         TestUtil.testCall(db, "return custom.answer2() as row", (row) -> assertEquals(42L, row.get("row")));
     }
@@ -268,7 +268,7 @@ public class CypherProceduresTest  {
     @Test
     public void registerSimpleStatementFunctionWithOneChar() throws Exception {
         db.executeTransactionally("call apoc.custom.asFunction('a','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         final String procedureSignature = "b() :: STRING";
         assertProcedureFails(String.format(SIGNATURE_SYNTAX_ERROR, procedureSignature),
                 "CALL apoc.custom.declareFunction('" + procedureSignature + "','RETURN 42 as answer')");
@@ -326,7 +326,7 @@ public class CypherProceduresTest  {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer', '', null, false, 'Answer to the Ultimate Question of Life, the Universe, and Everything')");
 
         // when
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
 
         // then
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
@@ -408,10 +408,10 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 43 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(43L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(43L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         // when
@@ -453,7 +453,7 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
 
         // when
         db.executeTransactionally("call apoc.custom.removeFunction('a.b.c')");
@@ -487,16 +487,16 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("call apoc.custom.asFunction('a.b.name','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         db.executeTransactionally("call apoc.custom.asFunction('a.b.name','RETURN 34 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, (((List)row.get("row")).get(0))));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         db.executeTransactionally("call apoc.custom.asFunction('x.z.name','RETURN 12 as answer')");
-        TestUtil.testCall(db, "return custom.x.z.name() as row", (row) -> assertEquals(12L, ((Map)((List)row.get("row")).get(0)).get("answer")));
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.x.z.name() as row", (row) -> assertEquals(12L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         TestUtil.testResult(db, "call apoc.custom.list", (row) -> {


### PR DESCRIPTION
Riguarda il commento di Michael fatto qui `https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2704`.

Per fare quello che ha chiesto, 
l'ideale sarebbe stato passare ad esempio un `MapResultType extends Neo4jTypes.MapType` per definire la `UserFunctionSignature` in `Signature.java` (riga 20).
In questo modo [qui](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/main/java/apoc/custom/CypherProceduresHandler.java#L393) non verrebbe fatto il wrapping. 

Però non è possibile perché in `org.neo4j.cypher.internal.spi.procsHelpers` fa una validazione su `Neo4jTypes`.


Quindi ho optato per cambiare l'attributo `category` di `UserFunctionSignature`, che sembra simile all'attributo description e non sembra cambiare il comportamento della funzione.
In questo modo, possiamo distinguere il caso `MAP` da `MAPRESULT`.

---

In alternativa, possiamo semplicemente aggiungere `MAPRESULT` (in Signature.g4) e lasciare il resto così com'è,
e fare in modo si comporti come `STRING` (che a dispetto del nome può ritornare anche interi, mappe, etc..).

Però se faccio `SHOW FUNCTIONS` avrò la signature sbagliata, ovvero con `nomeFun(.... ) :: STRING?`.

---
---

Altrimenti penso sia meglio optare per un parametro aggiuntivo in `apoc.custom.declareFunction(...)` similmente a `forceSingle`

