### PR TITLE
Fixes 2612: Added MAPRESULT type to custom functions

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
@@ -35,7 +35,7 @@ The `typeParam` and `typeResult` in the signature parameter can be one of the fo
 * DATE, DATETIME, LOCALDATETIME, TIME, LOCALTIME, DURATION
 * NODE, REL, RELATIONSHIP, EDGE, PATH
 * MAP
-* MAPRESULT (valid for declareFunctions, does not wrap the result in a further map. see here: <<map-vs-map-result>>)
+* MAPRESULT (valid for declareFunction, does not wrap the result in a further map. see here: <<map-vs-map-result>>)
 * LIST TYPE, LIST OF TYPE (where `TYPE` can be one of the previous values)
 * ANY
 

--- a/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
@@ -35,6 +35,7 @@ The `typeParam` and `typeResult` in the signature parameter can be one of the fo
 * DATE, DATETIME, LOCALDATETIME, TIME, LOCALTIME, DURATION
 * NODE, REL, RELATIONSHIP, EDGE, PATH
 * MAP
+* MAPRESULT (valid for declareFunctions, does not wrap the result in a further map. see here: <<map-vs-map-result>>)
 * LIST TYPE, LIST OF TYPE (where `TYPE` can be one of the previous values)
 * ANY
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.custom.declareFunction.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.custom.declareFunction.adoc
@@ -25,20 +25,78 @@ Or you can also write in this way:
 CALL apoc.custom.declareFunction('answerFunMap() :: MAP', 'RETURN 42 as answer')
 ----
 
-In this case the result is wrapped in a stream of maps called `row`. Therefore, you can do:
+In this case the result is wrapped in a map of key `answer` and value `42`. 
+Therefore, you can do:
 
 [source,cypher]
 ----
-WITH custom.answerFunMap() YIELD row
-RETURN row.answer
+RETURN custom.answerFunMap() AS row
 ----
 
 .Results
 [opts="header"]
 |===
-| answer
-| 42
+| row
+| { "answer": 42 }
 |===
+
+[[map-vs-map-result]]
+In case you return a map, you can choose to wrap the result in another map with key the name of the result, and value the value obtained.
+For example, declaring this function:
+
+[source,cypher]
+----
+CALL apoc.custom.declareFunction('answerFunMap(value:: INT) :: MAPRESULT', 'RETURN {a: $value}')
+----
+
+you can execute:
+
+[source,cypher]
+----
+return custom.answerFunMap(2) as row
+----
+
+.Results
+[opts="header"]
+|===
+| row
+a|
+[source,json]
+----
+{
+    "{a: $value}": 
+    {"a": 2}
+  }
+----
+|===
+
+Note that the `{"a": 2}` is wrapped by a map with key `{a: $value}"`, 
+that is the column name which would be returned from the `RETURN {a: $value}`
+
+Instead, using `MAPRESULT`:
+[source,cypher]
+----
+CALL apoc.custom.declareFunction('answerFunMapResult(value:: INT) :: MAPRESULT', 'RETURN $value')
+----
+
+you can execute:
+[source,cypher]
+----
+RETURN custom.answerFunMapResult(2) AS row
+----
+
+.Results
+[opts="header"]
+|===
+| row
+a|
+[source,json]
+----
+{"a": 2}
+----
+|===
+
+
 
 We can create the function `custom.powers` that returns a stream of the powers of the first parameter, up to and including the power provided by the second parameter:
 

--- a/extended/src/main/antlr/apoc/custom/Signature.g4
+++ b/extended/src/main/antlr/apoc/custom/Signature.g4
@@ -13,7 +13,7 @@ defaultValue: value;
 
 list_type:	'LIST''?'?' OF '+opt_type ;
 opt_type:	base_type'?'? ;
