### PR TITLE
Issue 6R2yEhGU: No procedure with name  registered for this database instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ subprojects {
     test {
         //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
 
+        include '**/CypherProceduresClusterTest*'
+
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country ' : 'US',

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -205,7 +205,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         ), statement, forceSingle);
     }
 
-    public void restoreProceduresAndFunctions() {
+    public synchronized void restoreProceduresAndFunctions() {
         lastUpdate = System.currentTimeMillis();
         Set<ProcedureSignature> currentProceduresToRemove = new HashSet<>(registeredProcedureSignatures);
         Set<UserFunctionSignature> currentUserFunctionsToRemove = new HashSet<>(registeredUserFunctionSignatures);
@@ -250,9 +250,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.forceSingle.name(), forceSingle);
 
             setLastUpdate(tx);
-            registerFunction(signature, statement, forceSingle);
             return null;
         });
+
+        restoreProceduresAndFunctions();
     }
 
     public void storeProcedure(ProcedureSignature signature, String statement) {
@@ -268,9 +269,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.outputs.name(), serializeSignatures(signature.outputSignature()));
             node.setProperty(SystemPropertyKeys.mode.name(), signature.mode().name());
             setLastUpdate(tx);
-            registerProcedure(signature, statement);
             return null;
         });
+
+        restoreProceduresAndFunctions();
     }
 
     private String serializeSignatures(List<FieldSignature> signatures) {

--- a/full/src/test/java/apoc/custom/CypherProceduresClusterTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresClusterTest.java
@@ -11,8 +11,12 @@ import org.neo4j.internal.helpers.collection.MapUtil;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static apoc.util.TestUtil.isRunningInCI;
+import static apoc.util.TestContainerUtil.testCallEventuallyInReadTransaction;
+import static apoc.util.TestContainerUtil.testCallEventually;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
@@ -52,12 +56,10 @@ public class CypherProceduresClusterTest {
             TestContainerUtil.testCall(session, "return custom.answer1() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         }
 
-        Thread.sleep(1000);
-
         // then
         // we use the readTransaction in order to route the execution to the READ_REPLICA
         try(Session session = cluster.getDriver().session()) {
-            TestContainerUtil.testCallInReadTransaction(session, "return custom.answer1() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+            TestContainerUtil.testCallEventuallyInReadTransaction(session, "return custom.answer1() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")), 10L);
         }
     }
 
@@ -69,11 +71,12 @@ public class CypherProceduresClusterTest {
 
         // when
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answer2', 'RETURN 52 as answer')")); // we update the function
-        Thread.sleep(1000);
+
+        cluster.getSession().run("call db.clearQueryCaches()");
 
         // then
         // we use the readTransaction in order to route the execution to the READ_REPLICA
-        TestContainerUtil.testCallInReadTransaction(cluster.getSession(), "return custom.answer2() as row", (row) -> assertEquals(52L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestContainerUtil.testCallEventuallyInReadTransaction(cluster.getSession(), "return custom.answer2() as row", (row) -> assertEquals(52L, ((Map)((List)row.get("row")).get(0)).get("answer")), 10L);
     }
 
     @Test
@@ -83,9 +86,10 @@ public class CypherProceduresClusterTest {
 
         // when
         TestContainerUtil.testCall(cluster.getSession(), "call custom.answerProcedure1()", (row) -> Assert.assertEquals(33L, row.get("answer")));
-        Thread.sleep(1000);
+
+        cluster.getSession().run("call db.clearQueryCaches()");
         // then
-        TestContainerUtil.testCallInReadTransaction(cluster.getSession(), "call custom.answerProcedure1()", (row) -> Assert.assertEquals(33L, row.get("answer")));
+        TestContainerUtil.testCallEventuallyInReadTransaction(cluster.getSession(), "call custom.answerProcedure1()", (row) -> Assert.assertEquals(33L, row.get("answer")), 10L);
     }
 
     @Test
@@ -97,18 +101,17 @@ public class CypherProceduresClusterTest {
         // when
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerProcedure2', 'RETURN 55 as answer', 'read', [['answer','long']])")); // we create a procedure
 
-        Thread.sleep(1000);
+        cluster.getSession().run("call db.clearQueryCaches()");
         // then
-        TestContainerUtil.testCallInReadTransaction(cluster.getSession(), "call custom.answerProcedure2()", (row) -> Assert.assertEquals(55L, row.get("answer")));
+        TestContainerUtil.testCallEventuallyInReadTransaction(cluster.getSession(), "call custom.answerProcedure2()", (row) -> Assert.assertEquals(55L, row.get("answer")), 10L);
     }
 
     @Test(expected = DatabaseException.class)
     public void shouldRemoveProcedureOnOtherClusterMembers() throws InterruptedException {
         // given
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerToRemove', 'RETURN 33 as answer', 'read', [['answer','long']])")); // we create a procedure
-        Thread.sleep(1000);
         try {
-            TestContainerUtil.testCallInReadTransaction(cluster.getSession(), "call custom.answerToRemove()", (row) -> Assert.assertEquals(33L, row.get("answer")));
+            TestContainerUtil.testCallEventuallyInReadTransaction(cluster.getSession(), "call custom.answerToRemove()", (row) -> Assert.assertEquals(33L, row.get("answer")), 10L);
         } catch (Exception e) {
             fail("Exception while calling the procedure");
         }
@@ -117,10 +120,8 @@ public class CypherProceduresClusterTest {
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.removeProcedure('answerToRemove')")); // we remove procedure
 
         // then
-        Thread.sleep(1000);
-        System.out.println("waited 5000ms");
         try {
-            TestContainerUtil.testCallInReadTransaction(cluster.getSession(), "call custom.answerToRemove()", (row) -> fail("Procedure not removed"));
+            TestContainerUtil.testCallEventuallyInReadTransaction(cluster.getSession(), "call custom.answerToRemove()", (row) -> fail("Procedure not removed"), 10L);
         } catch (DatabaseException e) {
             String expectedMessage = "There is no procedure with the name `custom.answerToRemove` registered for this database instance. Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.";
             assertEquals(expectedMessage, e.getMessage());
@@ -132,9 +133,8 @@ public class CypherProceduresClusterTest {
     public void shouldRemoveFunctionOnOtherClusterMembers() throws InterruptedException {
         // given
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answerFunctionToRemove', 'RETURN 42 as answer')")); // we create a function
-        Thread.sleep(1000);
         try {
-            TestContainerUtil.testCallInReadTransaction(cluster.getSession(), "return custom.answerFunctionToRemove() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+            TestContainerUtil.testCallEventuallyInReadTransaction(cluster.getSession(), "return custom.answerFunctionToRemove() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")), 10L);
         } catch (Exception e) {
             fail("Exception while calling the function");
         }
@@ -143,13 +143,83 @@ public class CypherProceduresClusterTest {
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.removeFunction('answerFunctionToRemove')")); // we remove procedure
 
         // then
-        Thread.sleep(1000);
         try {
-            TestContainerUtil.testCallInReadTransaction(cluster.getSession(), "return custom.answerFunctionToRemove() as row", (row) -> fail("Function not removed"));
+            TestContainerUtil.testCallEventuallyInReadTransaction(cluster.getSession(), "return custom.answerFunctionToRemove() as row", (row) -> fail("Function not removed"), 10L);
         } catch (DatabaseException e) {
             String expectedMessage = "Unknown function 'custom.answerFunctionToRemove'";
             assertEquals(expectedMessage, e.getMessage());
             throw e;
         }
+    }
+
+    @Test
+    public void testRestoreProcedureWorksCorrectlyOnOtherClusterMembers() {
+        List<String> listProcNames = IntStream.range(0, 30)
+                .mapToObj(i -> "proc" + i)
+                .collect(Collectors.toList());
+
+        // for each element, declare a procedure with that name,
+        // then call the custom procedure
+        // and finally overwrite and re-call it
+        listProcNames.forEach(name -> {
+            String declareProcedure = String.format("CALL apoc.custom.declareProcedure('%s() :: (answer::INT)', $query)", name);
+            String callProcedure = String.format("call custom.%s", name);
+
+            cluster.getSession().writeTransaction(
+                    tx -> tx.run(declareProcedure, Map.of("query", "RETURN 42 AS answer"))
+            );
+
+            testCallEventually(cluster.getSession(), callProcedure, Map.of(),
+                    row -> assertEquals(42L, row.get("answer")),
+                    10L);
+
+            // overwriting
+            cluster.getSession().writeTransaction(
+                    tx -> tx.run(declareProcedure, Map.of("query", "RETURN 1 AS answer"))
+            );
+
+            cluster.getSession().run("call db.clearQueryCaches()");
+
+            // we use the readTransaction in order to route the execution to the READ_REPLICA
+            testCallEventuallyInReadTransaction(cluster.getSession(), callProcedure, Map.of(),
+                    row -> assertEquals(1L, row.get("answer")),
+                    10L);
+        });
+    }
+
+    @Test
+    public void testRestoreFunctionWorksCorrectlyOnOtherClusterMembers() {
+        // create a list of ["fun1", "fun2", "fun3" ....] strings
+        List<String> listFunNames = IntStream.range(0, 30)
+                .mapToObj(i -> "fun" + i)
+                .collect(Collectors.toList());
+
+        // for each element, declare a function with that name,
+        // then call the custom function
+        // and finally overwrite and re-call it
+        listFunNames.forEach(name -> {
+            final String declareFunction = String.format("CALL apoc.custom.declareFunction('%s() :: INT', $query)", name);
+            final String funQuery = String.format("return custom.%s() as row", name);
+
+            cluster.getSession().writeTransaction(tx -> tx.run(declareFunction,
+                    Map.of("query", "RETURN 42 as answer")
+            ));
+
+            testCallEventually(cluster.getSession(), funQuery, Map.of(),
+                    row -> assertEquals(42L, row.get("row")),
+                    10L);
+
+            // overwriting
+            cluster.getSession().writeTransaction(
+                    tx -> tx.run(declareFunction, Map.of("query", "RETURN 1 AS answer"))
+            );
+
+            cluster.getSession().run("call db.clearQueryCaches()");
+
+            // we use the readTransaction in order to route the execution to the READ_REPLICA
+            testCallEventuallyInReadTransaction(cluster.getSession(), funQuery, Map.of(),
+                    row -> assertEquals(1L, row.get("row")),
+                    10L);
+        });
     }
 }

--- a/full/src/test/java/apoc/custom/CypherProceduresClusterTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresClusterTest.java
@@ -14,13 +14,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.TestContainerUtil.testCallEventuallyInReadTransaction;
 import static apoc.util.TestContainerUtil.testCallEventually;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
 
 public class CypherProceduresClusterTest {
 
@@ -28,12 +25,12 @@ public class CypherProceduresClusterTest {
 
     @BeforeClass
     public static void setupCluster() {
-        assumeFalse(isRunningInCI());
+//        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() ->  cluster = TestContainerUtil
                 .createEnterpriseCluster(3, 1, Collections.emptyMap(), MapUtil.stringMap("apoc.custom.procedures.refresh", "100")),
                 Exception.class);
-        Assume.assumeNotNull(cluster);
-        assumeTrue("Neo4j Cluster should be up-and-running", cluster.isRunning());
+//        Assume.assumeNotNull(cluster);
+//        assumeTrue("Neo4j Cluster should be up-and-running", cluster.isRunning());
     }
 
     @AfterClass
@@ -169,9 +166,12 @@ public class CypherProceduresClusterTest {
                     tx -> tx.run(declareProcedure, Map.of("query", "RETURN 42 AS answer"))
             );
 
-            testCallEventually(cluster.getSession(), callProcedure, Map.of(),
-                    row -> assertEquals(42L, row.get("answer")),
-                    10L);
+            // test that it's work for every cluster
+            cluster.getClusterMembers().forEach(container -> {
+                testCallEventually(container.getSession(), callProcedure, Map.of(),
+                        row -> assertEquals(42L, row.get("answer")),
+                        10L);
+            });
 
             // overwriting
             cluster.getSession().writeTransaction(
@@ -180,10 +180,12 @@ public class CypherProceduresClusterTest {
 
             cluster.getSession().run("call db.clearQueryCaches()");
 
-            // we use the readTransaction in order to route the execution to the READ_REPLICA
-            testCallEventuallyInReadTransaction(cluster.getSession(), callProcedure, Map.of(),
-                    row -> assertEquals(1L, row.get("answer")),
-                    10L);
+            // test that it's work and is updated for every cluster
+            cluster.getClusterMembers().forEach(container -> {
+                testCallEventually(container.getSession(), callProcedure, Map.of(),
+                        row -> assertEquals(1L, row.get("answer")),
+                        10L);
+            });
         });
     }
 
@@ -205,9 +207,12 @@ public class CypherProceduresClusterTest {
                     Map.of("query", "RETURN 42 as answer")
             ));
 
-            testCallEventually(cluster.getSession(), funQuery, Map.of(),
-                    row -> assertEquals(42L, row.get("row")),
-                    10L);
+            // test that it's work for every cluster
+            cluster.getClusterMembers().forEach(container -> {
+                testCallEventually(container.getSession(), funQuery, Map.of(),
+                        row -> assertEquals(42L, row.get("row")),
+                        10L);
+            });
 
             // overwriting
             cluster.getSession().writeTransaction(
@@ -216,10 +221,12 @@ public class CypherProceduresClusterTest {
 
             cluster.getSession().run("call db.clearQueryCaches()");
 
-            // we use the readTransaction in order to route the execution to the READ_REPLICA
-            testCallEventuallyInReadTransaction(cluster.getSession(), funQuery, Map.of(),
-                    row -> assertEquals(1L, row.get("row")),
-                    10L);
+            // test that it's work and is updated for every cluster
+            cluster.getClusterMembers().forEach(container -> {
+                testCallEventually(container.getSession(), funQuery, Map.of(),
+                        row -> assertEquals(1L, row.get("row")),
+                        10L);
+            });
         });
     }
 }

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -80,7 +80,7 @@ public class CypherProceduresStorageTest {
             String declareProc = String.format("CALL apoc.custom.declareProcedure('%s() :: (answer::INT)', $query)", name);
 
             db.executeTransactionally(declareProc,
-                    Map.of("name", name, "query", "RETURN 42 AS answer"),
+                    Map.of("query", "RETURN 42 AS answer"),
                     Result::resultAsString
             );
 
@@ -91,7 +91,7 @@ public class CypherProceduresStorageTest {
 
             // overwriting
             db.executeTransactionally(declareProc,
-                    Map.of("name", name, "query", "RETURN 1 AS answer"),
+                    Map.of("query", "RETURN 1 AS answer"),
                     Result::resultAsString
             );
         });

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -7,24 +7,29 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
 import org.neo4j.internal.helpers.collection.Iterators;
-import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static apoc.custom.CypherProceduresHandler.CUSTOM_PROCEDURES_REFRESH;
+import static apoc.util.DbmsTestUtil.startDbWithApocConfs;
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
 
 /**
  * @author mh
@@ -42,17 +47,117 @@ public class CypherProceduresStorageTest {
 
     @Before
     public void setUp() throws Exception {
-        databaseManagementService = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
-        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        databaseManagementService = startDbWithApocConfs(STORE_DIR,
+                CUSTOM_PROCEDURES_REFRESH + "=10");
+        db = databaseManagementService.database(DEFAULT_DATABASE_NAME);
+
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
     }
 
     private void restartDb() {
         databaseManagementService.shutdown();
-        databaseManagementService = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
-        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        try {
+            databaseManagementService = startDbWithApocConfs(STORE_DIR,
+                    CUSTOM_PROCEDURES_REFRESH + "=10");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        db = databaseManagementService.database(DEFAULT_DATABASE_NAME);
         assertTrue(db.isAvailable(1000));
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
+    }
+
+    @Test
+    public void testRestoreProcedureWorksCorrectlyWithoutConflicts() {
+        // create a list of ["proc1", "proc2", "proc3" ....] strings
+        List<String> listProcNames = IntStream.range(0, 200)
+                .mapToObj(i -> "proc" + i)
+                .collect(Collectors.toList());
+
+        // for each element, declare a procedure with that name,
+        // then call the custom procedure and finally overwrite it
+        listProcNames.forEach(name -> {
+            String declareProc = String.format("CALL apoc.custom.declareProcedure('%s() :: (answer::INT)', $query)", name);
+
+            db.executeTransactionally(declareProc,
+                    Map.of("name", name, "query", "RETURN 42 AS answer"),
+                    Result::resultAsString
+            );
+
+            TestUtil.testCall(db,
+                    String.format("call custom.%s", name),
+                    (row) -> assertEquals(42L, row.get("answer"))
+            );
+
+            // overwriting
+            db.executeTransactionally(declareProc,
+                    Map.of("name", name, "query", "RETURN 1 AS answer"),
+                    Result::resultAsString
+            );
+        });
+
+        // check that the previous overwrite works correctly after the `db.clearQueryCaches`
+        db.executeTransactionally("call db.clearQueryCaches");
+        listProcNames.forEach(name -> TestUtil.testCall(db,
+                    String.format("call custom.%s", name),
+                    (row) -> assertEquals(1L, row.get("answer"))
+                )
+        );
+
+        // check that everything worked correctly after a db restart
+        restartDb();
+        listProcNames.forEach(name -> TestUtil.testCall(db,
+                    String.format("call custom.%s", name),
+                    (row) -> assertEquals(1L, row.get("answer"))
+                )
+        );
+    }
+
+    @Test
+    public void testRestoreFunctionWorksCorrectlyWithoutConflicts() {
+        // create a list of ["fun1", "fun2", "fun3" ....] strings
+        List<String> listFunNames = IntStream.range(0, 200)
+                .mapToObj(i -> "fun" + i)
+                .collect(Collectors.toList());
+        final String funQuery = "return custom.%s() as row";
+
+        // for each element, declare a function with that name,
+        // then call the custom function and finally overwrite it
+        listFunNames.forEach(name -> {
+            final String declareFunction = String.format("CALL apoc.custom.declareFunction('%s() :: INT', $query)", name);
+
+            db.executeTransactionally(declareFunction,
+                    Map.of("query", "RETURN 42 as answer"),
+                    Result::resultAsString
+            );
+
+            TestUtil.testCall(db,
+                    String.format(funQuery, name),
+                    (row) -> assertEquals(42L, row.get("row"))
+            );
+
+            // overwriting
+            db.executeTransactionally(declareFunction,
+                    Map.of("query", "RETURN 1 as answer"),
+                    Result::resultAsString
+            );
+        });
+
+        // check that the previous overwrite works correctly after the `db.clearQueryCaches`
+        db.executeTransactionally("call db.clearQueryCaches");
+        listFunNames.forEach(name -> TestUtil.testCall(db,
+                        String.format(funQuery, name),
+                        (row) -> assertEquals(1L, row.get("row"))
+                )
+        );
+
+        // check that everything worked correctly after a db restart
+        restartDb();
+        listFunNames.forEach(name -> TestUtil.testCall(db,
+                    String.format(funQuery, name),
+                    (row) -> assertEquals(1L, row.get("row"))
+                )
+        );
     }
 
     @Test

--- a/full/src/test/java/apoc/util/DbmsTestUtil.java
+++ b/full/src/test/java/apoc/util/DbmsTestUtil.java
@@ -14,7 +14,10 @@ import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestrict
 
 public class DbmsTestUtil {
     public static DatabaseManagementService startDbWithApocConfs(TemporaryFolder storeDir, String... conf) throws IOException {
-        final File configFile = storeDir.newFile("apoc.conf");
+        // Used `new File(..).createNewFile()` instead of storeDir.newFile(..)
+        // because the latter throws an IOException if the file already exists
+        File configFile = new File(storeDir.getRoot(), "apoc.conf");
+        configFile.createNewFile();
         try (FileWriter writer = new FileWriter(configFile)) {
             writer.write(String.join("\n", conf));
         }

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -13,6 +13,7 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
 import org.testcontainers.containers.ContainerFetchException;
 import org.testcontainers.utility.MountableFile;
 
@@ -170,14 +171,11 @@ public class TestContainerUtil {
         executeGradleTasks(baseDir, tasks);
     }
 
+
     public static void testCall(Session session, String call, Map<String,Object> params, Consumer<Map<String, Object>> consumer) {
         testResult(session, call, params, (res) -> {
             try {
-                assertNotNull("result should be not null", res);
-                assertTrue("result should be not empty", res.hasNext());
-                Map<String, Object> row = res.next();
-                consumer.accept(row);
-                assertFalse("result should not have next", res.hasNext());
+                testCallAssertions(consumer, res);
             } catch(Throwable t) {
                 printFullStackTrace(t);
                 throw t;
@@ -187,6 +185,37 @@ public class TestContainerUtil {
 
     public static void testCall(Session session, String call, Consumer<Map<String, Object>> consumer) {
         testCall(session, call, null, consumer);
+    }
+
+    public static void testCallEventuallyInReadTransaction(Session session, String call, Consumer<Map<String, Object>> consumer, long timeout) {
+        testCallEventuallyInReadTransaction(session, call, Collections.emptyMap(), consumer, timeout);
+    }
+
+    public static void testCallEventuallyInReadTransaction(Session session, String call, Map<String,Object> params, Consumer<Map<String, Object>> consumer, long timeout) {
+        assertEventually(
+                () -> session.readTransaction(tx -> testCallEventuallyCommon(call, params, consumer, tx)),
+                (value) -> value, timeout, TimeUnit.SECONDS);
+    }
+
+    public static void testCallEventually(Session session, String call, Map<String,Object> params, Consumer<Map<String, Object>> consumer, long timeout) {
+        assertEventually(
+                () -> session.writeTransaction(tx -> testCallEventuallyCommon(call, params, consumer, tx)),
+                (value) -> value, timeout, TimeUnit.SECONDS);
+    }
+
+    private static boolean testCallEventuallyCommon(String call, Map<String, Object> params, Consumer<Map<String, Object>> consumer, Transaction tx) {
+        Iterator<Map<String, Object>> iterator = tx.run(call, params).stream().map(Record::asMap).collect(Collectors.toList()).iterator();
+        testCallAssertions(consumer, iterator);
+        tx.commit();
+        return true;
+    }
+
+    private static void testCallAssertions(Consumer<Map<String, Object>> consumer, Iterator<Map<String, Object>> res) {
+        assertNotNull("result should be not null", res);
+        assertTrue("result should be not empty", res.hasNext());
+        Map<String, Object> row = res.next();
+        consumer.accept(row);
+        assertFalse("result should not have next", res.hasNext());
     }
 
     public static void testResult(Session session, String call, Consumer<Iterator<Map<String, Object>>> resultConsumer) {
@@ -213,11 +242,7 @@ public class TestContainerUtil {
     public static void testCallInReadTransaction(Session session, String call, Map<String,Object> params, Consumer<Map<String, Object>> consumer) {
         testResultInReadTransaction(session, call, params, (res) -> {
             try {
-                assertNotNull("result should be not null", res);
-                assertTrue("result should be not empty", res.hasNext());
-                Map<String, Object> row = res.next();
-                consumer.accept(row);
-                assertFalse("result should not have next", res.hasNext());
+                testCallAssertions(consumer, res);
             } catch(Throwable t) {
                 printFullStackTrace(t);
                 throw t;


### PR DESCRIPTION
https://trello.com/c/6R2yEhGU/40-s3ria-financialno-procedure-with-name-xxxxx-registered-for-this-database-instance

- added synchronized to avoid potential conflict
- removed `registerFunction(signature, statement, forceSingle);` and `registerProcedure(signature, statement);` from the system-node merge, to prevent erroneous proc/func deletion before the sys-node is actually created/updated (on lines 224-226, with comment `// de-register removed procs/functions`)