### PR TITLE
Fixes 3072: apoc.custom.declareProcedure fails with java.lang.RuntimeException if provided mode is SCHEMA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,6 @@ allprojects {
 }
 
 apply plugin: 'java-library'
-if (System.env.CI != null)
-    apply from: 'teamcity-repository.gradle'
 
 repositories {
 

--- a/extended/src/main/java/apoc/custom/CypherProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherProcedures.java
@@ -161,7 +161,7 @@ public class CypherProcedures {
                         checkInputParams(result);
                     }
                     if (mode != null) {
-                        checkMode(result/*.getQueryExecutionType().queryType()*/, mode);
+                        checkMode(result, mode);
                     }
                     return null;
                 });
@@ -192,7 +192,7 @@ public class CypherProcedures {
         // if query type not matched
         if (queryType != null) {
             /*
-            The `correspondenceList` print a list like:
+            The `correspondenceList` prints a list like:
                 - Mode: SCHEMA can have as a query execution type: [READ_ONLY, WRITE, READ_WRITE, SCHEMA_WRITE]
                 - Mode: DBMS can have as a query execution type: [DBMS]
                 ...

--- a/extended/src/main/java/apoc/custom/CypherProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherProcedures.java
@@ -24,6 +24,7 @@ import org.neo4j.procedure.Mode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -168,19 +169,34 @@ public class CypherProcedures {
     }
 
     private void checkMode(Result result, Mode mode) {
+        // all modes can have DEFAULT and READ procedures as well
+        Set<Mode> modes = new HashSet<>() {{
+            add(mode);
+            add(Mode.DEFAULT);
+            add(Mode.READ);
+        }};
+
+        // schema can have WRITE procedures as well
+        if (mode.equals(Mode.SCHEMA)) {
+            modes.add(Mode.WRITE);
+        }
 
         // check that all inner procedure have a correct Mode
-        if (!procsAreValid(api, Set.of(mode), result )){
+        if (!procsAreValid(api, modes, result)) {
             throw new RuntimeException("One or more inner procedure modes have operation different from the mode parameter: " + mode);
         }
 
         List<QueryType> readQueryTypes = List.of(QueryType.READ_ONLY);
         List<QueryType> writeQueryTypes = List.of(QueryType.READ_ONLY, QueryType.WRITE, QueryType.READ_WRITE);
         List<QueryType> schemaQueryTypes = List.of(QueryType.READ_ONLY, QueryType.WRITE, QueryType.READ_WRITE, QueryType.SCHEMA_WRITE);
-        List<QueryType> dbmsQueryTypes = List.of(QueryType.DBMS);
+        List<QueryType> dbmsQueryTypes = List.of(QueryType.READ_ONLY, QueryType.DBMS);
 
         // create a map of Mode to allowed `QueryType`s
-        Map<Mode, List<QueryType>> modeQueryTypeMap = Map.of(Mode.READ, readQueryTypes,
+        // WRITE mode can have READ and WRITE query types
+        // SCHEMA mode can have SCHEMA, READ and WRITE query types
+        // DBMS mode can have READ and DBMS query types
+        Map<Mode, List<QueryType>> modeQueryTypeMap = Map.of(
+                Mode.READ, readQueryTypes,
                 Mode.WRITE, writeQueryTypes,
                 Mode.SCHEMA, schemaQueryTypes,
                 Mode.DBMS, dbmsQueryTypes);

--- a/extended/src/main/java/apoc/custom/CypherProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherProcedures.java
@@ -4,7 +4,7 @@ import apoc.Extended;
 import apoc.util.collection.Iterables;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Notification;
-import org.neo4j.graphdb.QueryExecutionType;
+
 import org.neo4j.graphdb.Result;
 import org.neo4j.internal.kernel.api.exceptions.ProcedureException;
 import org.neo4j.internal.kernel.api.procs.DefaultParameterValue;
@@ -34,6 +34,10 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.custom.CypherProceduresHandler.*;
+import static apoc.util.ExtendedUtil.isQueryValid;
+import static apoc.util.ExtendedUtil.procsAreValid;
+
+import org.neo4j.graphdb.QueryExecutionType.QueryType;
 
 /**
  * @author mh
@@ -157,25 +161,57 @@ public class CypherProcedures {
                         checkInputParams(result);
                     }
                     if (mode != null) {
-                        checkMode(result.getQueryExecutionType().queryType(), mode);
+                        checkMode(result/*.getQueryExecutionType().queryType()*/, mode);
                     }
                     return null;
                 });
     }
 
