### PR TITLE
[NOID] Remove register BuiltInDbmsProcedures.class

### DIFF
--- a/extended/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -53,7 +53,7 @@ public class CypherProceduresTest  {
 
     @Before
     public void setup() {
-        TestUtil.registerProcedure(db, CypherProcedures.class, BuiltInDbmsProcedures.class);
+        TestUtil.registerProcedure(db, CypherProcedures.class);
     }
 
     @AfterAll


### PR DESCRIPTION
Removed `BuiltInDbmsProcedures.class` from `TestUtil.registerProcedure(..)`,
which is not needed for both 4.4 and 5.x,

and with 5.10.0+ versions fails with error:
```
org.neo4j.internal.kernel.api.exceptions.ProcedureException: Unable to register procedure, because the name `db.clearQueryCaches` is already in use.
```
Like here: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/5553853187/jobs/10144529232?pr=3658#step:6:13825