### PR TITLE
Issue 3640: Custom procedures declaration fails in 5.9.0

### DIFF
--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -173,7 +173,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 Mode.valueOf((String) node.getProperty(ExtendedSystemPropertyKeys.mode.name())),
                 false,
                 null,
-                new String[0],
                 description,
                 null,
                 false,

--- a/extended/src/main/java/apoc/custom/Signatures.java
+++ b/extended/src/main/java/apoc/custom/Signatures.java
@@ -5,7 +5,6 @@ import org.antlr.v4.runtime.*;
 import org.neo4j.internal.kernel.api.procs.*;
 import org.neo4j.procedure.Mode;
 
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -85,11 +84,10 @@ public class Signatures {
         List<FieldSignature> inputSignatures = signature.parameter().stream().map(p -> getInputField(name(p.name()), type(p.type()), defaultValue(p.defaultValue(), type(p.type())))).collect(Collectors.toList());
         boolean admin = false;
         String deprecated = "";
-        String[] allowed = new String[0];
         String warning = null; // "todo warning";
         boolean eager = false;
         boolean caseInsensitive = true;
-        return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, allowed, description, warning, eager, caseInsensitive, false, false, false);
+        return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, description, warning, eager, caseInsensitive, false, false, false);
     }
 
     public List<String> namespace(SignatureParser.NamespaceContext namespaceContext) {
@@ -237,7 +235,6 @@ public class Signatures {
                                                               Mode mode,
                                                               boolean admin,
                                                               String deprecated,
-                                                              String[] allowed,
                                                               String description,
                                                               String warning,
                                                               boolean eager,
@@ -245,64 +242,18 @@ public class Signatures {
                                                               boolean systemProcedure,
                                                               boolean internal,
                                                               boolean allowExpiredCredentials) {
-        try {
-            // in Neo4j 4.0.5 org.neo4j.internal.kernel.api.procs.ProcedureSignature
-            // changed the signature adding a boolean at the end and without leaving the old signature
-            // in order to maintain the backwards compatibility with version prior to 4.0.5 we use the
-            // reflection to create a new instance of the class
-            // in Neo4j 4.3 another boolean was added
-            final Class<?> clazz = Class.forName("org.neo4j.internal.kernel.api.procs.ProcedureSignature");
-            final Constructor<?>[] constructors = clazz.getConstructors();
-            for (int i = 0; i < constructors.length; i++) {
-                final Constructor<?> constructor = constructors[i];
-                switch (constructor.getParameterCount()) {
-                    case 14:
-                        return (ProcedureSignature) constructor.newInstance(name,
-                                inputSignature,
-                                outputSignature,
-                                mode,
-                                admin,
-                                deprecated,
-                                allowed,
-                                description,
-                                warning,
-                                eager,
-                                caseInsensitive,
-                                systemProcedure,
-                                internal,
-                                allowExpiredCredentials);
-                    case 13:
-                        return (ProcedureSignature) constructor.newInstance(name,
-                                inputSignature,
-                                outputSignature,
-                                mode,
-                                admin,
-                                deprecated,
-                                allowed,
-                                description,
-                                warning,
-                                eager,
-                                caseInsensitive,
-                                systemProcedure,
-                                internal);
-                    case 12:
-                        return (ProcedureSignature) constructor.newInstance(name,
-                                inputSignature,
-                                outputSignature,
-                                mode,
-                                admin,
-                                deprecated,
-                                allowed,
-                                description,
-                                warning,
-                                eager,
-                                caseInsensitive,
-                                systemProcedure);
-                }
-            }
-            throw new RuntimeException("Constructor of org.neo4j.internal.kernel.api.procs.ProcedureSignature not found");
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return new ProcedureSignature(name,
+                inputSignature,
+                outputSignature,
+                mode,
+                admin,
+                deprecated,
+                description,
+                warning,
+                eager,
+                caseInsensitive,
+                systemProcedure,
+                internal,
+                allowExpiredCredentials);
     }
 }


### PR DESCRIPTION
Il problema riguarda qualsiasi versione `5.x`.

Sporadicamente [la reflection](https://github.com/vga91/neo4j-apoc-procedures/compare/dev...vga91:neo4j-apoc-procedures:issue-3640?expand=1#diff-7a6794bc38939217b5b8ca0f55b06b9cfd4bfd59ebd1be9e2a4709f12c2c3304L248) trova 2 costruttori e cicla iniziando con quello che ha 13 parametri, ma in questo caso viene lanciato il seguente errore, perché trova [questo construttore](https://github.com/neo4j/neo4j/blob/5.9.0/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureSignature.java#L54) (che tra l'altro è `@Deprecated`) prima del successivo non deprecato.
```
Caused by: java.lang.RuntimeException: java.lang.IllegalArgumentException: argument type mismatch
```

In ogni caso, la Reflection non dovrebbe più essere necessaria, in quanto in precedenza avremmo potuto avere, ad esempio, una APOC 4.x compatibile con Neo4j 4.x.y (con un ProcedureSignature che ha 14 elementi) e 4.x.z (con un ProcedureSignature che ha 13 elementi).

In Neo4j 5 non dovrebbe accadere, perché, ad esempio, APOC 5.9.0 è compatibile con Neo4j 5.9.x, e teoricamente, come dice [qui](https://neo4j.com/developer/kb/neo4j-supported-versions/), la versione `x` aumenta solo nel caso di hotfix, e non dovrebbe causare breaking changes.

----

Ho provato a creare dei test junit sia con docker enterprise che con embedded, ma funziona sempre perché inizia a ciclare partendo prima dalla signature con 14 elementi, anche provando a riavviare il database più volte