-    private void checkMode(QueryExecutionType.QueryType queryType, Mode mode) {
-        Map<QueryExecutionType.QueryType, Mode> map = Map.of(QueryExecutionType.QueryType.WRITE, Mode.WRITE,
-                QueryExecutionType.QueryType.READ_ONLY, Mode.READ,
-                QueryExecutionType.QueryType.READ_WRITE, Mode.WRITE,
-                QueryExecutionType.QueryType.DBMS, Mode.DBMS,
-                QueryExecutionType.QueryType.SCHEMA_WRITE, Mode.SCHEMA);
-        
-        if (!map.get(queryType).equals(mode)) {
-            throw new RuntimeException(String.format("The query execution type is %s, but you provided mode %s.\n" +
-                            "Supported modes are %s",
-                    queryType.name(), 
-                    mode.name(), 
-                    map.values().stream().sorted().collect(Collectors.toList())));
+    private void checkMode(Result result, Mode mode) {
+
+        // check that all inner procedure have a correct Mode
+        if (!procsAreValid(api, Set.of(mode), result )){
+            throw new RuntimeException("One or more inner procedure modes have operation different from the mode parameter: " + mode);
+        }
+
+        List<QueryType> readQueryTypes = List.of(QueryType.READ_ONLY);
+        List<QueryType> writeQueryTypes = List.of(QueryType.READ_ONLY, QueryType.WRITE, QueryType.READ_WRITE);
+        List<QueryType> schemaQueryTypes = List.of(QueryType.READ_ONLY, QueryType.WRITE, QueryType.READ_WRITE, QueryType.SCHEMA_WRITE);
+        List<QueryType> dbmsQueryTypes = List.of(QueryType.DBMS);
+
+        // create a map of Mode to allowed `QueryType`s
+        Map<Mode, List<QueryType>> modeQueryTypeMap = Map.of(Mode.READ, readQueryTypes,
+                Mode.WRITE, writeQueryTypes,
+                Mode.SCHEMA, schemaQueryTypes,
+                Mode.DBMS, dbmsQueryTypes);
+
+        List<QueryType> queryTypes = modeQueryTypeMap.get(mode);
+
+        // check that the statement have a valid queryType
+        QueryType queryType = isQueryValid(result, queryTypes.toArray(QueryType[]::new));
+        // if query type not matched
+        if (queryType != null) {
+            /*
+            The `correspondenceList` print a list like:
+                - Mode: SCHEMA can have as a query execution type: [READ_ONLY, WRITE, READ_WRITE, SCHEMA_WRITE]
+                - Mode: DBMS can have as a query execution type: [DBMS]
+                ...
+             */
+            String correspondenceList = modeQueryTypeMap.entrySet()
+                    .stream()
+                    .map(i -> "- Mode: " + i.getKey() + " can have as a query execution type: " + i.getValue())
+                    .collect(Collectors.joining("\n"));
+
+            throw new RuntimeException(String.format("""
+                            The query execution type of the statement is: `%s`, but you provided as a parameter mode: `%s`.
+                            You have to declare a `mode` which corresponds to one of the following query execution type.
+                            That is:
+                            %s""",
+                    queryType.name(),
+                    mode.name(),
+                    correspondenceList
+                    )
+            );
         }
     }
 

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -2,13 +2,27 @@ package apoc.util;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatProperties;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatToString;
+import static apoc.util.Util.getAllQueryProcs;
 
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import apoc.util.collection.Iterators;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionType;
+import org.neo4j.graphdb.Result;
+import org.neo4j.procedure.Mode;
 
 public class ExtendedUtil
 {
@@ -42,5 +56,49 @@ public class ExtendedUtil
     public static String toCypherMap( Map<String, Object> map) {
         final StringBuilder builder = formatProperties(map);
         return "{" + formatToString(builder) + "}";
+    }
+
+    public static void validateResult(GraphDatabaseService db, Set<Mode> supportedModes, Result result, QueryExecutionType.QueryType... supportedQueryTypes) {
+        final boolean isQueryTypeValid = supportedQueryTypes == null || supportedQueryTypes.length == 0 || Stream.of(supportedQueryTypes)
+                .anyMatch(sqt -> sqt.equals(result.getQueryExecutionType().queryType()));
+
+        if (!isQueryTypeValid) {
+            throw new RuntimeException("Supported query types for the operation are " + Arrays.toString(supportedQueryTypes));
+        }
+
+        if (!procsAreValid(db, supportedModes, result)) {
+            throw new RuntimeException("Supported inner procedure modes for the operation are " + new TreeSet<>(supportedModes));
+        }
+    }
+
+    // Similar to `boolean isQueryTypeValid` located in Util.java (APOC Core)
+    public static QueryExecutionType.QueryType isQueryValid(Result result, QueryExecutionType.QueryType... supportedQueryTypes) {
+        QueryExecutionType.QueryType type = result.getQueryExecutionType().queryType();
+        if (supportedQueryTypes != null && supportedQueryTypes.length != 0 && Stream.of(supportedQueryTypes).noneMatch(sqt -> sqt.equals(type))) {
+            return type;
+        }
+        return null;
+    }
+
+    // TODO - transform analogous Util.procsAreValid, located in Core, to a public method
+    public static boolean procsAreValid(GraphDatabaseService db, Set<Mode> supportedModes, Result result) {
+        if (supportedModes != null && !supportedModes.isEmpty()) {
+            final ExecutionPlanDescription executionPlanDescription = result.getExecutionPlanDescription();
+            // get procedures used in the query
+            Set<String> queryProcNames = new HashSet<>();
+            getAllQueryProcs(executionPlanDescription, queryProcNames);
+
+            if (!queryProcNames.isEmpty()) {
+                final Set<String> modes = supportedModes.stream().map(Mode::name).collect(Collectors.toSet());
+                // check if sub-procedures have valid mode
+                final Set<String> procNames = db.executeTransactionally("SHOW PROCEDURES YIELD name, mode where mode in $modes return name",
+                        Map.of("modes", modes),
+                        r -> Iterators.asSet(r.columnAs("name")));
+
+                return procNames.containsAll(queryProcNames);
+            }
+        }
+
+        return true;
     }
 }

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -7,11 +7,9 @@ import static apoc.util.Util.getAllQueryProcs;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -58,29 +56,18 @@ public class ExtendedUtil
         return "{" + formatToString(builder) + "}";
     }
 
-    public static void validateResult(GraphDatabaseService db, Set<Mode> supportedModes, Result result, QueryExecutionType.QueryType... supportedQueryTypes) {
-        final boolean isQueryTypeValid = supportedQueryTypes == null || supportedQueryTypes.length == 0 || Stream.of(supportedQueryTypes)
-                .anyMatch(sqt -> sqt.equals(result.getQueryExecutionType().queryType()));
-
-        if (!isQueryTypeValid) {
-            throw new RuntimeException("Supported query types for the operation are " + Arrays.toString(supportedQueryTypes));
-        }
-
-        if (!procsAreValid(db, supportedModes, result)) {
-            throw new RuntimeException("Supported inner procedure modes for the operation are " + new TreeSet<>(supportedModes));
-        }
-    }
-
     // Similar to `boolean isQueryTypeValid` located in Util.java (APOC Core)
     public static QueryExecutionType.QueryType isQueryValid(Result result, QueryExecutionType.QueryType... supportedQueryTypes) {
         QueryExecutionType.QueryType type = result.getQueryExecutionType().queryType();
+        // if everything is ok return null, otherwise the current getQueryExecutionType().queryType()
         if (supportedQueryTypes != null && supportedQueryTypes.length != 0 && Stream.of(supportedQueryTypes).noneMatch(sqt -> sqt.equals(type))) {
             return type;
         }
         return null;
     }
 
-    // TODO - transform analogous Util.procsAreValid, located in Core, to a public method
+    // TODO - before submitting the pr,
+    //  transform analogous Util.procsAreValid, located in Core, to a public method and remove this one
     public static boolean procsAreValid(GraphDatabaseService db, Set<Mode> supportedModes, Result result) {
         if (supportedModes != null && !supportedModes.isEmpty()) {
             final ExecutionPlanDescription executionPlanDescription = result.getExecutionPlanDescription();

--- a/extended/src/test/java/apoc/CoreExtendedTest.java
+++ b/extended/src/test/java/apoc/CoreExtendedTest.java
@@ -2,6 +2,7 @@ package apoc;
 
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 import apoc.util.TestContainerUtil.ApocPackage;
 import org.neo4j.driver.Record;
@@ -24,6 +25,7 @@ import static org.junit.Assert.fail;
  into a Neo4j instance without any startup issue.
  If you don't have docker installed it will fail, and you can simply ignore it.
  */
+@Ignore("Remove the ignore in neo4j-contrib PR")
 public class CoreExtendedTest {
     @Test
     public void checkForCoreAndExtended() {

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -5,6 +5,7 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import org.apache.commons.io.FileUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
@@ -28,6 +29,7 @@ import static org.junit.Assert.fail;
 /*
  This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
  */
+@Ignore("Remove the ignore in neo4j-contrib PR")
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";
     private static final List<String> EXPECTED_EXTENDED_NAMES;

--- a/extended/src/test/java/apoc/VersionUpdateChecksTest.java
+++ b/extended/src/test/java/apoc/VersionUpdateChecksTest.java
@@ -1,0 +1,44 @@
+package apoc;
+
+import org.junit.Test;
+import org.neo4j.procedure.Mode;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType;
+
+public class VersionUpdateChecksTest {
+
+    /**
+     * If any new org.neo4j.procedure.Mode or org.neo4j.graphdb.QueryExecutionType are added, this test will fail.
+     * Add the new stuff to the tests as well
+     * and update validateProcedure in {@link apoc.custom.CypherProcedures} to work with them.
+     */
+    @Test
+    public void testAPOCisAwareOfAllModes() {
+        List<Mode> expected = List.of(
+                Mode.READ,
+                Mode.WRITE,
+                Mode.SCHEMA,
+                Mode.DBMS,
+                Mode.DEFAULT
+        );
+        List<Mode> actual = Arrays.asList(Mode.values());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testAPOCisAwareOfAllQueryExecutionTypes() {
+        List<QueryType> expected = List.of(
+                QueryType.READ_ONLY,
+                QueryType.READ_WRITE,
+                QueryType.WRITE,
+                QueryType.SCHEMA_WRITE,
+                QueryType.DBMS
+        );
+        List<QueryType> actual = Arrays.asList(QueryType.values());
+        assertEquals(expected, actual);
+    }
+}

--- a/extended/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -3,6 +3,7 @@ package apoc.custom;
 import apoc.ExtendedSystemLabels;
 import apoc.RegisterComponentFactory;
 import apoc.SystemPropertyKeys;
+import apoc.schema.Schemas;
 import apoc.util.StatusCodeMatcher;
 import apoc.util.TestUtil;
 import apoc.util.collection.Iterators;
@@ -17,6 +18,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.procedure.Mode;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -30,9 +32,11 @@ import static apoc.custom.CypherProceduresHandler.FUNCTION;
 import static apoc.custom.CypherProceduresHandler.PROCEDURE;
 import static apoc.custom.Signatures.SIGNATURE_SYNTAX_ERROR;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testCallCount;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -52,7 +56,7 @@ public class CypherProceduresTest  {
 
     @Before
     public void setup() {
-        TestUtil.registerProcedure(db, CypherProcedures.class);
+        TestUtil.registerProcedure(db, CypherProcedures.class, Schemas.class);
     }
 
     @AfterAll
@@ -602,7 +606,6 @@ public class CypherProceduresTest  {
                 .collect(Collectors.toList()));
         assertFalse(functions.isEmpty());
 
-
         String procedureVoid = "CALL apoc.custom.declareProcedure(\n" +
                 "  'setTxMetadata(meta :: MAP) :: VOID',\n" +
                 "  '\n" +
@@ -616,15 +619,236 @@ public class CypherProceduresTest  {
                 "meta", Map.of("foo", "bar")
         ));
     }
-    
+
+    @Test
+    public void testValidateIssue3072() {
+        String procedure = "CALL apoc.custom.declareProcedure($signature, $statement, $mode)";
+
+        // even if `apoc.schema.assert` do schema operations, the `EXPLAIN <query>` sees the  query as a `READ_WRITE`,
+        // as is a procedure with mode SCHEMA, not a cypher query like `CREATE INDEX ....`.
+        // So, by passing either `write` or `schema` as a `mode` parameter, the custom procedure works correctly.
+        String statement = "CALL apoc.schema.assert({Foo:['bar']}, null) yield label, key, keys, unique, action " +
+                           "RETURN 0 as response";
+
+        db.executeTransactionally(procedure, Map.of("signature", "testOne() :: (response::INT)",
+                "statement", statement,
+                "mode", Mode.SCHEMA.name())
+        );
+        db.executeTransactionally("CALL custom.testOne");
+        testCallCount(db, "SHOW INDEX YIELD labelsOrTypes, properties WHERE properties = ['bar'] AND labelsOrTypes = ['Foo']",
+                1);
+
+        // failing modes
+
+        String expectedMessageWrite = "One or more inner procedure modes have operation different from the mode parameter: WRITE";
+        assertProcedureFails(expectedMessageWrite, procedure,
+                Map.of("signature", "testFoo() :: (response::INT)",
+                        "statement", statement,
+                        "mode", Mode.WRITE.name())
+        );
+
+        String expectedMessageRead = "One or more inner procedure modes have operation different from the mode parameter: READ";
+        assertProcedureFails(expectedMessageRead, procedure, Map.of("signature", "testTwo() :: (response::INT)",
+                "statement", statement,
+                "mode", Mode.READ.name())
+        );
+
+
+        String expectedMessage24 = "One or more inner procedure modes have operation different from the mode parameter: DBMS";;
+        assertProcedureFails(expectedMessage24, procedure, Map.of("signature", "testFour() :: (response::INT)",
+                "statement", statement,
+                "mode", Mode.DBMS.name()));
+    }
+
+    @Test
+    public void testValidateCreateQueryWithReturn() {
+        String procedure = "CALL apoc.custom.declareProcedure($signature, $statement, $mode)";
+        String statement = "CREATE (n:Something {id: 1}) RETURN n.id AS id";
+
+        db.executeTransactionally(procedure, Map.of("signature", "testOne() :: (id::INT)",
+                "statement", statement,
+                "mode", Mode.SCHEMA.name())
+        );
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testThree() :: (id::INT)",
+                        "statement", statement,
+                        "mode", Mode.WRITE.name())
+        );
+
+        // failing modes
+
+        String expectedMessageRead = """
+                The query execution type of the statement is: `READ_WRITE`, but you provided as a parameter mode: `READ`.
+                You have to declare a `mode` which corresponds to one of the following query execution type.
+                """;
+        assertProcedureFails(expectedMessageRead, procedure, Map.of("signature", "testTwo() :: (id::INT)",
+                "statement", statement,
+                "mode", Mode.READ.name())
+        );
+
+        String expectedMessageDbms = """
+                The query execution type of the statement is: `READ_WRITE`, but you provided as a parameter mode: `DBMS`.
+                You have to declare a `mode` which corresponds to one of the following query execution type.
+                """;
+        assertProcedureFails(expectedMessageDbms, procedure, Map.of("signature", "testFour() :: (id::INT)",
+                "statement", statement,
+                "mode", Mode.DBMS.name()));
+    }
+
+    @Test
+    public void testValidateCreateQueryWithNoReturn() {
+        String procedure = "CALL apoc.custom.declareProcedure($signature, $statement, $mode)";
+        String statement = "CREATE (n:Something {id: 1})";
+
+        db.executeTransactionally(procedure, Map.of("signature", "testOne() :: VOID",
+                "statement", statement,
+                "mode", Mode.SCHEMA.name())
+        );
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testThree() :: VOID",
+                        "statement", statement,
+                        "mode", Mode.WRITE.name())
+        );
+
+        // failing modes
+
+        String expectedMessageRead = """
+                The query execution type of the statement is: `WRITE`, but you provided as a parameter mode: `READ`.
+                You have to declare a `mode` which corresponds to one of the following query execution type.
+                """;
+        assertProcedureFails(expectedMessageRead, procedure, Map.of("signature", "testTwo() :: VOID",
+                "statement", statement,
+                "mode", Mode.READ.name())
+        );
+
+
+        String expectedMessageDbms = """
+                The query execution type of the statement is: `WRITE`, but you provided as a parameter mode: `DBMS`.
+                You have to declare a `mode` which corresponds to one of the following query execution type.
+                """;
+        assertProcedureFails(expectedMessageDbms, procedure, Map.of("signature", "testFour() :: VOID",
+                "statement", statement,
+                "mode", Mode.DBMS.name()));
+    }
+
+    @Test
+    public void testValidateReadOperation() {
+        String procedure = "CALL apoc.custom.declareProcedure($signature, $statement, $mode)";
+        String statement = "RETURN 1 as response";
+
+        db.executeTransactionally(procedure, Map.of("signature", "testOne() :: (response::INT)",
+                "statement", statement,
+                "mode", Mode.SCHEMA.name())
+        );
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testTwo() :: (response::INT)",
+                "statement", statement,
+                "mode", Mode.READ.name())
+        );
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testThree() :: (response::INT)",
+                        "statement", statement,
+                        "mode", Mode.WRITE.name())
+        );
+
+        // failing modes
+
+        String expectedMessageDbms = """
+                The query execution type of the statement is: `READ_ONLY`, but you provided as a parameter mode: `DBMS`.
+                """;
+        assertProcedureFails(expectedMessageDbms, procedure,
+                Map.of("signature", "testFour() :: (response::INT)",
+                "statement", statement,
+                "mode", Mode.DBMS.name()));
+    }
+
+    @Test
+    public void testValidateDbmsOperation() {
+        String procedure = "CALL apoc.custom.declareProcedure($signature, $statement, $mode)";
+        String statement = "CALL dbms.listConfig() YIELD name";
+
+        db.executeTransactionally(procedure, Map.of("signature", "testFour() :: (name::STRING)",
+                "statement", statement,
+                "mode", Mode.DBMS.name()));
+        testCall(db, "CALL custom.testFour() YIELD name RETURN name LIMIT 1", r -> {
+            assertNotNull(r.get("name"));
+        });
+
+        // failing modes
+
+        String expectedMessageSchema = "One or more inner procedure modes have operation different from the mode parameter: SCHEMA";
+        assertProcedureFails(expectedMessageSchema, procedure, Map.of("signature", "testOne() :: (name::STRING)",
+                "statement", statement,
+                "mode", Mode.SCHEMA.name())
+        );
+
+        String expectedMessageRead = "One or more inner procedure modes have operation different from the mode parameter: READ";
+        assertProcedureFails(expectedMessageRead, procedure, Map.of("signature", "testTwo() :: (name::STRING)",
+                "statement", statement,
+                "mode", Mode.READ.name())
+        );
+
+        String expectedMessageWrite = "One or more inner procedure modes have operation different from the mode parameter: WRITE";
+        assertProcedureFails(expectedMessageWrite, procedure,
+                Map.of("signature", "testThree() :: (name::STRING)",
+                        "statement", statement,
+                        "mode", Mode.WRITE.name())
+        );
+    }
+
+    @Test
+    public void testValidationSchemaOperation() {
+        String procedure = "CALL apoc.custom.declareProcedure($signature, $statement, $mode)";
+        String statement = "CREATE INDEX IF NOT EXISTS FOR (n:LabelName) ON n.propertyName";
+
+        db.executeTransactionally(procedure, Map.of("signature", "testOne() :: VOID",
+                "statement", statement,
+                "mode", Mode.SCHEMA.name())
+        );
+
+        // failing modes
+
+        String expectedMessageRead = """
+                The query execution type of the statement is: `SCHEMA_WRITE`, but you provided as a parameter mode: `READ`.
+                """;
+        assertProcedureFails(expectedMessageRead, procedure, Map.of("signature", "testTwo() :: VOID",
+                "statement", statement,
+                "mode", Mode.READ.name())
+        );
+
+        String expectedMessageWrite = """
+                The query execution type of the statement is: `SCHEMA_WRITE`, but you provided as a parameter mode: `WRITE`.
+                """;
+        assertProcedureFails(expectedMessageWrite, procedure,
+                Map.of("signature", "testThree() :: VOID",
+                        "statement", statement,
+                        "mode", Mode.WRITE.name())
+        );
+
+        String expectedMessageDbms = """
+                The query execution type of the statement is: `SCHEMA_WRITE`, but you provided as a parameter mode: `DBMS`.
+                """;
+        assertProcedureFails(expectedMessageDbms, procedure, Map.of("signature", "testFour() :: VOID",
+                "statement", statement,
+                "mode", Mode.DBMS.name()));
+    }
 
     private void assertProcedureFails(String expectedMessage, String query) {
+        assertProcedureFails(expectedMessage, query, Map.of());
+    }
+
+    private void assertProcedureFails(String expectedMessage, String query, Map<String, Object> params) {
         try {
-            testCall(db, query, row -> fail("The test should fail because of: " + expectedMessage));
+            testCall(db, query, params, row -> fail("The test should fail because of: " + expectedMessage));
         } catch (QueryExecutionException e) {
             Throwable except = ExceptionUtils.getRootCause(e);
             assertTrue(except instanceof RuntimeException);
-            assertTrue(except.getMessage().contains(expectedMessage));
+            String message = except.getMessage();
+            assertTrue("Actual err. message is: " + message, message.contains(expectedMessage));
         }
     }
 }

