### PR TITLE
Exclude :core:shadowJar task from extended

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,5 +19,9 @@ startParameter.excludedTaskNames = [
         ':test-utils:test',
         ':core:publish',
         ':common:publish',
-        ':test-utils:publish'
+        ':test-utils:publish',
+        // the :core:shadowJar should be used only for integration tests with both core and extended jars
+        // e.g. StartupExtendedTest, where the core jar is created by executing `shadowJar` directly in the `apoc-core`
+        // not when a `gradle shadow` or a `gradle build` is executed in this root project folder
+        ':core:shadowJar'
 ]


### PR DESCRIPTION
In teamcity is firstly executed a `./gradlew shadow` in the root folder, which creates an `apoc-5.8.1-core.jar`, 
where 5.8.1 is the current APOC Extended version.

But when `StartupExtendedTest.checkCoreAndFullWithExtraDependenciesJars` is executed, 
this runs the `:core:shadowJar` task on the apoc-core folder (via https://github.com/neo4j/apoc/blob/dev/test-utils/src/main/java/apoc/util/TestContainerUtil.java#L133), 
which create an  `apoc-5.8.0-core.jar` (5.8.0: current APOC Core version), 
this causes an error due to duplicated packages: 
```
procedure `apoc.periodic.iterate` is already in use
```

In this pr I excluded `:core:shadowJar`, when running on the root folder, 
since it is actually only needed when running integration tests with both core and extended.

---

FOLLOW UP:

Anyway, this causes packages with different versions (i.e. apoc-5.8.1-processor and apoc-5.8.0-processor, apoc-5.8.0-core and apoc-5.8.1 in core folder, apoc-5.8.0 and apoc-5.8 .1 in common, etc..), 
so I think the ideal solution would be to force core, processor and common to accept the current core version when we run `/.gradle shadow` in the root folder (5.8.0 in this case), 
but to do this it would also be necessary to change the APOC Core build.gradle , so I created a follow-up card: https://trello.com/c/OIvGQTfi/53-force-processor-core-and-common-to-create-jar-with-the-current-apoc-core-version