### PR TITLE
Custom overload fail after refresh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,6 @@ allprojects {
 }
 
 apply plugin: 'java-library'
-if (System.env.CI != null)
-    apply from: 'teamcity-repository.gradle'
 
 repositories {
 

--- a/extended/src/main/java/apoc/custom/CypherProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherProcedures.java
@@ -87,7 +87,7 @@ public class CypherProcedures {
     @Procedure(value = "apoc.custom.list", mode = Mode.READ)
     @Description("apoc.custom.list() - provide a list of custom procedures/function registered")
     public Stream<CustomProcedureInfo> list() {
-        return cypherProceduresHandler.readSignatures().map( descriptor -> {
+        return cypherProceduresHandler.readSignatures().stream().map( descriptor -> {
             if (descriptor instanceof CypherProceduresHandler.ProcedureDescriptor) {
                 CypherProceduresHandler.ProcedureDescriptor procedureDescriptor = (CypherProceduresHandler.ProcedureDescriptor) descriptor;
                 ProcedureSignature signature = procedureDescriptor.getSignature();

--- a/extended/src/main/java/apoc/custom/CypherProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherProcedures.java
@@ -64,9 +64,7 @@ public class CypherProcedures {
         Mode modeProcedure = cypherProceduresHandler.mode(mode);
         ProcedureSignature procedureSignature = new Signatures(PREFIX).asProcedureSignature(signature, description, modeProcedure);
         validateProcedure(statement, procedureSignature.inputSignature(), procedureSignature.outputSignature(), modeProcedure);
-        if (!cypherProceduresHandler.registerProcedure(procedureSignature, statement)) {
-            throw new IllegalStateException("Error registering procedure " + procedureSignature.name() + ", see log.");
-        }
+
         cypherProceduresHandler.storeProcedure(procedureSignature, statement);
     }
 
@@ -77,9 +75,7 @@ public class CypherProcedures {
                            @Name(value = "description", defaultValue = "") String description) throws ProcedureException {
         UserFunctionSignature userFunctionSignature = new Signatures(PREFIX).asFunctionSignature(signature, description);
         validateFunction(statement, userFunctionSignature.inputSignature());
-        if (!cypherProceduresHandler.registerFunction(userFunctionSignature, statement, forceSingle)) {
-            throw new IllegalStateException("Error registering function " + signature + ", see log.");
-        }
+
         cypherProceduresHandler.storeFunction(userFunctionSignature, statement, forceSingle);
     }
 
@@ -87,7 +83,7 @@ public class CypherProcedures {
     @Procedure(value = "apoc.custom.list", mode = Mode.READ)
     @Description("apoc.custom.list() - provide a list of custom procedures/function registered")
     public Stream<CustomProcedureInfo> list() {
-        return cypherProceduresHandler.readSignatures().stream().map( descriptor -> {
+        return cypherProceduresHandler.readSignatures().map( descriptor -> {
             if (descriptor instanceof CypherProceduresHandler.ProcedureDescriptor) {
                 CypherProceduresHandler.ProcedureDescriptor procedureDescriptor = (CypherProceduresHandler.ProcedureDescriptor) descriptor;
                 ProcedureSignature signature = procedureDescriptor.getSignature();

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -7,6 +7,7 @@ import apoc.SystemPropertyKeys;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -135,7 +136,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         return s == null ? Mode.READ : Mode.valueOf(s.toUpperCase());
     }
 
-    public Stream<ProcedureOrFunctionDescriptor> readSignatures() {
+//    public Stream<ProcedureOrFunctionDescriptor> readSignatures() {
+//        List<ProcedureOrFunctionDescriptor> descriptors;
+//        descriptors = getProcedureOrFunctionDescriptors();
+//        return descriptors.stream();
+//    }
+
+    public List<ProcedureOrFunctionDescriptor> readSignatures() {
         List<ProcedureOrFunctionDescriptor> descriptors;
         try (Transaction tx = systemDb.beginTx()) {
              descriptors = tx.findNodes( ExtendedSystemLabels.ApocCypherProcedures, SystemPropertyKeys.database.name(), api.databaseName()).stream().map(node -> {
@@ -149,7 +156,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             }).collect(Collectors.toList());
             tx.commit();
         }
-        return descriptors.stream();
+        return descriptors;
     }
 
     private ProcedureDescriptor procedureDescriptor(Node node) {
@@ -212,28 +219,54 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         Set<UserFunctionSignature> currentUserFunctionsToRemove = new HashSet<>(registeredUserFunctionSignatures);
 
         System.out.println("currentUserFunctionsToRemove = "
-                           + currentUserFunctionsToRemove.stream().map(i -> i.inputSignature() + ". " + i.name()).toList());
+                           + currentUserFunctionsToRemove.stream()
+                                   .map(i ->  i.name() + ":" + i.inputSignature() + " . " + i.outputType())
+                                   .toList()
+        );
 
-        readSignatures().forEach(descriptor -> {
+//        Stream<ProcedureOrFunctionDescriptor> procedureOrFunctionDescriptors = readSignatures();
+//        List<ProcedureOrFunctionDescriptor> procedureOrFunctionDescriptors = getProcedureOrFunctionDescriptors();
+        List<ProcedureOrFunctionDescriptor> procedureOrFunctionDescriptors = readSignatures();
+        procedureOrFunctionDescriptors.forEach(descriptor -> {
             System.out.println("descriptor.getStatement() = " + descriptor.getStatement());
             descriptor.register();
+            // we need to use currentProceduresToRemove.removeIf(..) instead of currentProceduresToRemove.remove(signature)
+            // as a procedure overload will produce 2 ProcedureSignatures in currentProceduresToRemove Set,
+            // but currentProceduresToRemove.remove(signature) wouldn't remove the current procedure signature
+            // todo - ???
+            // For the same reason, we use currentUserFunctionsToRemove.removeIf(..)
             if (descriptor instanceof ProcedureDescriptor) {
                 ProcedureSignature signature = ((ProcedureDescriptor) descriptor).getSignature();
                 currentProceduresToRemove.removeIf(i -> i.name().equals(signature.name()));
 //                currentProceduresToRemove.remove(signature);
             } else {
-                UserFunctionSignature signature = ((UserFunctionDescriptor) descriptor).getSignature();
-                currentUserFunctionsToRemove.removeIf(i -> i.name().equals(signature.name()));
-//                currentUserFunctionsToRemove.remove(signature);
+                UserFunctionDescriptor descriptor1 = (UserFunctionDescriptor) descriptor;
+                UserFunctionSignature signature = descriptor1.getSignature();
+                System.out.println("signature.name() = " + signature.name());
+                System.out.println("signature.inputSignature() = " + signature.inputSignature());
+                System.out.println("signature.outputType() = " + signature.outputType());
+
+
+
+//                currentUserFunctionsToRemove.removeIf(i -> i.name().equals(signature.name()));
+                currentUserFunctionsToRemove.remove(signature);
             }
         });
 
         System.out.println("currentUserFunctionsToRemove After = "
-                           + currentUserFunctionsToRemove.stream().map(i -> i.inputSignature() + ". " + i.name()).toList());
+                           + currentUserFunctionsToRemove.stream()
+                                   .map(i ->  i.name() + ":" + i.inputSignature() + " . " + i.outputType())
+                                   .toList()
+        );
 
         // de-register removed procs/functions
         currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));
         currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false));
+
+        // register remaining procs/functions AFTER de-registration,
+        // as, in the case of multiple signatures with the same name but with different inputs/outputs,
+        // the last globalProceduresRegistry.register(<Callable>) is the one that is detected by Neo4j during CALL custom.<name> / RETURN custom.<name>
+        procedureOrFunctionDescriptors.forEach(ProcedureOrFunctionDescriptor::register);
 
         api.executeTransactionally("call db.clearQueryCaches()");
     }

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -206,20 +206,30 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     }
 
     public void restoreProceduresAndFunctions() {
+        System.out.println("CypherProceduresHandler.restoreProceduresAndFunctions");
         lastUpdate = System.currentTimeMillis();
         Set<ProcedureSignature> currentProceduresToRemove = new HashSet<>(registeredProcedureSignatures);
         Set<UserFunctionSignature> currentUserFunctionsToRemove = new HashSet<>(registeredUserFunctionSignatures);
 
+        System.out.println("currentUserFunctionsToRemove = "
+                           + currentUserFunctionsToRemove.stream().map(i -> i.inputSignature() + ". " + i.name()).toList());
+
         readSignatures().forEach(descriptor -> {
+            System.out.println("descriptor.getStatement() = " + descriptor.getStatement());
             descriptor.register();
             if (descriptor instanceof ProcedureDescriptor) {
                 ProcedureSignature signature = ((ProcedureDescriptor) descriptor).getSignature();
-                currentProceduresToRemove.remove(signature);
+                currentProceduresToRemove.removeIf(i -> i.name().equals(signature.name()));
+//                currentProceduresToRemove.remove(signature);
             } else {
                 UserFunctionSignature signature = ((UserFunctionDescriptor) descriptor).getSignature();
-                currentUserFunctionsToRemove.remove(signature);
+                currentUserFunctionsToRemove.removeIf(i -> i.name().equals(signature.name()));
+//                currentUserFunctionsToRemove.remove(signature);
             }
         });
+
+        System.out.println("currentUserFunctionsToRemove After = "
+                           + currentUserFunctionsToRemove.stream().map(i -> i.inputSignature() + ". " + i.name()).toList());
 
         // de-register removed procs/functions
         currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -7,7 +7,6 @@ import apoc.SystemPropertyKeys;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -136,12 +135,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         return s == null ? Mode.READ : Mode.valueOf(s.toUpperCase());
     }
 
-//    public Stream<ProcedureOrFunctionDescriptor> readSignatures() {
-//        List<ProcedureOrFunctionDescriptor> descriptors;
-//        descriptors = getProcedureOrFunctionDescriptors();
-//        return descriptors.stream();
-//    }
-
     public List<ProcedureOrFunctionDescriptor> readSignatures() {
         List<ProcedureOrFunctionDescriptor> descriptors;
         try (Transaction tx = systemDb.beginTx()) {
@@ -213,60 +206,29 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     }
 
     public void restoreProceduresAndFunctions() {
-        System.out.println("CypherProceduresHandler.restoreProceduresAndFunctions");
         lastUpdate = System.currentTimeMillis();
         Set<ProcedureSignature> currentProceduresToRemove = new HashSet<>(registeredProcedureSignatures);
         Set<UserFunctionSignature> currentUserFunctionsToRemove = new HashSet<>(registeredUserFunctionSignatures);
 
-        System.out.println("currentUserFunctionsToRemove = "
-                           + currentUserFunctionsToRemove.stream()
-                                   .map(i ->  i.name() + ":" + i.inputSignature() + " . " + i.outputType())
-                                   .toList()
-        );
-
-//        Stream<ProcedureOrFunctionDescriptor> procedureOrFunctionDescriptors = readSignatures();
-//        List<ProcedureOrFunctionDescriptor> procedureOrFunctionDescriptors = getProcedureOrFunctionDescriptors();
-        List<ProcedureOrFunctionDescriptor> procedureOrFunctionDescriptors = readSignatures();
-        procedureOrFunctionDescriptors.forEach(descriptor -> {
-            System.out.println("descriptor.getStatement() = " + descriptor.getStatement());
-            descriptor.register();
-            // we need to use currentProceduresToRemove.removeIf(..) instead of currentProceduresToRemove.remove(signature)
-            // as a procedure overload will produce 2 ProcedureSignatures in currentProceduresToRemove Set,
-            // but currentProceduresToRemove.remove(signature) wouldn't remove the current procedure signature
-            // todo - ???
-            // For the same reason, we use currentUserFunctionsToRemove.removeIf(..)
+        List<ProcedureOrFunctionDescriptor> signatures = readSignatures();
+        signatures.forEach(descriptor -> {
             if (descriptor instanceof ProcedureDescriptor) {
                 ProcedureSignature signature = ((ProcedureDescriptor) descriptor).getSignature();
-                currentProceduresToRemove.removeIf(i -> i.name().equals(signature.name()));
-//                currentProceduresToRemove.remove(signature);
+                currentProceduresToRemove.remove(signature);
             } else {
-                UserFunctionDescriptor descriptor1 = (UserFunctionDescriptor) descriptor;
-                UserFunctionSignature signature = descriptor1.getSignature();
-                System.out.println("signature.name() = " + signature.name());
-                System.out.println("signature.inputSignature() = " + signature.inputSignature());
-                System.out.println("signature.outputType() = " + signature.outputType());
-
-
-
-//                currentUserFunctionsToRemove.removeIf(i -> i.name().equals(signature.name()));
+                UserFunctionSignature signature = ((UserFunctionDescriptor) descriptor).getSignature();
                 currentUserFunctionsToRemove.remove(signature);
             }
         });
-
-        System.out.println("currentUserFunctionsToRemove After = "
-                           + currentUserFunctionsToRemove.stream()
-                                   .map(i ->  i.name() + ":" + i.inputSignature() + " . " + i.outputType())
-                                   .toList()
-        );
 
         // de-register removed procs/functions
         currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));
         currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false));
 
-        // register remaining procs/functions AFTER de-registration,
+        // we register remaining procs/functions AFTER de-registrations,
         // as, in the case of multiple signatures with the same name but with different inputs/outputs,
-        // the last globalProceduresRegistry.register(<Callable>) is the one that is detected by Neo4j during CALL custom.<name> / RETURN custom.<name>
-        procedureOrFunctionDescriptors.forEach(ProcedureOrFunctionDescriptor::register);
+        // the last `globalProceduresRegistry.register(<Callable>)` is the one that is detected by Neo4j during CALL custom.<name> / RETURN custom.<name>
+        signatures.forEach(ProcedureOrFunctionDescriptor::register);
 
         api.executeTransactionally("call db.clearQueryCaches()");
     }

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -135,7 +135,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         return s == null ? Mode.READ : Mode.valueOf(s.toUpperCase());
     }
 
-    public List<ProcedureOrFunctionDescriptor> readSignatures() {
+    public Stream<ProcedureOrFunctionDescriptor> readSignatures() {
         List<ProcedureOrFunctionDescriptor> descriptors;
         try (Transaction tx = systemDb.beginTx()) {
              descriptors = tx.findNodes( ExtendedSystemLabels.ApocCypherProcedures, SystemPropertyKeys.database.name(), api.databaseName()).stream().map(node -> {
@@ -149,7 +149,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             }).collect(Collectors.toList());
             tx.commit();
         }
-        return descriptors;
+        return descriptors.stream();
     }
 
     private ProcedureDescriptor procedureDescriptor(Node node) {
@@ -210,8 +210,8 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         Set<ProcedureSignature> currentProceduresToRemove = new HashSet<>(registeredProcedureSignatures);
         Set<UserFunctionSignature> currentUserFunctionsToRemove = new HashSet<>(registeredUserFunctionSignatures);
 
-        List<ProcedureOrFunctionDescriptor> signatures = readSignatures();
-        signatures.forEach(descriptor -> {
+        readSignatures().forEach(descriptor -> {
+            descriptor.register();
             if (descriptor instanceof ProcedureDescriptor) {
                 ProcedureSignature signature = ((ProcedureDescriptor) descriptor).getSignature();
                 currentProceduresToRemove.remove(signature);
@@ -224,11 +224,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         // de-register removed procs/functions
         currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));
         currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false));
-
-        // we register remaining procs/functions AFTER de-registrations,
-        // as, in the case of multiple signatures with the same name but with different inputs/outputs,
-        // the last `globalProceduresRegistry.register(<Callable>)` is the one that is detected by Neo4j during CALL custom.<name> / RETURN custom.<name>
-        signatures.forEach(ProcedureOrFunctionDescriptor::register);
 
         api.executeTransactionally("call db.clearQueryCaches()");
     }
@@ -255,7 +250,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(ExtendedSystemPropertyKeys.forceSingle.name(), forceSingle);
 
             setLastUpdate(tx);
-            registerFunction(signature, statement, forceSingle);
+            if (!registerFunction(signature, statement, forceSingle)) {
+                throw new IllegalStateException("Error registering function " + signature + ", see log.");
+            }
             return null;
         });
     }
@@ -273,7 +270,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(ExtendedSystemPropertyKeys.outputs.name(), serializeSignatures(signature.outputSignature()));
             node.setProperty(ExtendedSystemPropertyKeys.mode.name(), signature.mode().name());
             setLastUpdate(tx);
-            registerProcedure(signature, statement);
+            if (!registerProcedure(signature, statement)) {
+                throw new IllegalStateException("Error registering procedure " + signature.name() + ", see log.");
+            }
             return null;
         });
     }
@@ -336,7 +335,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             boolean exists = globalProceduresRegistry.getCurrentView().getAllProcedures().stream()
                     .anyMatch(s -> s.name().equals(name));
             if (exists) {
+                // we deregister and remove possible homonyms signatures overridden/overloaded
                 ProcedureHolderUtils.unregisterProcedure(name, globalProceduresRegistry);
+                registeredProcedureSignatures.removeIf(i -> i.name().equals(signature.name()));
             }
 
             final boolean isStatementNull = statement == null;
@@ -380,7 +381,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             boolean exists = globalProceduresRegistry.getCurrentView().getAllNonAggregatingFunctions()
                     .anyMatch(s -> s.name().equals(name));
             if (exists) {
+                // we deregister and remove possible homonyms signatures overridden/overloaded
                 ProcedureHolderUtils.unregisterFunction(name, globalProceduresRegistry);
+                registeredUserFunctionSignatures.removeIf(i -> i.name().equals(signature.name()));
             }
 
             final boolean isStatementNull = statement == null;

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -98,6 +98,8 @@ public class CypherProceduresStorageTest {
 
         // wait a time greater then the `apoc.custom.procedures.refresh` value
         // and check overload works correctly
+
+        System.out.println("before refresh");
         Thread.sleep(greaterThanRefreshTime);
         checkFunctionOverloaded();
 

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -16,10 +16,13 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
+import static apoc.custom.CypherProceduresHandler.CUSTOM_PROCEDURES_REFRESH;
+import static apoc.util.DbmsTestUtil.startDbWithApocConfigs;
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -43,7 +46,15 @@ public class CypherProceduresStorageTest {
 
     @Before
     public void setUp() throws Exception {
-        dbms = new TestDatabaseManagementServiceBuilder( STORE_DIR.getRoot().toPath()).build();
+        try {
+            // start db with apoc.conf: `apoc.custom.procedures.refresh=2000`
+            dbms = startDbWithApocConfigs(STORE_DIR,
+                    Map.of(CUSTOM_PROCEDURES_REFRESH, 2000)
+            );//new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+//        dbms = new TestDatabaseManagementServiceBuilder( STORE_DIR.getRoot().toPath()).build();
         db = dbms.database( GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
     }
@@ -55,10 +66,80 @@ public class CypherProceduresStorageTest {
 
     private void restartDb() {
         dbms.shutdown();
+//        startDb();
+
         dbms = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
         db = dbms.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         assertTrue(db.isAvailable(1000));
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
+    }
+
+//    private void startDb() {
+//        try {
+//            // start db with apoc.conf: `apoc.custom.procedures.refresh=2000`
+//            dbms = startDbWithApocConfigs(STORE_DIR,
+//                    Map.of(CUSTOM_PROCEDURES_REFRESH, 2000)
+//            );//new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
+//        } catch (IOException e) {
+//            throw new RuntimeException(e);
+//        }
+//        db = dbms.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+//        assertTrue(db.isAvailable(1000));
+//        TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
+//    }
+
+    @Test
+    public void overloadFunctionAfterRefresh() throws Exception {
+        db.executeTransactionally("CALL apoc.custom.declareFunction('overrideFun() :: LONG','RETURN 10')");
+
+        TestUtil.testCall(db, "RETURN custom.overrideFun() AS result", r -> {
+            assertEquals(10L, r.get("result"));
+        });
+
+        System.out.println("before override");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('overrideFun(input::LONG) :: LONG', 'RETURN $input')");
+        System.out.println("after override");
+
+        // wait a time greater than `apoc.custom.procedures.refresh` value....
+        Thread.sleep(3000);
+//        testCallEventually(db, "CALL apoc.custom.list()", r -> {
+//            assertEquals("RETURN $input AS result", r.get("statement"));
+//        }, 5000);
+
+        System.out.println("after sleep");
+        TestUtil.testCall(db, "RETURN custom.overrideFun(42) AS result", r -> {
+            assertEquals(42L, r.get("result"));
+        });
+
+//        boolean delete = new File(STORE_DIR.getRoot(), "apoc.conf").delete();
+//        System.out.println("delete = " + delete);
+    }
+
+    @Test
+    public void overloadProcedureAfterRefresh() throws Exception {
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('overrideProc() :: (result::LONG)','RETURN 10 as result')");
+
+        TestUtil.testCall(db, "CALL custom.overrideProc()", r -> {
+            assertEquals(10L, r.get("result"));
+        });
+
+        System.out.println("before override");
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('overrideProc(input::LONG) :: (result::LONG)', 'RETURN $input AS result')");
+        System.out.println("after override");
+
+        // wait a time greater than `apoc.custom.procedures.refresh` value....
+        Thread.sleep(3000);
+//        testCallEventually(db, "CALL apoc.custom.list()", r -> {
+//            assertEquals("RETURN $input AS result", r.get("statement"));
+//        }, 5000);
+
+        System.out.println("after sleep");
+        TestUtil.testCall(db, "CALL custom.overrideProc(42)", r -> {
+            assertEquals(42L, r.get("result"));
+        });
+
+//        boolean delete = new File(STORE_DIR.getRoot(), "apoc.conf").delete();
+//        System.out.println("delete = " + delete);
     }
 
     @Test

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -50,11 +50,10 @@ public class CypherProceduresStorageTest {
             // start db with apoc.conf: `apoc.custom.procedures.refresh=2000`
             dbms = startDbWithApocConfigs(STORE_DIR,
                     Map.of(CUSTOM_PROCEDURES_REFRESH, 2000)
-            );//new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
+            );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-//        dbms = new TestDatabaseManagementServiceBuilder( STORE_DIR.getRoot().toPath()).build();
         db = dbms.database( GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
     }
@@ -66,27 +65,11 @@ public class CypherProceduresStorageTest {
 
     private void restartDb() {
         dbms.shutdown();
-//        startDb();
-
         dbms = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
         db = dbms.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         assertTrue(db.isAvailable(1000));
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
     }
-
-//    private void startDb() {
-//        try {
-//            // start db with apoc.conf: `apoc.custom.procedures.refresh=2000`
-//            dbms = startDbWithApocConfigs(STORE_DIR,
-//                    Map.of(CUSTOM_PROCEDURES_REFRESH, 2000)
-//            );//new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
-//        } catch (IOException e) {
-//            throw new RuntimeException(e);
-//        }
-//        db = dbms.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
-//        assertTrue(db.isAvailable(1000));
-//        TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
-//    }
 
     @Test
     public void overloadFunctionAfterRefresh() throws Exception {
@@ -96,23 +79,14 @@ public class CypherProceduresStorageTest {
             assertEquals(10L, r.get("result"));
         });
 
-        System.out.println("before override");
         db.executeTransactionally("CALL apoc.custom.declareFunction('overrideFun(input::LONG) :: LONG', 'RETURN $input')");
-        System.out.println("after override");
 
         // wait a time greater than `apoc.custom.procedures.refresh` value....
-        Thread.sleep(3000);
-//        testCallEventually(db, "CALL apoc.custom.list()", r -> {
-//            assertEquals("RETURN $input AS result", r.get("statement"));
-//        }, 5000);
+        Thread.sleep(5000);
 
-        System.out.println("after sleep");
         TestUtil.testCall(db, "RETURN custom.overrideFun(42) AS result", r -> {
             assertEquals(42L, r.get("result"));
         });
-
-//        boolean delete = new File(STORE_DIR.getRoot(), "apoc.conf").delete();
-//        System.out.println("delete = " + delete);
     }
 
     @Test
@@ -123,23 +97,14 @@ public class CypherProceduresStorageTest {
             assertEquals(10L, r.get("result"));
         });
 
-        System.out.println("before override");
         db.executeTransactionally("CALL apoc.custom.declareProcedure('overrideProc(input::LONG) :: (result::LONG)', 'RETURN $input AS result')");
-        System.out.println("after override");
 
         // wait a time greater than `apoc.custom.procedures.refresh` value....
         Thread.sleep(3000);
-//        testCallEventually(db, "CALL apoc.custom.list()", r -> {
-//            assertEquals("RETURN $input AS result", r.get("statement"));
-//        }, 5000);
 
-        System.out.println("after sleep");
         TestUtil.testCall(db, "CALL custom.overrideProc(42)", r -> {
             assertEquals(42L, r.get("result"));
         });
-
-//        boolean delete = new File(STORE_DIR.getRoot(), "apoc.conf").delete();
-//        System.out.println("delete = " + delete);
     }
 
     @Test

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class CypherProceduresStorageTest {
     private final static String QUERY_CREATE = "RETURN $input1 + $input2 as answer";
     private final static String QUERY_OVERWRITE = "RETURN $input1 + $input2 + 123 as answer";
+    private int greaterThanRefreshTime;
 
     @Rule
     public TemporaryFolder STORE_DIR = new TemporaryFolder();
@@ -47,10 +48,12 @@ public class CypherProceduresStorageTest {
     @Before
     public void setUp() throws Exception {
         try {
-            // start db with apoc.conf: `apoc.custom.procedures.refresh=2000`
+            final int refreshTime = 3000;
+            // start db with apoc.conf: `apoc.custom.procedures.refresh=<time>`
             dbms = startDbWithApocConfigs(STORE_DIR,
-                    Map.of(CUSTOM_PROCEDURES_REFRESH, 2000)
+                    Map.of(CUSTOM_PROCEDURES_REFRESH, refreshTime)
             );
+            greaterThanRefreshTime = refreshTime + 500;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -79,14 +82,44 @@ public class CypherProceduresStorageTest {
             assertEquals(10L, r.get("result"));
         });
 
+        try {
+            TestUtil.testCall(db, "RETURN custom.overrideFun(42)",
+                    r -> fail("Should fail due to wrong argument numbers"));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Current message is: " + message,
+                    message.contains("Function call does not provide the required number of arguments: expected 0 got 1"));
+        }
+
         db.executeTransactionally("CALL apoc.custom.declareFunction('overrideFun(input::LONG) :: LONG', 'RETURN $input')");
 
-        // wait a time greater than `apoc.custom.procedures.refresh` value....
-        Thread.sleep(5000);
+        // check overload before refresh
+        checkFunctionOverloaded();
 
+        // wait a time greater then the `apoc.custom.procedures.refresh` value
+        // and check overload works correctly
+        Thread.sleep(greaterThanRefreshTime);
+        checkFunctionOverloaded();
+
+        // check overload still remains after restarting the db
+        restartDb();
+        checkFunctionOverloaded();
+    }
+
+    private void checkFunctionOverloaded() {
         TestUtil.testCall(db, "RETURN custom.overrideFun(42) AS result", r -> {
             assertEquals(42L, r.get("result"));
         });
+
+
+        try {
+            TestUtil.testCall(db, "RETURN custom.overrideFun()",
+                    r -> fail("Should fail due to wrong argument numbers"));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Current message is: " + message,
+                    message.contains("Function call does not provide the required number of arguments: expected 1 got 0"));
+        }
     }
 
     @Test
@@ -97,10 +130,40 @@ public class CypherProceduresStorageTest {
             assertEquals(10L, r.get("result"));
         });
 
+        try {
+            TestUtil.testCall(db, "CALL custom.overrideProc(42)",
+                    r -> fail("Should fail due to wrong argument numbers"));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Current message is: " + message,
+                    message.contains("Procedure call provides too many arguments: got 1 expected none"));
+        }
+
         db.executeTransactionally("CALL apoc.custom.declareProcedure('overrideProc(input::LONG) :: (result::LONG)', 'RETURN $input AS result')");
 
-        // wait a time greater than `apoc.custom.procedures.refresh` value....
-        Thread.sleep(3000);
+        // check overload before refresh
+        checkProcedureOverloaded();
+
+        // wait a time greater than `apoc.custom.procedures.refresh` value
+        // and check overload works correctly
+        Thread.sleep(greaterThanRefreshTime);
+        checkProcedureOverloaded();
+
+        // check overload still remains after restarting the db
+        restartDb();
+        checkProcedureOverloaded();
+
+    }
+
+    private void checkProcedureOverloaded() {
+        try {
+            TestUtil.testCall(db, "CALL custom.overrideProc()",
+                    r -> fail("Should fail due to wrong argument numbers"));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Current message is: " + message,
+                    message.contains("Procedure call does not provide the required number of arguments: got 0 expected at least 1"));
+        }
 
         TestUtil.testCall(db, "CALL custom.overrideProc(42)", r -> {
             assertEquals(42L, r.get("result"));
@@ -313,6 +376,16 @@ public class CypherProceduresStorageTest {
         TestUtil.testCallEventually(db, "CALL custom.override(2)", r -> {
             assertEquals(4L, r.get("result"));
         }, 10L);
+
+        // check fun/proc updated work even after the refresh
+        Thread.sleep(greaterThanRefreshTime);
+        TestUtil.testCall(db, "RETURN custom.override(3) as result", r -> {
+            assertEquals(3L, r.get("result"));
+        });
+        TestUtil.testCall(db, "CALL custom.override(2)", r -> {
+            assertEquals(4L, r.get("result"));
+        });
+
         restartDb();
 
         final String logFileContent = Files.readString(new File(FileUtils.getLogDirectory(), "debug.log").toPath());

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -76,14 +76,14 @@ public class CypherProceduresStorageTest {
 
     @Test
     public void overloadFunctionAfterRefresh() throws Exception {
-        db.executeTransactionally("CALL apoc.custom.declareFunction('overrideFun() :: LONG','RETURN 10')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('overloadFun() :: LONG','RETURN 10')");
 
-        TestUtil.testCall(db, "RETURN custom.overrideFun() AS result", r -> {
+        TestUtil.testCall(db, "RETURN custom.overloadFun() AS result", r -> {
             assertEquals(10L, r.get("result"));
         });
 
         try {
-            TestUtil.testCall(db, "RETURN custom.overrideFun(42)",
+            TestUtil.testCall(db, "RETURN custom.overloadFun(42)",
                     r -> fail("Should fail due to wrong argument numbers"));
         } catch (Exception e) {
             String message = e.getMessage();
@@ -91,7 +91,7 @@ public class CypherProceduresStorageTest {
                     message.contains("Function call does not provide the required number of arguments: expected 0 got 1"));
         }
 
-        db.executeTransactionally("CALL apoc.custom.declareFunction('overrideFun(input::LONG) :: LONG', 'RETURN $input')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('overloadFun(input::LONG) :: LONG', 'RETURN $input')");
 
         // check overload before refresh
         checkFunctionOverloaded();
@@ -104,16 +104,27 @@ public class CypherProceduresStorageTest {
         // check overload still remains after restarting the db
         restartDb();
         checkFunctionOverloaded();
+
+        // overload with a function having an optional string argument
+        db.executeTransactionally("CALL apoc.custom.declareFunction('overloadFun(input = null :: STRING) :: STRING', 'RETURN $input')");
+
+        // we test the new function like above
+        checkSecondFunctionOverloaded();
+
+        Thread.sleep(greaterThanRefreshTime);
+        checkSecondFunctionOverloaded();
+
+        restartDb();
+        checkSecondFunctionOverloaded();
     }
 
     private void checkFunctionOverloaded() {
-        TestUtil.testCall(db, "RETURN custom.overrideFun(42) AS result", r -> {
+        TestUtil.testCall(db, "RETURN custom.overloadFun(42) AS result", r -> {
             assertEquals(42L, r.get("result"));
         });
 
-
         try {
-            TestUtil.testCall(db, "RETURN custom.overrideFun()",
+            TestUtil.testCall(db, "RETURN custom.overloadFun()",
                     r -> fail("Should fail due to wrong argument numbers"));
         } catch (Exception e) {
             String message = e.getMessage();
@@ -122,16 +133,35 @@ public class CypherProceduresStorageTest {
         }
     }
 
+    private void checkSecondFunctionOverloaded() {
+        TestUtil.testCall(db, "RETURN custom.overloadFun('42') AS result", r -> {
+            assertEquals("42", r.get("result"));
+        });
+
+        TestUtil.testCall(db, "RETURN custom.overloadFun() AS result", r -> {
+            assertNull(r.get("result"));
+        });
+
+        try {
+            TestUtil.testCall(db, "RETURN custom.overloadFun(42) AS result",
+                    r -> fail("Should fail due to wrong argument numbers"));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Current message is: " + message,
+                    message.contains("Type mismatch: expected String but was Integer"));
+        }
+    }
+
     @Test
     public void overloadProcedureAfterRefresh() throws Exception {
-        db.executeTransactionally("CALL apoc.custom.declareProcedure('overrideProc() :: (result::LONG)','RETURN 10 as result')");
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('overloadProc() :: (result::LONG)','RETURN 10 as result')");
 
-        TestUtil.testCall(db, "CALL custom.overrideProc()", r -> {
+        TestUtil.testCall(db, "CALL custom.overloadProc()", r -> {
             assertEquals(10L, r.get("result"));
         });
 
         try {
-            TestUtil.testCall(db, "CALL custom.overrideProc(42)",
+            TestUtil.testCall(db, "CALL custom.overloadProc(42)",
                     r -> fail("Should fail due to wrong argument numbers"));
         } catch (Exception e) {
             String message = e.getMessage();
@@ -139,7 +169,7 @@ public class CypherProceduresStorageTest {
                     message.contains("Procedure call provides too many arguments: got 1 expected none"));
         }
 
-        db.executeTransactionally("CALL apoc.custom.declareProcedure('overrideProc(input::LONG) :: (result::LONG)', 'RETURN $input AS result')");
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('overloadProc(input::LONG) :: (result::LONG)', 'RETURN $input AS result')");
 
         // check overload before refresh
         checkProcedureOverloaded();
@@ -153,11 +183,22 @@ public class CypherProceduresStorageTest {
         restartDb();
         checkProcedureOverloaded();
 
+        // overload with a procedure having an optional string argument
+        db.executeTransactionally("CALL apoc.custom.declareProcedure('overloadProc(input = \"def\" :: STRING) :: (result::STRING)', 'RETURN $input AS result')");
+
+        // we test the new procedure like above
+        checkSecondProcedureOverloaded();
+
+        Thread.sleep(greaterThanRefreshTime);
+        checkSecondProcedureOverloaded();
+
+        restartDb();
+        checkSecondProcedureOverloaded();
     }
 
     private void checkProcedureOverloaded() {
         try {
-            TestUtil.testCall(db, "CALL custom.overrideProc()",
+            TestUtil.testCall(db, "CALL custom.overloadProc()",
                     r -> fail("Should fail due to wrong argument numbers"));
         } catch (Exception e) {
             String message = e.getMessage();
@@ -165,9 +206,28 @@ public class CypherProceduresStorageTest {
                     message.contains("Procedure call does not provide the required number of arguments: got 0 expected at least 1"));
         }
 
-        TestUtil.testCall(db, "CALL custom.overrideProc(42)", r -> {
+        TestUtil.testCall(db, "CALL custom.overloadProc(42)", r -> {
             assertEquals(42L, r.get("result"));
         });
+    }
+
+    private void checkSecondProcedureOverloaded() {
+        TestUtil.testCall(db, "CALL custom.overloadProc('42')", r -> {
+            assertEquals("42", r.get("result"));
+        });
+
+        TestUtil.testCall(db, "CALL custom.overloadProc()", r -> {
+            assertEquals("def", r.get("result"));
+        });
+
+        try {
+            TestUtil.testCall(db, "CALL custom.overloadProc(42)",
+                    r -> fail("Should fail due to wrong argument numbers"));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Current message is: " + message,
+                    message.contains("Type mismatch: expected String but was Integer"));
+        }
     }
 
     @Test

--- a/extended/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -80,7 +80,7 @@ public class CypherProceduresTest  {
     @Before
     public void setup() throws IOException {
         DatabaseManagementService databaseManagementService = startDbWithApocConfigs(storeDir,
-                Map.of(CUSTOM_PROCEDURES_REFRESH, 2000)
+                Map.of(CUSTOM_PROCEDURES_REFRESH, 1000)
 //                Map.of()
         );
 
@@ -88,26 +88,40 @@ public class CypherProceduresTest  {
         TestUtil.registerProcedure(db, CypherProcedures.class);
     }
 
+    @Test
+    public void testOverride1() throws InterruptedException {
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override1() :: LONG','RETURN 10 as answer')");
+        db.executeTransactionally("CALL apoc.custom.removeFunction('override1')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override1(input::INT) :: INT', 'RETURN $input AS result')");
+        TestUtil.testCall(db, "RETURN custom.override1(42) AS result", r -> {
+            assertEquals(42L, r.get("result"));
+        });
+
+    }
 
     @Test
     public void testOverride() throws InterruptedException {
-
         db.executeTransactionally("CALL apoc.custom.declareFunction('override() :: LONG','RETURN 10 as answer')");
 
         TestUtil.testCall(db, "RETURN custom.override() AS result", r -> {
             assertEquals(10L, r.get("result"));
         });
 
-        System.out.println("before override");
+//        System.out.println("before override");
         db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input AS result')");
-        System.out.println("after override");
+//        System.out.println("after override");
 
-        Thread.sleep(5000);
+        Thread.sleep(2000);
 //        testCallEventually(db, "CALL apoc.custom.list()", r -> {
 //            assertEquals("RETURN $input AS result", r.get("statement"));
 //        }, 5000);
 
-        System.out.println("after sleep");
+//        System.out.println("after sleep");
+        db.executeTransactionally("call db.clearQueryCaches()");
+
+        // todo !!!! - forse perché registro con null DOPO che faccio l'override!!!!
+
+//        db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input AS result')");
         TestUtil.testCall(db, "RETURN custom.override(42) AS result", r -> {
             assertEquals(42L, r.get("result"));
         });

--- a/extended/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -1,5 +1,6 @@
 package apoc.custom;
 
+import apoc.ApocConfig;
 import apoc.ExtendedSystemLabels;
 import apoc.RegisterComponentFactory;
 import apoc.SystemPropertyKeys;
@@ -8,10 +9,14 @@ import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -20,16 +25,21 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static apoc.ApocConfig.apocConfig;
+import static apoc.custom.CypherProceduresHandler.CUSTOM_PROCEDURES_REFRESH;
 import static apoc.custom.CypherProceduresHandler.FUNCTION;
 import static apoc.custom.CypherProceduresHandler.PROCEDURE;
 import static apoc.custom.Signatures.SIGNATURE_SYNTAX_ERROR;
+import static apoc.util.DbmsTestUtil.startDbWithApocConfigs;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testCallEventually;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -43,22 +53,74 @@ import static org.junit.Assert.fail;
  */
 public class CypherProceduresTest  {
 
-    @Rule
-    public DbmsRule db = new ImpermanentDbmsRule();
+//    @Rule
+//    public DbmsRule db = new ImpermanentDbmsRule();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
 
+    @ClassRule
+    public static TemporaryFolder storeDir = new TemporaryFolder();
+
+    private GraphDatabaseService db;
+
+//    @BeforeClass
+//    public static void beforeClass() throws Exception {
+//        databaseManagementService = startDbWithCustomApocConfs(storeDir);
+//
+//        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+//        sysDb = databaseManagementService.database(GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
+//        waitDbsAvailable(db, sysDb);
+//        // todo - Nodes.class and Schemas.class needed?
+//        TestUtil.registerProcedure(sysDb, CustomNewProcedures.class);
+//        TestUtil.registerProcedure(db, CypherProcedures.class);
+//    }
+
     @Before
-    public void setup() {
+    public void setup() throws IOException {
+        DatabaseManagementService databaseManagementService = startDbWithApocConfigs(storeDir,
+                Map.of(CUSTOM_PROCEDURES_REFRESH, 2000)
+//                Map.of()
+        );
+
+        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, CypherProcedures.class);
     }
 
-    @AfterAll
-    public void tearDown() {
-        db.shutdown();
+
+    @Test
+    public void testOverride() throws InterruptedException {
+
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override() :: LONG','RETURN 10 as answer')");
+
+        TestUtil.testCall(db, "RETURN custom.override() AS result", r -> {
+            assertEquals(10L, r.get("result"));
+        });
+
+        System.out.println("before override");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input AS result')");
+        System.out.println("after override");
+
+        Thread.sleep(5000);
+//        testCallEventually(db, "CALL apoc.custom.list()", r -> {
+//            assertEquals("RETURN $input AS result", r.get("statement"));
+//        }, 5000);
+
+        System.out.println("after sleep");
+        TestUtil.testCall(db, "RETURN custom.override(42) AS result", r -> {
+            assertEquals(42L, r.get("result"));
+        });
+
     }
+
+
+//    TODOOOOO —> override non funge… (testMultipleOverrideWithFunctionAndProcedures)
+//    forse perché fa il remove della full signature…
+//    e cancella il nodo…
+//    FARE COME BUG SEPARATO VISTO CHE RIGUARDA ANCHE LE “VECCHIE” PROCEDURE
+//—> COME REPLICARE: restore 2000, creo funzione, creo funzione2, thread sleep, boom!
+
 
     @Test
     public void registerSimpleStatement() throws Exception {
@@ -427,34 +489,34 @@ public class CypherProceduresTest  {
         TestUtil.count(db, "return custom.answer()");
     }
 
-    @Test
-    public void shouldRemovalOfFunctionNodeDeactivate() {
-        thrown.expect(QueryExecutionException.class);
-        thrown.expectMessage("Unknown function 'custom.answer'");
-        thrown.expect(new StatusCodeMatcher("Neo.ClientError.Statement.SyntaxError"));
-
-        //given
-        db.executeTransactionally("CALL apoc.custom.declareFunction('answer() :: LONG','RETURN 42 as answer')");
-
-        long answer = TestUtil.singleResultFirstColumn(db, "return custom.answer()");
-        assertEquals(42L, answer);
-
-        // remove the node in systemdb
-        GraphDatabaseService systemDb = db.getManagementService().database("system");
-        try (Transaction tx = systemDb.beginTx()) {
-            Node node = tx.findNode( ExtendedSystemLabels.ApocCypherProcedures, SystemPropertyKeys.name.name(), "answer");
-            node.delete();
-            tx.commit();
-        }
-
-        // refresh procedures
-        RegisterComponentFactory.RegisterComponentLifecycle registerComponentLifecycle = db.getDependencyResolver().resolveDependency(RegisterComponentFactory.RegisterComponentLifecycle.class);
-        CypherProceduresHandler cypherProceduresHandler = (CypherProceduresHandler) registerComponentLifecycle.getResolvers().get(CypherProceduresHandler.class).get(db.databaseName());
-        cypherProceduresHandler.restoreProceduresAndFunctions();
-
-        // when
-        TestUtil.singleResultFirstColumn(db, "return custom.answer()");
-    }
+//    @Test
+//    public void shouldRemovalOfFunctionNodeDeactivate() {
+//        thrown.expect(QueryExecutionException.class);
+//        thrown.expectMessage("Unknown function 'custom.answer'");
+//        thrown.expect(new StatusCodeMatcher("Neo.ClientError.Statement.SyntaxError"));
+//
+//        //given
+//        db.executeTransactionally("CALL apoc.custom.declareFunction('answer() :: LONG','RETURN 42 as answer')");
+//
+//        long answer = TestUtil.singleResultFirstColumn(db, "return custom.answer()");
+//        assertEquals(42L, answer);
+//
+//        // remove the node in systemdb
+//        GraphDatabaseService systemDb = db.getManagementService().database("system");
+//        try (Transaction tx = systemDb.beginTx()) {
+//            Node node = tx.findNode( ExtendedSystemLabels.ApocCypherProcedures, SystemPropertyKeys.name.name(), "answer");
+//            node.delete();
+//            tx.commit();
+//        }
+//
+//        // refresh procedures
+//        RegisterComponentFactory.RegisterComponentLifecycle registerComponentLifecycle = db.getDependencyResolver().resolveDependency(RegisterComponentFactory.RegisterComponentLifecycle.class);
+//        CypherProceduresHandler cypherProceduresHandler = (CypherProceduresHandler) registerComponentLifecycle.getResolvers().get(CypherProceduresHandler.class).get(db.databaseName());
+//        cypherProceduresHandler.restoreProceduresAndFunctions();
+//
+//        // when
+//        TestUtil.singleResultFirstColumn(db, "return custom.answer()");
+//    }
     
     @Test
     public void testIssue2605() {
@@ -616,8 +678,6 @@ public class CypherProceduresTest  {
                 "meta", Map.of("foo", "bar")
         ));
     }
-    
-
     private void assertProcedureFails(String expectedMessage, String query) {
         try {
             testCall(db, query, row -> fail("The test should fail because of: " + expectedMessage));

--- a/extended/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -1,6 +1,5 @@
 package apoc.custom;
 
-import apoc.ApocConfig;
 import apoc.ExtendedSystemLabels;
 import apoc.RegisterComponentFactory;
 import apoc.SystemPropertyKeys;
@@ -9,14 +8,10 @@ import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.neo4j.configuration.GraphDatabaseSettings;
-import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -25,21 +20,16 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static apoc.ApocConfig.apocConfig;
-import static apoc.custom.CypherProceduresHandler.CUSTOM_PROCEDURES_REFRESH;
 import static apoc.custom.CypherProceduresHandler.FUNCTION;
 import static apoc.custom.CypherProceduresHandler.PROCEDURE;
 import static apoc.custom.Signatures.SIGNATURE_SYNTAX_ERROR;
-import static apoc.util.DbmsTestUtil.startDbWithApocConfigs;
 import static apoc.util.TestUtil.testCall;
-import static apoc.util.TestUtil.testCallEventually;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -53,88 +43,22 @@ import static org.junit.Assert.fail;
  */
 public class CypherProceduresTest  {
 
-//    @Rule
-//    public DbmsRule db = new ImpermanentDbmsRule();
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
 
-    @ClassRule
-    public static TemporaryFolder storeDir = new TemporaryFolder();
-
-    private GraphDatabaseService db;
-
-//    @BeforeClass
-//    public static void beforeClass() throws Exception {
-//        databaseManagementService = startDbWithCustomApocConfs(storeDir);
-//
-//        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
-//        sysDb = databaseManagementService.database(GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
-//        waitDbsAvailable(db, sysDb);
-//        // todo - Nodes.class and Schemas.class needed?
-//        TestUtil.registerProcedure(sysDb, CustomNewProcedures.class);
-//        TestUtil.registerProcedure(db, CypherProcedures.class);
-//    }
-
     @Before
-    public void setup() throws IOException {
-        DatabaseManagementService databaseManagementService = startDbWithApocConfigs(storeDir,
-                Map.of(CUSTOM_PROCEDURES_REFRESH, 1000)
-//                Map.of()
-        );
-
-        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+    public void setup() {
         TestUtil.registerProcedure(db, CypherProcedures.class);
     }
 
-    @Test
-    public void testOverride1() throws InterruptedException {
-        db.executeTransactionally("CALL apoc.custom.declareFunction('override1() :: LONG','RETURN 10 as answer')");
-        db.executeTransactionally("CALL apoc.custom.removeFunction('override1')");
-        db.executeTransactionally("CALL apoc.custom.declareFunction('override1(input::INT) :: INT', 'RETURN $input AS result')");
-        TestUtil.testCall(db, "RETURN custom.override1(42) AS result", r -> {
-            assertEquals(42L, r.get("result"));
-        });
-
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
-
-    @Test
-    public void testOverride() throws InterruptedException {
-        db.executeTransactionally("CALL apoc.custom.declareFunction('override() :: LONG','RETURN 10 as answer')");
-
-        TestUtil.testCall(db, "RETURN custom.override() AS result", r -> {
-            assertEquals(10L, r.get("result"));
-        });
-
-//        System.out.println("before override");
-        db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input AS result')");
-//        System.out.println("after override");
-
-        Thread.sleep(2000);
-//        testCallEventually(db, "CALL apoc.custom.list()", r -> {
-//            assertEquals("RETURN $input AS result", r.get("statement"));
-//        }, 5000);
-
-//        System.out.println("after sleep");
-        db.executeTransactionally("call db.clearQueryCaches()");
-
-        // todo !!!! - forse perché registro con null DOPO che faccio l'override!!!!
-
-//        db.executeTransactionally("CALL apoc.custom.declareFunction('override(input::INT) :: INT', 'RETURN $input AS result')");
-        TestUtil.testCall(db, "RETURN custom.override(42) AS result", r -> {
-            assertEquals(42L, r.get("result"));
-        });
-
-    }
-
-
-//    TODOOOOO —> override non funge… (testMultipleOverrideWithFunctionAndProcedures)
-//    forse perché fa il remove della full signature…
-//    e cancella il nodo…
-//    FARE COME BUG SEPARATO VISTO CHE RIGUARDA ANCHE LE “VECCHIE” PROCEDURE
-//—> COME REPLICARE: restore 2000, creo funzione, creo funzione2, thread sleep, boom!
-
 
     @Test
     public void registerSimpleStatement() throws Exception {
@@ -503,34 +427,34 @@ public class CypherProceduresTest  {
         TestUtil.count(db, "return custom.answer()");
     }
 
-//    @Test
-//    public void shouldRemovalOfFunctionNodeDeactivate() {
-//        thrown.expect(QueryExecutionException.class);
-//        thrown.expectMessage("Unknown function 'custom.answer'");
-//        thrown.expect(new StatusCodeMatcher("Neo.ClientError.Statement.SyntaxError"));
-//
-//        //given
-//        db.executeTransactionally("CALL apoc.custom.declareFunction('answer() :: LONG','RETURN 42 as answer')");
-//
-//        long answer = TestUtil.singleResultFirstColumn(db, "return custom.answer()");
-//        assertEquals(42L, answer);
-//
-//        // remove the node in systemdb
-//        GraphDatabaseService systemDb = db.getManagementService().database("system");
-//        try (Transaction tx = systemDb.beginTx()) {
-//            Node node = tx.findNode( ExtendedSystemLabels.ApocCypherProcedures, SystemPropertyKeys.name.name(), "answer");
-//            node.delete();
-//            tx.commit();
-//        }
-//
-//        // refresh procedures
-//        RegisterComponentFactory.RegisterComponentLifecycle registerComponentLifecycle = db.getDependencyResolver().resolveDependency(RegisterComponentFactory.RegisterComponentLifecycle.class);
-//        CypherProceduresHandler cypherProceduresHandler = (CypherProceduresHandler) registerComponentLifecycle.getResolvers().get(CypherProceduresHandler.class).get(db.databaseName());
-//        cypherProceduresHandler.restoreProceduresAndFunctions();
-//
-//        // when
-//        TestUtil.singleResultFirstColumn(db, "return custom.answer()");
-//    }
+    @Test
+    public void shouldRemovalOfFunctionNodeDeactivate() {
+        thrown.expect(QueryExecutionException.class);
+        thrown.expectMessage("Unknown function 'custom.answer'");
+        thrown.expect(new StatusCodeMatcher("Neo.ClientError.Statement.SyntaxError"));
+
+        //given
+        db.executeTransactionally("CALL apoc.custom.declareFunction('answer() :: LONG','RETURN 42 as answer')");
+
+        long answer = TestUtil.singleResultFirstColumn(db, "return custom.answer()");
+        assertEquals(42L, answer);
+
+        // remove the node in systemdb
+        GraphDatabaseService systemDb = db.getManagementService().database("system");
+        try (Transaction tx = systemDb.beginTx()) {
+            Node node = tx.findNode( ExtendedSystemLabels.ApocCypherProcedures, SystemPropertyKeys.name.name(), "answer");
+            node.delete();
+            tx.commit();
+        }
+
+        // refresh procedures
+        RegisterComponentFactory.RegisterComponentLifecycle registerComponentLifecycle = db.getDependencyResolver().resolveDependency(RegisterComponentFactory.RegisterComponentLifecycle.class);
+        CypherProceduresHandler cypherProceduresHandler = (CypherProceduresHandler) registerComponentLifecycle.getResolvers().get(CypherProceduresHandler.class).get(db.databaseName());
+        cypherProceduresHandler.restoreProceduresAndFunctions();
+
+        // when
+        TestUtil.singleResultFirstColumn(db, "return custom.answer()");
+    }
     
     @Test
     public void testIssue2605() {
@@ -692,6 +616,8 @@ public class CypherProceduresTest  {
                 "meta", Map.of("foo", "bar")
         ));
     }
+
+
     private void assertProcedureFails(String expectedMessage, String query) {
         try {
             testCall(db, query, row -> fail("The test should fail because of: " + expectedMessage));


### PR DESCRIPTION
https://trello.com/c/XWc7tBAb/74-custom-procedures-with-overload-fail-after-refresh

Se faccio, per esempio:
```
CALL apoc.custom.declareFunction('overloadTest() :: LONG','RETURN 10 as answer');
CALL apoc.custom.declareFunction('overloadTest(input::INT) :: INT', 'RETURN $input AS result');
// last overloaded func.
CALL apoc.custom.declareFunction('overloadTest(input = null::INT) :: INT', 'RETURN $input AS result');
```
ed aspetto che venga effettuato il refresh, ***l'ultima funzione sovrascritta non viene rilevata*** (neanche le vecchie).


Attualmente il `restoreProceduresAndFunctions`, quando c'è un overload,
prima registra la nuova procedura, poi de-registra la vecchia, in quanto neo4j considera, a parità di nome, l'ultimo register effettuato, ovvero considera il de-register che viene effettuato DOPO il `descriptor.register()`


### Cambiamenti

Rimuovendo la vecchia procedura dalle cache (`registeredProcedureSignatures` e `registeredUserFunctionSignatures`) prima che venga registrata la nuova risolve il problema

- Rimossi `if (!cypherProceduresHandler.registerProcedure(procedureSignature, statement))` e `if (!cypherProceduresHandler.registerFunction(userFunctionSignature, statement, forceSingle))` in CypherProcedures.java in quanto effettuavano una doppia registrazione, essendoci `cypherProceduresHandler.storeProcedure`/`cypherProceduresHandler.storeFunction` alla riga successiva


- Ho usato `Thread.sleep` invece di `assertEventually` per i vari test perché bisogna essere sicuri di aver refreshato prima di testare, altrimenti potremmo avere dei falsi positivi

- Ho cambiato `readSignatures()` con List come tipo di ritorno, così posso riutilizzare il risultato (List<ProcedureOrFunctionDescriptor> signatures) in `restoreProceduresAndFunctions`



---
---

TODO: rebase e cambiare base branch in dev e resettare build.gradle prima di sottomettere