-base_type:	'MAP' | 'ANY' | 'NODE' | 'REL' | 'RELATIONSHIP' | 'EDGE' | 'PATH' | 'NUMBER' | 'INTEGER | FLOAT' | 'LONG' | 'INT' | 'INTEGER' | 'FLOAT' | 'DOUBLE' | 'BOOL' | 'BOOLEAN' | 'DATE' | 'TIME' | 'LOCALTIME' | 'DATETIME' | 'LOCALDATETIME' | 'DURATION' | 'POINT' | 'GEO' | 'GEOMETRY' | 'STRING' | 'TEXT' ;
+base_type:	'MAP' | 'MAPRESULT' | 'ANY' | 'NODE' | 'REL' | 'RELATIONSHIP' | 'EDGE' | 'PATH' | 'NUMBER' | 'INTEGER | FLOAT' | 'LONG' | 'INT' | 'INTEGER' | 'FLOAT' | 'DOUBLE' | 'BOOL' | 'BOOLEAN' | 'DATE' | 'TIME' | 'LOCALTIME' | 'DATETIME' | 'LOCALDATETIME' | 'DURATION' | 'POINT' | 'GEO' | 'GEOMETRY' | 'STRING' | 'TEXT' ;
 NEWLINE:	[\r\n]+ ;
 QUOTED_IDENTIFIER:	'`' [^`]+? '`' ;
 IDENTIFIER:	[a-zA-Z_][a-zA-Z0-9_]+ ;

--- a/extended/src/main/java/apoc/ExtendedSystemPropertyKeys.java
+++ b/extended/src/main/java/apoc/ExtendedSystemPropertyKeys.java
@@ -10,6 +10,7 @@ public enum ExtendedSystemPropertyKeys
     output,
     forceSingle,
     prefix,
+    mapResult,
 
     // triggers
     selector,

--- a/extended/src/main/java/apoc/custom/CypherProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherProcedures.java
@@ -73,10 +73,13 @@ public class CypherProcedures {
     public void declareFunction(@Name("signature") String signature, @Name("statement") String statement,
                            @Name(value = "forceSingle", defaultValue = "false") boolean forceSingle,
                            @Name(value = "description", defaultValue = "") String description) throws ProcedureException {
-        UserFunctionSignature userFunctionSignature = new Signatures(PREFIX).asFunctionSignature(signature, description);
+        final Signatures signatures = new Signatures(PREFIX);
+        final SignatureParser.FunctionContext functionContext = signatures.parseFunction(signature);
+        UserFunctionSignature userFunctionSignature = signatures.toFunctionSignature(functionContext, description);
         validateFunction(statement, userFunctionSignature.inputSignature());
+        final boolean mapResult = signatures.isMapResult(functionContext);
 
-        cypherProceduresHandler.storeFunction(userFunctionSignature, statement, forceSingle);
+        cypherProceduresHandler.storeFunction(userFunctionSignature, statement, forceSingle, mapResult);
     }
 
 

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -224,7 +224,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
         // de-register removed procs/functions
         currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));
-        currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false, false));
+        currentUserFunctionsToRemove.forEach(this::registerFunction);
 
         api.executeTransactionally("call db.clearQueryCaches()");
     }
@@ -377,6 +377,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
+    public boolean registerFunction(UserFunctionSignature signature) {
+        return registerFunction(signature, null, false, false);
+    }
+
     public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle, boolean mapResult) {
         try {
             QualifiedName name = signature.name();
@@ -441,8 +445,9 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     /**
      * We wrap the result only if we have a "true" map,
-     * so neither NodeType or RelationshipType that extends MapType,
-     * and the output signature is not a `MAPRESULT` / `LIST OF MAPRESULT` output
+     * that is: the output signature is not a `MAP` / `LIST OF MAP` 
+     *  and the outputType is exactly equals to MapType 
+     *  (neither with NodeType nor with RelationshipType wrap the result, even though they extend MapType)
      */
     private boolean isWrapped(AnyType outType, boolean mapResult) {
         return !mapResult && outType.getClass().equals(Neo4jTypes.MapType.class);
@@ -668,7 +673,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     ExtendedSystemPropertyKeys.prefix.name(), qName.namespace()
             ).stream().filter(n -> n.hasLabel(ExtendedSystemLabels.Function)).forEach(node -> {
                 UserFunctionDescriptor descriptor = userFunctionDescriptor(node);
-                registerFunction(descriptor.getSignature(), null, false, false);
+                registerFunction(descriptor.getSignature());
                 node.delete();
                 setLastUpdate(tx);
             });

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -191,6 +191,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         List<FieldSignature> inputs = deserializeSignatures(property);
 
         boolean forceSingle = (boolean) node.getProperty(ExtendedSystemPropertyKeys.forceSingle.name(), false);
+        boolean mapResult = (boolean) node.getProperty(ExtendedSystemPropertyKeys.mapResult.name(), false);
         return new UserFunctionDescriptor(new UserFunctionSignature(
                 new QualifiedName(prefix, name),
                 inputs,
@@ -202,7 +203,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 false,
                 false,
                 false
-        ), statement, forceSingle);
+        ), statement, forceSingle, mapResult);
     }
 
     public void restoreProceduresAndFunctions() {
@@ -223,7 +224,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
         // de-register removed procs/functions
         currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));