--- a/extended/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -3,6 +3,7 @@ package apoc.custom;
 import apoc.ExtendedSystemLabels;
 import apoc.RegisterComponentFactory;
 import apoc.SystemPropertyKeys;
+import apoc.cypher.Cypher;
 import apoc.schema.Schemas;
 import apoc.util.StatusCodeMatcher;
 import apoc.util.TestUtil;
@@ -56,7 +57,7 @@ public class CypherProceduresTest  {
 
     @Before
     public void setup() {
-        TestUtil.registerProcedure(db, CypherProcedures.class, Schemas.class);
+        TestUtil.registerProcedure(db, CypherProcedures.class, Schemas.class, Cypher.class);
     }
 
     @AfterAll
@@ -755,15 +756,40 @@ public class CypherProceduresTest  {
                         "mode", Mode.WRITE.name())
         );
 
-        // failing modes
-
-        String expectedMessageDbms = """
-                The query execution type of the statement is: `READ_ONLY`, but you provided as a parameter mode: `DBMS`.
-                """;
-        assertProcedureFails(expectedMessageDbms, procedure,
+        db.executeTransactionally(procedure,
                 Map.of("signature", "testFour() :: (response::INT)",
                 "statement", statement,
                 "mode", Mode.DBMS.name()));
+    }
+
+    @Test
+    public void testValidateReadProcedure() {
+        String procedure = "CALL apoc.custom.declareProcedure($signature, $statement, $mode)";
+        String statement = "CALL apoc.when(true, 'return 1', 'return 2') yield value return value";
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testOne() :: (value::ANY)",
+                "statement", statement,
+                "mode", Mode.SCHEMA.name())
+        );
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testTwo() :: (value::ANY)",
+                        "statement", statement,
+                        "mode", Mode.READ.name())
+        );
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testThree() :: (value::ANY)",
+                        "statement", statement,
+                        "mode", Mode.WRITE.name())
+        );
+
+        db.executeTransactionally(procedure,
+                Map.of("signature", "testFour() :: (value::ANY)",
+                        "statement", statement,
+                        "mode", Mode.DBMS.name())
+        );
     }
 
     @Test
@@ -836,6 +862,7 @@ public class CypherProceduresTest  {
                 "statement", statement,
                 "mode", Mode.DBMS.name()));
     }
+
 
     private void assertProcedureFails(String expectedMessage, String query) {
         assertProcedureFails(expectedMessage, query, Map.of());


### PR DESCRIPTION
Improved validation by using a mechanism similar to Util.validateQuery

- VersionUpdateChecksTest to check eventual new types during the updates

- TODO: increase test coverage - add validation test for custom functions as well