### PR TITLE
Issue 3751: mapParallel2 with rebind error

### DIFF
--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -174,7 +174,7 @@ public class CypherExtended {
                 if (isPeriodicOperation(stmt)) {
                     Util.inThread(pools , () -> {
                         try {
-                            return db.executeTransactionally(stmt, params, result -> consumeResult(result, queue, addStatistics, timeout));
+                            return db.executeTransactionally(stmt, params, result -> consumeResult(result, queue, addStatistics, tx));
                         } catch (Exception e) {
                             collectError(queue, reportError, e, fileName);
                             return null;
@@ -184,7 +184,7 @@ public class CypherExtended {
                 else {
                     Util.inTx(db, pools, threadTx -> {
                         try (Result result = threadTx.execute(stmt, params)) {
-                            return consumeResult(result, queue, addStatistics, timeout);
+                            return consumeResult(result, queue, addStatistics, tx);
                         } catch (Exception e) {
                             collectError(queue, reportError, e, fileName);
                             return null;
@@ -227,7 +227,7 @@ public class CypherExtended {
             if (schemaOperation) {
                 Util.inTx(db, pools, txInThread -> {
                     try (Result result = txInThread.execute(stmt, params)) {
-                        return consumeResult(result, queue, addStatistics, timeout);
+                        return consumeResult(result, queue, addStatistics, tx);
                     } catch (Exception e) {
                         collectError(queue, reportError, e, fileName);
                         return null;
@@ -239,13 +239,13 @@ public class CypherExtended {
 
     private final static Pattern shellControl = Pattern.compile("^:?\\b(begin|commit|rollback)\\b", Pattern.CASE_INSENSITIVE);
 
-    private Object consumeResult(Result result, BlockingQueue<RowResult> queue, boolean addStatistics, long timeout) {
+    private Object consumeResult(Result result, BlockingQueue<RowResult> queue, boolean addStatistics, Transaction transaction) {
         try {
             long time = System.currentTimeMillis();
             int row = 0;
             while (result.hasNext()) {
                 terminationGuard.check();
-                Map<String, Object> res = EntityUtil.anyRebind(tx, result.next());
+                Map<String, Object> res = EntityUtil.anyRebind(transaction, result.next());
                 queue.put(new RowResult(row++, res));
             }
             if (addStatistics) {
@@ -369,20 +369,19 @@ public class CypherExtended {
         final String statement = withParamsAndIterator(fragment, params.keySet(), "_");
         tx.execute("EXPLAIN " + statement).close();
         BlockingQueue<RowResult> queue = new ArrayBlockingQueue<>(100000);
-        List<List<Object>> parallelPartitions = Util.partitionSubList(data, (int)(partitions <= 0 ? PARTITIONS : partitions), null)
-                .toList();
+        Stream<List<Object>> parallelPartitions = Util.partitionSubList(data, (int)(partitions <= 0 ? PARTITIONS : partitions), null);
         Util.inFuture(pools, () -> {
-            parallelPartitions
-                    .forEach((List<Object> partition) -> {
-                        try (Transaction transaction = db.beginTx();
-                             Result result = transaction.execute(statement, parallelParams(params, "_", partition))) {
-                            consumeResult(result, queue, false, timeout);
-                        } catch (Exception e) {
-                            throw new RuntimeException(e);
-                        }}
-                    );
+            long total = parallelPartitions
+                .map((List<Object> partition) -> {
+                    try (Transaction transaction = db.beginTx();
+                         Result result = transaction.execute(statement, parallelParams(params, "_", partition))) {
+                        return consumeResult(result, queue, false, transaction);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }}
+                ).count();
             queue.put(RowResult.TOMBSTONE);
-            return null;
+            return total;
         });
         return StreamSupport.stream(new QueueBasedSpliterator<>(queue, RowResult.TOMBSTONE, terminationGuard, (int)timeout),true).map((rowResult) -> new MapResult(rowResult.result));
     }

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -245,12 +245,8 @@ public class CypherExtended {
             int row = 0;
             while (result.hasNext()) {
                 terminationGuard.check();
-                try {
-                    Map<String, Object> res = EntityUtil.anyRebind(tx, result.next());
-                    queue.put(new RowResult(row++, res));
-                } catch (Exception e) {
-                    System.out.println("e = " + e);
-                }
+                Map<String, Object> res = EntityUtil.anyRebind(tx, result.next());
+                queue.put(new RowResult(row++, res));
             }
             if (addStatistics) {
                 queue.put(new RowResult(-1, toMap(result.getQueryStatistics(), System.currentTimeMillis() - time, row)));

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -245,8 +245,12 @@ public class CypherExtended {
             int row = 0;
             while (result.hasNext()) {
                 terminationGuard.check();
-                Map<String, Object> res = EntityUtil.anyRebind(tx, result.next());
-                queue.put(new RowResult(row++, res));
+                try {
+                    Map<String, Object> res = EntityUtil.anyRebind(tx, result.next());
+                    queue.put(new RowResult(row++, res));
+                } catch (Exception e) {
+                    System.out.println("e = " + e);
+                }
             }
             if (addStatistics) {
                 queue.put(new RowResult(-1, toMap(result.getQueryStatistics(), System.currentTimeMillis() - time, row)));
@@ -369,19 +373,20 @@ public class CypherExtended {
         final String statement = withParamsAndIterator(fragment, params.keySet(), "_");
         tx.execute("EXPLAIN " + statement).close();
         BlockingQueue<RowResult> queue = new ArrayBlockingQueue<>(100000);
-        Stream<List<Object>> parallelPartitions = Util.partitionSubList(data, (int)(partitions <= 0 ? PARTITIONS : partitions), null);
+        List<List<Object>> parallelPartitions = Util.partitionSubList(data, (int)(partitions <= 0 ? PARTITIONS : partitions), null)
+                .toList();
         Util.inFuture(pools, () -> {
-            long total = parallelPartitions
-                .map((List<Object> partition) -> {
-                    try (Transaction transaction = db.beginTx();
-                         Result result = transaction.execute(statement, parallelParams(params, "_", partition))) {
-                        return consumeResult(result, queue, false, timeout);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }}
-                ).count();
+            parallelPartitions
+                    .forEach((List<Object> partition) -> {
+                        try (Transaction transaction = db.beginTx();
+                             Result result = transaction.execute(statement, parallelParams(params, "_", partition))) {
+                            consumeResult(result, queue, false, timeout);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }}
+                    );
             queue.put(RowResult.TOMBSTONE);
-            return total;
+            return null;
         });
         return StreamSupport.stream(new QueueBasedSpliterator<>(queue, RowResult.TOMBSTONE, terminationGuard, (int)timeout),true).map((rowResult) -> new MapResult(rowResult.result));
     }

--- a/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -226,7 +226,23 @@ public class CypherExtendedTest {
                     "RETURN value.title limit 5",
                 r -> assertEquals(5, Iterators.count(r)));
     }
-    
+
+    @Test
+    public void testIssue3751MapParallel2() {
+        int expected = 500;
+        db.executeTransactionally("UNWIND range(1, $int) as id CREATE (:Polling {id: id})",
+                Map.of("int", expected));
+
+        // the error is flaky, so we need to run the query several times to replicate it
+        for (int i = 0; i < 15; i++) {
+            testCallCount(db, """
+                            MATCH  (n:Polling)  WITH collect({childD: n}) as params \s
+                            CALL apoc.cypher.mapParallel2(" WITH _.childD as childD RETURN childD", {}, params, 6, 10)\s
+                            YIELD value RETURN value""",
+                    Map.of(),
+                    expected);
+        }
+    }
     
     @Test
     public void testRunFileWithParameters() throws Exception {

--- a/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -5,6 +5,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.Utils;
 import apoc.util.collection.Iterators;
+import org.apache.commons.io.FileUtils;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -19,6 +20,8 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,11 +49,11 @@ import static org.neo4j.driver.internal.util.Iterables.count;
  * @since 08.05.16
  */
 public class CypherExtendedTest {
-
+    public static final String IMPORT_DIR = "src/test/resources";
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.allow_file_urls, true)
-            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, new File("src/test/resources").toPath().toAbsolutePath());
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, new File(IMPORT_DIR).toPath().toAbsolutePath());
 
     @Rule
     public ExpectedException thrown= ExpectedException.none();
@@ -234,14 +237,67 @@ public class CypherExtendedTest {
                 Map.of("int", expected));
 
         // the error is flaky, so we need to run the query several times to replicate it
-        for (int i = 0; i < 15; i++) {
+        for (int i = 0; i < 30; i++) {
             testCallCount(db, """
-                            MATCH  (n:Polling)  WITH collect({childD: n}) as params \s
+                            MATCH (n:Polling) WITH collect({childD: n}) as params \s
                             CALL apoc.cypher.mapParallel2(" WITH _.childD as childD RETURN childD", {}, params, 6, 10)\s
                             YIELD value RETURN value""",
                     Map.of(),
                     expected);
         }
+    }
+
+    @Test
+    public void testIssue3751RunFiles() {
+        int numEntities = 500;
+        db.executeTransactionally("UNWIND range(1, $int) as id CREATE (:Polling {id: id})",
+                Map.of("int", numEntities));
+
+        for (int i = 0; i < 30; i++) {
+            int numFiles = 30;
+            List<String> files = Collections.nCopies(numFiles, "parallel.cypher");
+
+            int expected = numEntities * numFiles;
+            testCallCount(db, "CALL apoc.cypher.runFiles($files, {statistics: false})",
+                    Map.of("files", files),
+                    expected);
+        }
+    }
+
+    @Test
+    public void testIssue3751RunSchemaFiles() throws IOException {
+        for (int i = 0; i < 15; i++) {
+            int numFiles = 10;
+            List<File> files = new ArrayList<>();
+
+            for (int fileIdx = 0; fileIdx < numFiles; fileIdx++) {
+                String id = i + "" + fileIdx;
+                File file = new File(IMPORT_DIR, "schema" + id);
+
+                String content = """
+                            CREATE INDEX index%1$s FOR (n:Person%1$s) ON (n.name%1$s);
+                            CREATE INDEX secondIndex%1$s FOR (n:Foo%1$s) ON (n.bar%1$s);
+                            CREATE INDEX thirdIndex%1$s FOR (n:Ajeje%1$s) ON (n.brazorf%1$s);
+                            """
+                        .formatted(id);
+                
+                FileUtils.writeStringToFile(file,
+                        content,
+                        StandardCharsets.UTF_8);
+                
+                files.add(file);
+            }
+
+            // 4 is the number of indexes
+            int expected = numFiles * 3;
+            List<String> fileNames = files.stream().map(File::getName).toList();
+            testCallCount(db, "CALL apoc.cypher.runSchemaFiles($files, {statistics: true})",
+                    Map.of("files", fileNames),
+                    expected);
+        
+            files.forEach(File::delete);
+        }
+        
     }
     
     @Test

--- a/extended/src/test/resources/parallel.cypher
+++ b/extended/src/test/resources/parallel.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Polling) SET n.test = date() RETURN n;


### PR DESCRIPTION
Issue 3751: `https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3751`

L'errore sembra essere dovuto al rebind introdotto in 5.9 (https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/main/java/apoc/cypher/CypherExtended.java#L248).

Molti sporadicamente il rebind lancia (sottobanco), un:
```
org.neo4j.exceptions.UnderlyingStorageException: Access to record Node[20,used=false,created=false,rel=-1,prop=-1,labels=Inline(0x0:[]),light,fixedRefs=false] went out of bounds of the page. The record size is 15 bytes, and the access was at offset 300 bytes into page 0, and the pages have a capacity of 8192 bytes. The mapped store file in question is /target/test data/neo4j/data/databases/neo4j/neostore.nodestore.db
```

oppure un:
```
org.neo4j.graphdb.NotFoundException: Node 4:cce42f14-8960-44a9-b61f-5cdf5d7f0bc9:420 not found.
```


## Risoluzione 

Discutendone con uni tizio di Neo4j qui:`https://github.com/neo4j/neo4j/issues/13315#issuecomment-1757553230`,
il probleme sembra essere dovuto al rebind, che invece di usare come transazione la `@Context Transaction tx` dovrebbe usare quella provienente da `db.beginTx()`.
In questo modo, sembrerebbe funzionare.

Lo stesso metodo viene utilizzato anche da altre procedure, ma queste funzionano anche con  `@Context Transaction tx`, ho creato dei test per sicurezza, quindi lo rimarrei così per non causare breaking-change.
Anche perché [questo qui](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/main/java/apoc/cypher/CypherExtended.java#L177) non è proprio possibile cambiarlo, in quanto darebbe errore `A query with 'CALL { ... } IN TRANSACTIONS' can only be executed in an implicit transaction`





---
---

## Vecchia descrizione - non più valida

## Risoluzione 

Non sono sicuro se sia un problema di Neo4j o delle Apoc, 
ma per risolverlo possiamo materializzare lo stream che viene parallelizato in seguito, come fatto nella PR.

---

Un'alternativa potrebbe essere inserire un meccanismo di retry, ad esempio:
```
    private <T> T retry(long times, Supplier<T> function) {
        try {
            return function.get();
        } catch (Exception e) {
            System.out.println("e = " + e);
            if (times > 0) {
                return retry(times - 1, function);
            } else {
                throw e;
            }
        }
    }

// ...
 Map<String, Object> retry = retry(5, () -> EntityUtil.anyRebind(tx, next));
 queue.put(new RowResult(row++, retry));
```


## Potenziale problema lato Neo4j (non più valido)

Forse, oltre a fixare il problema lato APOC, varrebbe la pena create una issue su neo4j per verificare se si può risolvere anche lato kernel. Per replicarlo basterebbe creare una procedura tipo:

```
    @Procedure("proc.name")
    public Stream<MapResult> test3(@Name("list") List<Object> data) {
        Stream<List<Object>> parallelPartitions = Util.partitionSubList(data, 6, null);

        parallelPartitions.forEach((List<Object> partition) -> {
            try (Transaction transaction = db.beginTx();
                 Result result = transaction.execute("UNWIND $part AS part WITH part RETURN part",
                         Map.of("part", data))) {

                result.forEachRemaining(i2 -> {
                    Node part = (Node) i2.get("part");
                    tx.getNodeByElementId(part.getElementId());
                });
            }
        });

        return Stream.of();
    }
```
e poi: 
```
UNWIND range(1, $int) as id CREATE (:Polling {id: id})

// maybe 5/6 times..
MATCH (n:Polling) with collect(n) as list 
CALL apoc.cypher.test3(list) 
YIELD value RETURN count(value)
```