-        currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false));
+        currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false, false));
 
         api.executeTransactionally("call db.clearQueryCaches()");
     }
@@ -236,7 +237,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
-    public void storeFunction(UserFunctionSignature signature, String statement, boolean forceSingle) {
+    public void storeFunction(UserFunctionSignature signature, String statement, boolean forceSingle, boolean mapResult) {
         withSystemDb(tx -> {
             Node node = Util.mergeNode(tx, ExtendedSystemLabels.ApocCypherProcedures, ExtendedSystemLabels.Function,
                     Pair.of(SystemPropertyKeys.database.name(), api.databaseName()),
@@ -250,7 +251,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(ExtendedSystemPropertyKeys.forceSingle.name(), forceSingle);
 
             setLastUpdate(tx);
-            if (!registerFunction(signature, statement, forceSingle)) {
+            if (!registerFunction(signature, statement, forceSingle, mapResult)) {
                 throw new IllegalStateException("Error registering function " + signature + ", see log.");
             }
             return null;
@@ -375,7 +376,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
-    public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle/*, boolean override*/) {
+    public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle, boolean mapResult) {
         try {
             QualifiedName name = signature.name();
             boolean exists = globalProceduresRegistry.getCurrentView().getAllNonAggregatingFunctions()
@@ -407,16 +408,16 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                             if (cols.isEmpty()) return null;
                             if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
                                 Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
-                                Neo4jTypes.AnyType innerType = listType.innerType();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (innerType.getClass().equals(Neo4jTypes.MapType.class))
+                                AnyType innerType = listType.innerType();
+                                if (isWrapped(innerType, mapResult))
                                     return ValueUtils.of(result.stream().collect(Collectors.toList()));
                                 if (cols.size() == 1)
                                     return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
                             } else {
                                 Map<String, Object> row = result.next();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
+                                if (isWrapped(outType, mapResult)) {
+                                    return ValueUtils.of(row);
+                                }
                                 if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
                             }
                             throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);
@@ -435,6 +436,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             log.error("Could not register function: " + signature + "\nwith: " + statement + "\n single result " + forceSingle, e);
             return false;
         }
+    }
+
+    private boolean isWrapped(AnyType outType, boolean mapResult) {
+        // We wrap the result only if we have a "true" map,
+        // so neither NodeType or RelationshipType that extends MapType,
+        // and the output signature is not a `MAPRESULT` / `LIST OF MAPRESULT` output
+        return !mapResult && outType.getClass().equals(Neo4jTypes.MapType.class);
     }
 
     public static QualifiedName qualifiedName(@Name("name") String name) {
@@ -657,7 +665,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     ExtendedSystemPropertyKeys.prefix.name(), qName.namespace()
             ).stream().filter(n -> n.hasLabel(ExtendedSystemLabels.Function)).forEach(node -> {
                 UserFunctionDescriptor descriptor = userFunctionDescriptor(node);
-                registerFunction(descriptor.getSignature(), null, false);
+                registerFunction(descriptor.getSignature(), null, false, false);
                 node.delete();
                 setLastUpdate(tx);
             });
@@ -701,11 +709,13 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     public class UserFunctionDescriptor extends ProcedureOrFunctionDescriptor {
         private final UserFunctionSignature signature;
         private final boolean forceSingle;
+        private final boolean mapResult;
 
-        public UserFunctionDescriptor(UserFunctionSignature signature, String statement, boolean forceSingle) {
+        public UserFunctionDescriptor(UserFunctionSignature signature, String statement, boolean forceSingle, boolean mapResult) {
             super(statement);
             this.signature = signature;
             this.forceSingle = forceSingle;
+            this.mapResult = mapResult;
         }
 
         public UserFunctionSignature getSignature() {
@@ -718,7 +728,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
         @Override
         public void register() {
-            registerFunction(getSignature(), getStatement(), isForceSingle());
+            registerFunction(getSignature(), getStatement(), isForceSingle(), mapResult);
         }
     }
 }

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -249,6 +249,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(ExtendedSystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));
             node.setProperty(ExtendedSystemPropertyKeys.output.name(), signature.outputType().toString());
             node.setProperty(ExtendedSystemPropertyKeys.forceSingle.name(), forceSingle);
+            node.setProperty(ExtendedSystemPropertyKeys.mapResult.name(), mapResult);
 
             setLastUpdate(tx);
             if (!registerFunction(signature, statement, forceSingle, mapResult)) {
@@ -438,10 +439,12 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         }
     }
 
+    /**
+     * We wrap the result only if we have a "true" map,
+     * so neither NodeType or RelationshipType that extends MapType,
+     * and the output signature is not a `MAPRESULT` / `LIST OF MAPRESULT` output
+     */
     private boolean isWrapped(AnyType outType, boolean mapResult) {
-        // We wrap the result only if we have a "true" map,
-        // so neither NodeType or RelationshipType that extends MapType,
-        // and the output signature is not a `MAPRESULT` / `LIST OF MAPRESULT` output
         return !mapResult && outType.getClass().equals(Neo4jTypes.MapType.class);
     }
 

--- a/extended/src/main/java/apoc/custom/Signatures.java
+++ b/extended/src/main/java/apoc/custom/Signatures.java
@@ -18,6 +18,7 @@ public class Signatures {
     public static final String NUMBER_TYPE = "INTEGER | FLOAT";
     public static final String SIGNATURE_SYNTAX_ERROR = "Syntax error(s) in signature definition %s. " +
             "\nNote that procedure/function name, possible map keys, input and output names must have at least 2 character:\n";
+    private static final String MAP_RESULT_TYPE = "MAPRESULT";
     private final String prefix;
 
     public Signatures(String prefix) {
@@ -189,11 +190,17 @@ public class Signatures {
         return Neo4jTypes.NTAny;
     }
 
+    public boolean isMapResult(SignatureParser.FunctionContext functionContext) {
+        final SignatureParser.TypeContext outputType = functionContext.type();
+        return outputType.getText().contains(MAP_RESULT_TYPE);
+    }
+
     private Neo4jTypes.AnyType type(SignatureParser.Opt_typeContext opt_type) {
         switch (opt_type.base_type().getText()) {
             case "ANY":
                 return NTAny;
             case "MAP":
+            case MAP_RESULT_TYPE:
                 return NTMap;
             case "NODE":
                 return NTNode;
@@ -251,11 +258,6 @@ public class Signatures {
             default:
                 return NTString;
         }
-    }
-
-    public UserFunctionSignature asFunctionSignature(String signature, String description) {
-        SignatureParser.FunctionContext functionContext = parseFunction(signature);
-        return toFunctionSignature(functionContext, description);
     }
 
     public ProcedureSignature asProcedureSignature(String signature, String description, Mode mode) {

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static apoc.custom.CypherProceduresHandler.CUSTOM_PROCEDURES_REFRESH;
 import static apoc.util.DbmsTestUtil.startDbWithApocConfigs;
@@ -597,5 +598,79 @@ public class CypherProceduresStorageTest {
         db.executeTransactionally("CALL apoc.custom.declareFunction('nn(val::INTEGER) :: NODE', 'MATCH (t:Target {value : $val}) RETURN t')");
         restartDb();
         TestUtil.testCall(db, "RETURN custom.nn(2) as row", (row) -> assertEquals(2L, ((Node) row.get("row")).getProperty("value")));
+    }
+
+    @Test
+    public void functionSignatureShouldNotChangeBeforeAndAfterRestartAndOverwriteMap() {
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map(val :: INTEGER) :: MAP ', 'RETURN {value : $val} as value')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_list(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result(val :: INTEGER) :: MAPRESULT ', 'RETURN {value : $val} as value')");
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result_list(val :: INTEGER) :: LIST OF MAPRESULT ', 'RETURN [{value : $val}] as value')");
+
+        functionMapAssertions();
+
+        restartDb();
+        functionMapAssertions();
+    }
+
+    // TODO
+    // TODO
+    // TODO
+    // TODO
+    // TODO
+    // TODO -- DOCUMENTAZIONE
+    // TODO
+    // TODO
+    // TODO
+    // TODO
+
+
+    private void functionMapAssertions() {
+        // check that both `MAP` and `MAPRESULT` have signature `MAP?` when it runs `SHOW FUNCTIONS` command
+        TestUtil.testResult(db, "SHOW FUNCTIONS YIELD signature, name WHERE name STARTS WITH 'custom.map' RETURN DISTINCT name, signature ORDER BY name",
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEquals("custom.map(val :: INTEGER?) :: (MAP?)", row.get("signature"));
+                    row = r.next();
+                    assertEquals("custom.map_list(val :: INTEGER?) :: (LIST? OF MAP?)", row.get("signature"));
+                    row = r.next();
+                    assertEquals("custom.map_result(val :: INTEGER?) :: (MAP?)", row.get("signature"));
+                    row = r.next();
+                    assertEquals("custom.map_result_list(val :: INTEGER?) :: (LIST? OF MAP?)", row.get("signature"));
+                    assertFalse(r.hasNext());
+                });
+
+        TestUtil.testResult(db, "call apoc.custom.list",
+                row -> {
+                    final Set<String> sumFun1 = Set.of("map", "map_list", "map_result", "map_result_list");
+                    assertEquals(sumFun1, Iterators.asSet(row.columnAs("name")));
+                });
+
+        // then
+        TestUtil.testResult(db, "RETURN custom.map_result(3) AS val", (result) -> {
+            Map<String, Object> map = result.<Map<String, Object>>columnAs("val").next();
+            assertEquals(1, map.size());
+            assertEquals(3L, map.get("value"));
+        });
+        TestUtil.testResult(db, "RETURN custom.map_result_list(4) AS val", (result) -> {
+            List<List<Map<String, Object>>> list = result.<List<List<Map<String, Object>>>>columnAs("val").next();
+            assertEquals(1, list.size());
+            List<Map<String, Object>> map = list.get(0);
+            assertEquals(1, map.size());
+            assertEquals(4L, map.get(0).get("value"));
+        });
+
+        TestUtil.testResult(db, "RETURN custom.map(3) AS val", (result) -> {
+            Map<String, Map<String, Object>> map = result.<Map<String, Map<String, Object>>>columnAs("val").next();
+            assertEquals(1, map.size());
+            assertEquals(3L, map.get("value").get("value"));
+        });
+        TestUtil.testResult(db, "RETURN custom.map_list(4) AS val", (result) -> {
+            List<Map<String, List<Map<String, Object>>>> list = result.<List<Map<String, List<Map<String, Object>>>>>columnAs("val").next();
+            assertEquals(1, list.size());
+            assertEquals(1, list.get(0).size());
+            assertEquals(4L, list.get(0).get("value").get(0).get("value"));
+        });
+
     }
 }

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -646,33 +646,44 @@ public class CypherProceduresStorageTest {
         // then
         TestUtil.testResult(db, "RETURN custom.map_result(3) AS val", (result) -> {
             Map map = result.<Map>columnAs("val").next();
-            assertEquals(1, map.size());
-            
-            assertEquals(3L, map.get("value"));
+            assertIsMap(map);
         });
-        TestUtil.testResult(db, "RETURN custom.map_result_list(4) AS val", (result) -> {
-            List<List<Map>> list = result.<List<List<Map>>>columnAs("val").next();
-            assertEquals(1, list.size());
-            
-            List<Map> map = list.get(0);
-            assertEquals(1, map.size());
-            assertEquals(4L, map.get(0).get("value"));
-        });
-
+        
         TestUtil.testResult(db, "RETURN custom.map(3) AS val", (result) -> {
             Map<String, Map> map = result.<Map<String, Map>>columnAs("val").next();
             assertEquals(1, map.size());
-            
-            assertEquals(3L, map.get("row").get("value"));
+            Map innerMap = map.get("row");
+
+            assertIsMap(innerMap);
         });
-        TestUtil.testResult(db, "RETURN custom.map_list(4) AS val", (result) -> {
+        
+        TestUtil.testResult(db, "RETURN custom.map_result_list(3) AS val", (result) -> {
+            List<List<Map>> list = result.<List<List<Map>>>columnAs("val").next();
+            assertEquals(1, list.size());
+
+            List<Map> map = list.get(0);
+            assertIsListOfMap(map);
+        });
+
+        TestUtil.testResult(db, "RETURN custom.map_list(3) AS val", (result) -> {
             List<Map<String, List<Map>>> list = result.<List<Map<String, List<Map>>>>columnAs("val").next();
             assertEquals(1, list.size());
             assertEquals(1, list.get(0).size());
             
-            List<Map> rowResult = list.get(0).get("row");
-            assertEquals(4L, rowResult.get(0).get("value"));
+            List<Map> mapList = list.get(0).get("row");
+            assertIsListOfMap(mapList);
         });
 
+    }
+
+    private static void assertIsListOfMap(List<Map> mapList) {
+        assertEquals(1, mapList.size());
+        Map map = mapList.get(0);
+        assertIsMap(map);
+    }
+
+    private static void assertIsMap(Map map) {
+        Map<String, Object> expected = Map.of("value", 3L);
+        assertEquals(expected, map);
     }
 }

--- a/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -602,27 +602,24 @@ public class CypherProceduresStorageTest {
 
     @Test
     public void functionSignatureShouldNotChangeBeforeAndAfterRestartAndOverwriteMap() {
-        db.executeTransactionally("CALL apoc.custom.declareFunction('map(val :: INTEGER) :: MAP ', 'RETURN {value : $val} as value')");
-        db.executeTransactionally("CALL apoc.custom.declareFunction('map_list(val :: INTEGER) :: LIST OF MAP ', 'RETURN [{value : $val}] as value')");
-        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result(val :: INTEGER) :: MAPRESULT ', 'RETURN {value : $val} as value')");
-        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result_list(val :: INTEGER) :: LIST OF MAPRESULT ', 'RETURN [{value : $val}] as value')");
+        // given
+        String mapReturn = "RETURN {value : $val} as row";
+        String listMapReturn = "RETURN [{value : $val}] as row";
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map(val :: INTEGER) :: MAP ', $statement)",
+                Map.of("statement", mapReturn));
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_list(val :: INTEGER) :: LIST OF MAP ', $statement)",
+                Map.of("statement", listMapReturn));
+        
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result(val :: INTEGER) :: MAPRESULT ', $statement)",
+                Map.of("statement", mapReturn));
+        db.executeTransactionally("CALL apoc.custom.declareFunction('map_result_list(val :: INTEGER) :: LIST OF MAPRESULT ', $statement)",
+                Map.of("statement", listMapReturn));
 
         functionMapAssertions();
 
         restartDb();
         functionMapAssertions();
     }
-
-    // TODO
-    // TODO
-    // TODO
-    // TODO
-    // TODO
-    // TODO -- DOCUMENTAZIONE
-    // TODO
-    // TODO
-    // TODO
-    // TODO
 
 
     private void functionMapAssertions() {
@@ -648,28 +645,33 @@ public class CypherProceduresStorageTest {
 
         // then
         TestUtil.testResult(db, "RETURN custom.map_result(3) AS val", (result) -> {
-            Map<String, Object> map = result.<Map<String, Object>>columnAs("val").next();
+            Map map = result.<Map>columnAs("val").next();
             assertEquals(1, map.size());
+            
             assertEquals(3L, map.get("value"));
         });
         TestUtil.testResult(db, "RETURN custom.map_result_list(4) AS val", (result) -> {
-            List<List<Map<String, Object>>> list = result.<List<List<Map<String, Object>>>>columnAs("val").next();
+            List<List<Map>> list = result.<List<List<Map>>>columnAs("val").next();
             assertEquals(1, list.size());
-            List<Map<String, Object>> map = list.get(0);
+            
+            List<Map> map = list.get(0);
             assertEquals(1, map.size());
             assertEquals(4L, map.get(0).get("value"));
         });
 
         TestUtil.testResult(db, "RETURN custom.map(3) AS val", (result) -> {
-            Map<String, Map<String, Object>> map = result.<Map<String, Map<String, Object>>>columnAs("val").next();
+            Map<String, Map> map = result.<Map<String, Map>>columnAs("val").next();
             assertEquals(1, map.size());
-            assertEquals(3L, map.get("value").get("value"));
+            
+            assertEquals(3L, map.get("row").get("value"));
         });
         TestUtil.testResult(db, "RETURN custom.map_list(4) AS val", (result) -> {
-            List<Map<String, List<Map<String, Object>>>> list = result.<List<Map<String, List<Map<String, Object>>>>>columnAs("val").next();
+            List<Map<String, List<Map>>> list = result.<List<Map<String, List<Map>>>>columnAs("val").next();
             assertEquals(1, list.size());
             assertEquals(1, list.get(0).size());
-            assertEquals(4L, list.get(0).get("value").get(0).get("value"));
+            
+            List<Map> rowResult = list.get(0).get("row");
+            assertEquals(4L, rowResult.get(0).get("value"));
         });
 
     }


### PR DESCRIPTION
Follow-up of: `https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2704#issuecomment-1346354805`

- Fixes 2704:
  - added `MAPRESULT` type, similar to `MAP`, but that doesn't wrap the result

- Other changes:
  - Fixed wrong wording in `apoc.custom.declareFunction.adoc`
  - Fixed wrong formatting in `cypher-based-procedures-functions.adoc` (line 30)

