### PR TITLE
V8keNXu0: error details while using apoc.cypher.runFiles

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runFile.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runFile.adoc
@@ -25,6 +25,9 @@ apoc.cypher.runFile(file :: STRING?, config = {} :: MAP?) :: (row :: INTEGER?, r
 |config|MAP?|{}
 |===
 
+== Config parameters
+include::partial$usage/config/apoc.cypher.runExtended.adoc[]
+
 == Output parameters
 [.procedures, opts=header]
 |===

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runFiles.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runFiles.adoc
@@ -25,6 +25,9 @@ apoc.cypher.runFiles(file :: LIST? OF STRING?, config = {} :: MAP?) :: (row :: I
 |config|MAP?|{}
 |===
 
+== Config parameters
+include::partial$usage/config/apoc.cypher.runExtended.adoc[]
+
 == Output parameters
 [.procedures, opts=header]
 |===

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runSchemaFile.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runSchemaFile.adoc
@@ -25,6 +25,9 @@ apoc.cypher.runSchemaFile(file :: STRING?, config = {} :: MAP?) :: (row :: INTEG
 |config|MAP?|{}
 |===
 
+== Config parameters
+include::partial$usage/config/apoc.cypher.runExtended.adoc[]
+
 == Output parameters
 [.procedures, opts=header]
 |===

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runSchemaFiles.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.cypher/apoc.cypher.runSchemaFiles.adoc
@@ -25,6 +25,9 @@ apoc.cypher.runSchemaFiles(file :: LIST? OF STRING?, config = {} :: MAP?) :: (ro
 |config|MAP?|{}
 |===
 
+== Config parameters
+include::partial$usage/config/apoc.cypher.runExtended.adoc[]
+
 == Output parameters
 [.procedures, opts=header]
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.cypher.runExtended.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.cypher.runExtended.adoc
@@ -1,0 +1,12 @@
+The procedure support the following config parameters:
+
+.Config parameters
+[opts=header, cols="1,1,1,5"]
+|===
+| name | type | default | description
+| reportError | boolean | false | Returns a entry row with key `error` and value the error occurred, if any.
+| statistics | boolean | true | Returns an additional row with the query statistics, leveraging the `org.neo4j.graphdb.QueryStatistics` api
+| timeout | long | 10 | The single query timeout (in seconds)
+| queueCapacity | long | 100 | The capacity of the `java.util.concurrent.BlockingQueue` used to aggregate the results.
+| parameters | Map<String, Object> | Empty map | Optional parameter map to be used with the `apoc.schema.runFile` and `apoc.schema.runFiles` procedures.
+|===

--- a/extended/src/test/resources/create_delete.cypher
+++ b/extended/src/test/resources/create_delete.cypher
@@ -1,4 +1,4 @@
 CREATE (n:Node {id:1});
 
-MATCH (n)
+MATCH (n:Node)
 DELETE n;

--- a/extended/src/test/resources/wrong_call_in_transactions.cypher
+++ b/extended/src/test/resources/wrong_call_in_transactions.cypher
@@ -1,0 +1,6 @@
+MATCH (n:Fail)
+CALL {
+    WITH n
+    CREATE (:Fail {foo: 1})
+} IN TRANSACTIONS OF 1 ROW;
+

--- a/extended/src/test/resources/wrong_schema_statements_runtime.cypher
+++ b/extended/src/test/resources/wrong_schema_statements_runtime.cypher
@@ -1,0 +1,1 @@
+CREATE INDEX CustomerIndex1 FOR (foo:Something) ON (bar.name);

--- a/extended/src/test/resources/wrong_statements.cypher
+++ b/extended/src/test/resources/wrong_statements.cypher
@@ -1,0 +1,1 @@
+CREATE (n:Person{id:1);

--- a/extended/src/test/resources/wrong_statements_runtime.cypher
+++ b/extended/src/test/resources/wrong_statements_runtime.cypher
@@ -1,0 +1,2 @@
+CREATE (n:Fail {foo: 1});
+


### PR DESCRIPTION
Trello: https://trello.com/c/V8keNXu0/56-s3securities-commission-malaysiais-there-any-way-to-get-the-error-details-while-using-apoccypherrunfiles

- Added `reportError` config to retrieve a `Map.of("error", "<ERROR_OBTAINED>")`, if any. See: https://github.com/vga91/neo4j-apoc-procedures/pull/359/files#diff-0be321a488b8e1a039cef51ff786b8142a2eac4a76f7585ff6121e4fc588dfc9R211
- Updated docs