### PR TITLE
Fix custom override with homonyms

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '17'
+          java-version: '17.0.8'
           distribution: 'temurin'
 
       - uses: actions/cache@v2

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ subprojects {
         archiveClassifier = 'javadoc'
     }
     test {
-        //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
+        include '**/StartupExtendedTest.class'//, '**/AtomicTest.class'
 
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ subprojects {
         archiveClassifier = 'javadoc'
     }
     test {
-        include '**/StartupExtendedTest.class'//, '**/AtomicTest.class'
+        //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
 
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id "org.jetbrains.kotlin.jvm" version "1.6.0"
-    id "com.diffplug.spotless" version "6.20.0"
+    id "com.diffplug.spotless" version "6.7.2"
 }
 
 spotless {

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -137,6 +137,7 @@ dependencies {
     testImplementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
     testImplementation group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
     testImplementation group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', withoutServers
 
 

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id "org.jetbrains.kotlin.jvm" version "1.6.0"
-    id "com.diffplug.spotless" version "6.7.2"
+    id "com.diffplug.spotless" version "6.20.0"
 }
 
 spotless {

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -109,6 +109,8 @@ dependencies {
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.1.0', withoutServers
 
 
+    compileOnly group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective
+
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar
     testImplementation project(':test-utils')
     testImplementation project(':core')

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -373,13 +373,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         // we unregister the previous function/procedure, if any
         globalProceduresRegistry.unregister(signatureName);
 
-        // the 1st time we search for an analogous function/procedure as below
+        // the 1st time (i.e. with override = true) we search for an analogous function/procedure as below
         if (!override) {
             return;
         }
 
         // if in sys-db there is a Procedure with the same name of the Function, or vice versa,
-        //  we re-register it, because the above unregister delete every fun and proc with that name.
+        // we re-register it, because the above unregister method delete every fun and proc with that name.
         // we use `registerWithoutOverride` to avoid recursion
         readSignatures().filter(i -> {
             QualifiedName name = null;

--- a/extended/src/main/java/apoc/export/parquet/ImportParquet.java
+++ b/extended/src/main/java/apoc/export/parquet/ImportParquet.java
@@ -1,5 +1,6 @@
 package apoc.export.parquet;
 
+import apoc.Extended;
 import apoc.Pools;
 import apoc.export.util.BatchTransaction;
 import apoc.export.util.ProgressReporter;
@@ -33,6 +34,7 @@ import static apoc.export.parquet.ParquetUtil.FIELD_SOURCE_ID;
 import static apoc.export.parquet.ParquetUtil.FIELD_TARGET_ID;
 import static apoc.export.parquet.ParquetUtil.FIELD_TYPE;
 
+@Extended
 public class ImportParquet {
 
     @Context

--- a/extended/src/main/java/apoc/export/parquet/ImportParquet.java
+++ b/extended/src/main/java/apoc/export/parquet/ImportParquet.java
@@ -1,6 +1,5 @@
 package apoc.export.parquet;
 
-import apoc.Extended;
 import apoc.Pools;
 import apoc.export.util.BatchTransaction;
 import apoc.export.util.ProgressReporter;
@@ -34,7 +33,6 @@ import static apoc.export.parquet.ParquetUtil.FIELD_SOURCE_ID;
 import static apoc.export.parquet.ParquetUtil.FIELD_TARGET_ID;
 import static apoc.export.parquet.ParquetUtil.FIELD_TYPE;
 
-@Extended
 public class ImportParquet {
 
     @Context

--- a/extended/src/main/java/apoc/load/LoadParquet.java
+++ b/extended/src/main/java/apoc/load/LoadParquet.java
@@ -1,5 +1,6 @@
 package apoc.load;
 
+import apoc.Extended;
 import apoc.export.parquet.ApocParquetReader;
 import apoc.export.parquet.ParquetConfig;
 import apoc.result.MapResult;
@@ -20,6 +21,7 @@ import java.util.stream.StreamSupport;
 
 import static apoc.export.parquet.ParquetReadUtil.getReader;
 
+@Extended
 public class LoadParquet {
 
     @Context public Log log;

--- a/extended/src/main/java/apoc/load/LoadParquet.java
+++ b/extended/src/main/java/apoc/load/LoadParquet.java
@@ -1,6 +1,5 @@
 package apoc.load;
 
-import apoc.Extended;
 import apoc.export.parquet.ApocParquetReader;
 import apoc.export.parquet.ParquetConfig;
 import apoc.result.MapResult;
@@ -21,7 +20,6 @@ import java.util.stream.StreamSupport;
 
 import static apoc.export.parquet.ParquetReadUtil.getReader;
 
-@Extended
 public class LoadParquet {
 
     @Context public Log log;

--- a/extended/src/main/java/org/neo4j/procedure/impl/ProcedureHolderUtils.java
+++ b/extended/src/main/java/org/neo4j/procedure/impl/ProcedureHolderUtils.java
@@ -1,0 +1,57 @@
+package org.neo4j.procedure.impl;
+
+import org.neo4j.internal.kernel.api.procs.QualifiedName;
+import org.neo4j.kernel.api.procedure.GlobalProcedures;
+import org.neo4j.procedure.LazyProcedures;
+
+import java.lang.reflect.Field;
+
+public class ProcedureHolderUtils {
+
+    public static void unregisterProcedure(QualifiedName name, GlobalProcedures registry) {
+        String kind = "procedures";
+        unregisterCommon(name, registry, kind);
+    }
+
+    public static void unregisterFunction(QualifiedName name, GlobalProcedures registry) {
+        String kind = "functions";
+        unregisterCommon(name, registry, kind);
+    }
+
+    private static void unregisterCommon(QualifiedName name, GlobalProcedures registry, String kind) {
+        try {
+            GlobalProceduresRegistry globalProcRegistry = getGlobalProcRegistry(registry);
+
+            // get the field `ProcedureRegistry registry` from the GlobalProceduresRegistry instance
+            Field registryField = GlobalProceduresRegistry.class.getDeclaredField("registry");
+            registryField.setAccessible(true);
+            ProcedureRegistry procedureRegistry = (ProcedureRegistry) registryField.get(globalProcRegistry);
+
+            // get `ProcedureHolder <kind>` (i.e `ProcedureHolder procedures` or `ProcedureHolder functions`) field from the ProcedureRegistry instance
+            Field procHolderField = ProcedureRegistry.class.getDeclaredField(kind);
+            procHolderField.setAccessible(true);
+            ProcedureHolder procedureHolder = (ProcedureHolder) procHolderField.get(procedureRegistry);
+
+            // unregister `name` from ProcedureHolder found
+            procedureHolder.unregister(name);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static GlobalProceduresRegistry getGlobalProcRegistry(GlobalProcedures registry) {
+        try {
+            // with embedded test database, the instance is of type LazyProcedures,
+            // so we get the field `globalProcedures` from the `LazyProcedures registry` instance
+            Field globalProceduresField = LazyProcedures.class.getDeclaredField("globalProcedures");
+            globalProceduresField.setAccessible(true);
+
+            return (GlobalProceduresRegistry) globalProceduresField.get(registry);
+
+        } catch (Throwable e) {
+            // with a real instance, the above code produces, due to LazyProcedures, produce a `NoClassDefFoundError` or an `IllegalArgumentException`
+            // because `registry` is directly of type GlobalProceduresRegistry, so we cast it
+            return (GlobalProceduresRegistry) registry;
+        }
+    }
+}

--- a/extended/src/main/resources/extended.txt
+++ b/extended/src/main/resources/extended.txt
@@ -40,6 +40,14 @@ apoc.es.postRaw
 apoc.es.put
 apoc.es.query
 apoc.es.stats
+apoc.export.parquet.all
+apoc.export.parquet.all.stream
+apoc.export.parquet.data
+apoc.export.parquet.data.stream
+apoc.export.parquet.graph
+apoc.export.parquet.graph.stream
+apoc.export.parquet.query
+apoc.export.parquet.query.stream
 apoc.export.xls.all
 apoc.export.xls.data
 apoc.export.xls.graph
@@ -52,6 +60,7 @@ apoc.generate.ws
 apoc.gephi.add
 apoc.get.nodes
 apoc.get.rels
+apoc.import.parquet
 apoc.load.csv
 apoc.load.csvParams
 apoc.load.directory
@@ -65,6 +74,7 @@ apoc.load.htmlPlainText
 apoc.load.jdbc
 apoc.load.jdbcUpdate
 apoc.load.ldap
+apoc.load.parquet
 apoc.load.xls
 apoc.log.debug
 apoc.log.error

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -43,7 +43,7 @@ public class StartupExtendedTest {
     }
 
     @Test
-    public void checkCoreAndFullWithExtraDependenciesJars() {
+    public void checkCoreAndExtendedWithExtraDependenciesJars() {
         // we check that with apoc-extended, apoc-core jar and all extra-dependencies jars every procedure/function is detected
         startContainerSessionWithExtraDeps((version) -> createDB(version, List.of(CORE, EXTENDED), true),
                 session -> {

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -5,7 +5,6 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import org.apache.commons.io.FileUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
@@ -29,8 +28,6 @@ import static org.junit.Assert.fail;
 /*
  This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
  */
-@Ignore("There are some conflict errors between the extra-dependencies and the apoc-extended jar." +
-        "For the moment we ignore this test, while we try to fix it")
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";
     private static final List<String> EXPECTED_EXTENDED_NAMES;

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -5,6 +5,7 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import org.apache.commons.io.FileUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
@@ -28,6 +29,8 @@ import static org.junit.Assert.fail;
 /*
  This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
  */
+@Ignore("There are some conflict errors between the extra-dependencies and the apoc-extended jar." +
+        "For the moment we ignore this test, while we try to fix it")
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";
     private static final List<String> EXPECTED_EXTENDED_NAMES;

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -239,6 +239,54 @@ public class CypherProceduresStorageTest {
     }
 
     @Test
+    public void testMultipleOverrideWithFunctionAndProcedures() throws Exception {
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('override() :: (result::LONG)','RETURN 42 as result')");
+
+        // function homonym to procedure
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override() :: LONG','RETURN 10 as answer')");
+
+        // get fun/proc created
+        TestUtil.testCall(db, "RETURN custom.override() as result", r -> {
+            assertEquals(10L, r.get("result"));
+        });
+        TestUtil.testCall(db, "CALL custom.override()", r -> {
+            assertEquals(42L, r.get("result"));
+        });
+
+        // overrides functions and procedures homonym to the previous ones
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input ^ 2 AS result')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input AS result')");
+
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('override(input::INT) :: (result::INT)', 'RETURN $input AS result')");
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('override(input::INT) :: (result::INT)', 'RETURN $input ^ 2 AS result')");
+
+        // get fun/proc updated
+        TestUtil.testCallEventually(db, "RETURN custom.override(3) as result", r -> {
+            assertEquals(3L, r.get("result"));
+        }, 10L);
+        TestUtil.testCallEventually(db, "CALL custom.override(2)", r -> {
+            assertEquals(4.0, r.get("result"));
+        }, 10L);
+        restartDb();
+
+        final String logFileContent = Files.readString(new File(FileUtils.getLogDirectory(), "debug.log").toPath());
+        assertFalse(logFileContent.contains("Could not register function: custom.vantagepoint_within_area"));
+        assertFalse(logFileContent.contains("Could not register procedure: custom.vantagepoint_within_area"));
+
+        // override after restart
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input + 1 AS result')");
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('override(input::INT) :: (result::INT)', 'RETURN $input + 2 AS result')");
+
+        // get fun/proc updated
+        TestUtil.testCallEventually(db, "RETURN custom.override(3) as result", r -> {
+            assertEquals(4L, r.get("result"));
+        }, 10L);
+        TestUtil.testCallEventually(db, "CALL custom.override(2)", r -> {
+            assertEquals(4L, r.get("result"));
+        }, 10L);
+    }
+
+    @Test
     public void functionSignatureShouldNotChangeBeforeAndAfterRestart() {
         functionsCreation();
         functionAssertions();

--- a/extended/src/test/java/apoc/export/ExportExtendedSecurityTest.java
+++ b/extended/src/test/java/apoc/export/ExportExtendedSecurityTest.java
@@ -184,13 +184,11 @@ public class ExportExtendedSecurityTest {
             this.apocProcedure = "apoc.export." + exportMethod + "." + exportMethodType + "(" + exportMethodArguments + ")";
         }
 
-        private static final String case1 = "'file:///%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2fapoc/test.txt'";
-        private static final String case2 = "'file:///%2e%2e%2f%2ftest.txt'";
-        private static final String case3 = "'../test.txt'";
-        private static final String case4 = "'tests/../../test.txt'";
-        private static final String case5 = "'tests/..//..//test.txt'";
+        private static final String case1 = "'../test.txt'";
+        private static final String case2 = "'tests/../../test.txt'";
+        private static final String case3 = "'tests/..//..//test.txt'";
 
-        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5);
+        private static final List<String> cases = Arrays.asList(case1, case2, case3);
 
         private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
                 "query",  cases.stream().map(
@@ -302,8 +300,10 @@ public class ExportExtendedSecurityTest {
         private static final String case6 = "'file:///tests//..//test.txt'";
         private static final String case7 = "'test.txt'";
         private static final String case8 = "'file:///..//..//..//..//test.txt'";
+        private static final String case9 = "'file:///%2e%2e%2f%2ftest.txt'";
+        public static final String case10 = "'file:///%2e%2e%2f%2ftest.txt'";
 
-        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6, case7, case8);
+        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6, case7, case8, case9, case10);
 
         private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
                 "query", cases.stream().map(

--- a/extended/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTest.java
@@ -91,13 +91,13 @@ public class LoadHtmlTest {
 
     @Test
     public void testParseGeneratedJsWrongConfigs() {
-        assertWrongConfig(INVALID_CONFIG_ERR + "No enum constant io.github.bonigarcia.wdm.config.OperatingSystem.dunno",
+        assertWrongConfig(INVALID_CONFIG_ERR,
                 map("browser", CHROME, "operatingSystem", "dunno"));
 
-        assertWrongConfig(INVALID_CONFIG_ERR + "No enum constant io.github.bonigarcia.wdm.config.Architecture.dunno",
+        assertWrongConfig(INVALID_CONFIG_ERR,
                 map("browser", FIREFOX, "architecture", "dunno"));
 
-        assertWrongConfig("Error HTTP 404 executing https://raw.githubusercontent.com/bonigarcia/webdrivermanager/master/docs/mirror/geckodriver",
+        assertWrongConfig("Error HTTP 404 executing",
                 map("browser", FIREFOX,
                         "gitHubToken", "12345",
                         "forceDownload", true));
@@ -282,7 +282,6 @@ public class LoadHtmlTest {
                     assertEquals(map("attributes", map("class", "firstClass"), "text", "My first paragraph.", "tagName", "p"), firstClass.get(0));
                     final List secondClass = value.get("secondClass");
                     assertEquals(map("attributes", map("class", "secondClass"), "text", "My second paragraph.", "tagName", "p"), secondClass.get(0));
-                    System.out.println("LoadHtmlTest.testQueryMetadataWithGetElementsByClass");
                 });
     }
 

--- a/extended/src/test/resources/long-create.cypher
+++ b/extended/src/test/resources/long-create.cypher
@@ -3,12 +3,3 @@ CREATE (n:NodeOne {id:id});
 
 UNWIND RANGE(0,99999) as id
 CREATE (n:NodeTwo {id:id});
-
-UNWIND RANGE(0,99999) as id
-CREATE (n:NodeThree {id:id});
-
-UNWIND RANGE(0,99999) as id
-CREATE (n:NodeFour {id:id});
-
-UNWIND RANGE(0,99999) as id
-CREATE (n:NodeFive {id:id});

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -30,6 +30,9 @@ shadowJar {
 def commonExclusions = {
     exclude group: 'io.netty'
     exclude group: 'com.sun.jersey'
+    exclude group: 'org.eclipse.jetty'
+    exclude group: 'org.eclipse.jetty.aggregate'
+    exclude group: 'org.slf4j', module: 'slf4j-api'
 }
 
 dependencies {


### PR DESCRIPTION
Fix custom con omonimi


Aggiunta classe `ProcedureHolderUtils` per ricavare i field `procedures` e `functions` a partire da GlobalProcedures globalProceduresRegistry.

Aggunto test `testMultipleOverrideWithFunctionAndProcedures` in `CypherProceduresStorageTest.java`.

Con i database embedded, la classe iniziale è `LazyProcedures` invece di `GlobalProcedureRegistry`, 
quindi ho dovuto fare una distinzione tra i due, ed per importarlo ho dovuto aggiungere questa dipendenza (compileOnly) che contiene la classe `LazyProcedures`.
```
compileOnly group: 'org.neo4j.community', name: 'it-test-support', version: neo4jVersionEffective
```

Testato anche con un'istanza reale su docker.