### PR TITLE
Fixes 3831: Improve procedure errors in case of missing dependency

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,14 +26,6 @@ jobs:
           java-version: '17.0.8'
           distribution: 'temurin'
 
-      - name: Download neo4j dev docker container
-        run: |
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
-          wait
-          docker load --input ${ENTERPRISE_TAR}
-          docker load --input ${COMMUNITY_TAR}
-
       - uses: actions/cache@v2
         with:
           path: |

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,6 @@ allprojects {
 }
 
 apply plugin: 'java-library'
-if (System.env.CI != null)
-    apply from: 'teamcity-repository.gradle'
 
 repositories {
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.15.0-enterprise-debian',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.13.0-enterprise',
                 'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.15.0-debian',
                 'coreDir': 'apoc-core/core'
 
@@ -130,7 +130,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.15.0"
+    neo4jVersion = "5.13.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/docs/asciidoc/modules/ROOT/partials/html/runtime.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/html/runtime.adoc
@@ -24,5 +24,8 @@ If we have a `test.html` file with a jQuery script like:
 ----
 
 we can read the generated js through the `browser` config.
+
+[[selenium-dependencies]]
+=== Install dependencies
 Note that to use the `browser` config (except with `"NONE"` value), you have to install additional dependencies
 which can be downloaded  https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/{apoc-release}/apoc-selenium-dependencies-{apoc-release}-all.jar[from this link].

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
@@ -6,7 +6,7 @@ The procedure support the following config parameters:
 | name | type | default | description
 | browser | Enum [NONE, CHROME, FIREFOX] | NONE | If it is set to "CHROME" or "FIREFOX", is used https://www.selenium.dev/documentation/en/webdriver/[Selenium Web Driver] to read the dynamically generated js.
     In case it is "NONE" (default), it is not possible to read dynamic contents.
-    Note that to use the Chrome or Firefox driver, you need to have them installed on your machine and you have to download additional jars into the plugin folder. <<selenium-depencencies, See below>>
+    Note that to use the Chrome or Firefox driver, you need to have them installed on your machine and you have to download additional jars into the plugin folder. <<selenium-dependencies, See below>>
 | wait | long | 0 | If greater than 0, it waits until it finds at least one element for each of those entered in the query parameter
     (up to a maximum of defined seconds, otherwise it continues execution).
     Useful to handle elements which can be rendered after the page is loaded (i.e. slow asynchronous calls).

--- a/extended/src/main/java/apoc/bolt/BoltConnection.java
+++ b/extended/src/main/java/apoc/bolt/BoltConnection.java
@@ -3,7 +3,6 @@ package apoc.bolt;
 import apoc.result.RowResult;
 import apoc.result.VirtualNode;
 import apoc.result.VirtualRelationship;
-import apoc.util.MissingDependencyException;
 import apoc.util.UriResolver;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;

--- a/extended/src/main/java/apoc/bolt/BoltConnection.java
+++ b/extended/src/main/java/apoc/bolt/BoltConnection.java
@@ -48,14 +48,9 @@ public class BoltConnection {
     }
     
     public static BoltConnection from(Map<String, Object> config, String url) throws URISyntaxException {
-        try {
-            final UriResolver resolver = new UriResolver(url, "bolt");
-            resolver.initialize();
-            return new BoltConnection(new BoltConfig(config), resolver);
-        } catch (NoClassDefFoundError e) {
-            throw new MissingDependencyException("Cannot find the needed jar into the plugins folder in order to use . \n" +
-                    "Please see the documentation: https://neo4j.com/labs/apoc/4.4/database-integration/bolt-neo4j/#_install_dependencies");
-        }
+        final UriResolver resolver = new UriResolver(url, "bolt");
+        resolver.initialize();
+        return new BoltConnection(new BoltConfig(config), resolver);
     }
 
     // methods from Bolt.java

--- a/extended/src/main/java/apoc/couchbase/CouchbaseConnection.java
+++ b/extended/src/main/java/apoc/couchbase/CouchbaseConnection.java
@@ -1,5 +1,9 @@
 package apoc.couchbase;
 
+import apoc.couchbase.document.CouchbaseByteArrayDocument;
+import apoc.couchbase.document.CouchbaseJsonDocument;
+import apoc.couchbase.document.CouchbaseQueryResult;
+import apoc.couchbase.document.CouchbaseUtils;
 import com.couchbase.client.core.env.PasswordAuthenticator;
 import com.couchbase.client.core.env.SeedNode;
 import com.couchbase.client.core.error.DocumentNotFoundException;
@@ -36,8 +40,9 @@ import static com.couchbase.client.java.query.QueryOptions.queryOptions;
 /**
  * A Couchbase Server connection.
  * <p/>
- * It wraps a Couchbase {@link Bucket} instance through that all of the
- * operations performed against Couchbase are done.
+ * It wraps a Couchbase {@link Bucket} instance through that all the
+ * operations performed against Couchbase are done,
+ * and return a result digestible by Neo4j.
  * <p/>
  * The class is {@link AutoCloseable} so that every operation can be performed
  * inside a try-block and if an exception is raised the internal state of the
@@ -131,12 +136,26 @@ public class CouchbaseConnection implements AutoCloseable {
 
     /**
      * Retrieves a {@link GetResult} by its unique ID.
+     * 
+     * @param documentId the unique ID of the document
+     * @return the found {@link CouchbaseJsonDocument} or null if not found
+     */
+    public CouchbaseJsonDocument get(String documentId) {
+        GetResult getResult = getResult(documentId);
+        if (getResult == null) {
+            return null;
+        }
+        return new CouchbaseJsonDocument(getResult, documentId);
+    }
+
+    /**
+     * Retrieves a {@link GetResult} by its unique ID.
      *
      * @param documentId the unique ID of the document
      * @return the found {@link GetResult} or null if not found
      * @see Collection#get(String)
      */
-    public GetResult get(String documentId) {
+    private GetResult getResult(String documentId) {
         try {
             return collection.get(documentId, getOptions().withExpiry(true));
         } catch (DocumentNotFoundException e) {
@@ -171,8 +190,10 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the newly created {@link MutationResult}
      * @see Collection#insert(String, Object)
      */
-    public MutationResult insert(String documentId, String json) {
-        return this.collection.insert(documentId, JsonObject.fromJson(json));
+    public CouchbaseJsonDocument insert(String documentId, String json) {
+        MutationResult insert = this.collection.insert(documentId, JsonObject.fromJson(json));
+        GetResult getResult = getResult(documentId);
+        return new CouchbaseJsonDocument(getResult, documentId, insert.mutationToken().orElse(null));
     }
 
     /**
@@ -183,20 +204,24 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the newly created or overwritten {@link MutationResult}
      * @see Collection#upsert(String, Object)
      */
-    public MutationResult upsert(String documentId, String json) {
-        return this.collection.upsert(documentId, JsonObject.fromJson(json));
+    public CouchbaseJsonDocument upsert(String documentId, String json) {
+        MutationResult upsertResult = this.collection.upsert(documentId, JsonObject.fromJson(json));
+        GetResult getResult = getResult(documentId);
+        return new CouchbaseJsonDocument(getResult, documentId, upsertResult.mutationToken().orElse(null));
     }
 
     /**
      * Appends a json content to an existing one.
      *
      * @param documentId the unique ID of the document
-     * @param content       the byte[] representing the document to append
+     * @param content    the byte[] representing the document to append
      * @return the updated {@link MutationResult}
      * @see BinaryCollection#append(String, byte[])
      */
-    public MutationResult append(String documentId, byte[] content) {
-        return binaryCollection.append(documentId, content);
+    public CouchbaseByteArrayDocument append(String documentId, byte[] content) {
+        MutationResult appendResult = binaryCollection.append(documentId, content);
+        GetResult getResult = getResult(documentId);
+        return new CouchbaseByteArrayDocument(getResult, documentId, appendResult.mutationToken().orElse(null));
     }
 
     /**
@@ -207,8 +232,10 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the updated {@link MutationResult}
      * @see BinaryCollection#prepend(String, byte[])
      */
-    public MutationResult prepend(String documentId, byte[] content) {
-        return binaryCollection.prepend(documentId, content);
+    public CouchbaseByteArrayDocument prepend(String documentId, byte[] content) {
+        MutationResult prependResult = binaryCollection.prepend(documentId, content);
+        GetResult binaryResult = getBinary(documentId);
+        return new CouchbaseByteArrayDocument(binaryResult, documentId, prependResult.mutationToken().orElse(null));
     }
 
     /**
@@ -218,8 +245,10 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the removed document
      * @see Collection#remove(String)
      */
-    public MutationResult remove(String documentId) {
-        return this.collection.remove(documentId);
+    public CouchbaseJsonDocument remove(String documentId) {
+        GetResult getResult = getResult(documentId);
+        MutationResult removeResult = this.collection.remove(documentId);
+        return new CouchbaseJsonDocument(getResult, documentId, removeResult.mutationToken().orElse(null));
     }
 
     /**
@@ -230,8 +259,10 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the replaced {@link MutationResult}
      * @see Collection#replace(String, Object)
      */
-    public MutationResult replace(String documentId, String json) {
-        return this.collection.replace(documentId, JsonObject.fromJson(json));
+    public CouchbaseJsonDocument replace(String documentId, String json) {
+        MutationResult replaceResult = this.collection.replace(documentId, JsonObject.fromJson(json));
+        GetResult getResult = getResult(documentId);
+        return new CouchbaseJsonDocument(getResult, documentId, replaceResult.mutationToken().orElse(null));
     }
 
     /**
@@ -241,8 +272,9 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the list of {@link JsonObject}s retrieved by this query
      * @see Cluster#query(String)
      */
-    public List<JsonObject> executeStatement(String statement) {
-        return this.cluster.query(statement).rowsAsObject();
+    public CouchbaseQueryResult executeStatement(String statement) {
+        List<JsonObject> statementResult = this.cluster.query(statement).rowsAsObject();
+        return CouchbaseUtils.convertToCouchbaseQueryResult(statementResult);
     }
 
     /**
@@ -254,10 +286,11 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the list of {@link JsonObject}s retrieved by this query
      * @see Cluster#query(String, QueryOptions)
      */
-    public List<JsonObject> executeParameterizedStatement(String statement, List<Object> parameters) {
+    public CouchbaseQueryResult executeParameterizedStatement(String statement, List<Object> parameters) {
         JsonArray positionalParams = JsonArray.from(parameters);
         final QueryResult queryResult = this.cluster.query(statement, queryOptions().parameters(positionalParams));
-        return queryResult.rowsAsObject();
+        List<JsonObject> statementResult = queryResult.rowsAsObject();
+        return CouchbaseUtils.convertToCouchbaseQueryResult(statementResult);
     }
 
     /**
@@ -270,13 +303,14 @@ public class CouchbaseConnection implements AutoCloseable {
      * @return the list of {@link JsonObject}s retrieved by this query
      * @see Cluster#query(String, QueryOptions)
      */
-    public List<JsonObject> executeParameterizedStatement(String statement, List<String> parameterNames,
+    public CouchbaseQueryResult executeParameterizedStatement(String statement, List<String> parameterNames,
                                                           List<Object> parameterValues) {
         JsonObject namedParams = JsonObject.create();
         for (int param = 0; param < parameterNames.size(); param++) {
             namedParams.put(parameterNames.get(param), parameterValues.get(param));
         }
         QueryResult queryResult = this.cluster.query(statement, queryOptions().parameters(namedParams));
-        return queryResult.rowsAsObject();
+        List<JsonObject> statementResult = queryResult.rowsAsObject();
+        return CouchbaseUtils.convertToCouchbaseQueryResult(statementResult);
     }
 }

--- a/extended/src/main/java/apoc/data/email/ExtractEmail.java
+++ b/extended/src/main/java/apoc/data/email/ExtractEmail.java
@@ -1,31 +1,29 @@
 package apoc.data.email;
 
 import apoc.Extended;
-import apoc.util.Util;
+import apoc.util.MissingDependencyException;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.UserFunction;
 
-import javax.mail.internet.*;
 import java.util.Map;
+
+import static apoc.data.email.ExtractEmailHandler.extractEmail;
 
 @Extended
 public class ExtractEmail {
+    public static final String EMAIL_MISSING_DEPS_ERROR = """
+            Cannot find the needed jar into the plugins folder in order to use .\s
+            Please put the apoc-email-dependencies-5.x.x-all.jar into plugin folder.
+            See the documentation: https://neo4j.com/labs/apoc/5/overview/apoc.data/apoc.data.email/#_install_dependencies""";
 
     @UserFunction("apoc.data.email")
     @Description("apoc.data.email('email_address') as {personal,user,domain} - extract the personal name, user and domain as a map")
     public Map<String,String> email(final @Name("email_address") String value) {
-        if (value == null || value.indexOf('@') == -1) {
-            return null;
-        }
         try {
-            InternetAddress addr = new InternetAddress(value);
-            String rawAddr = addr.getAddress();
-            int idx = rawAddr.indexOf('@');
-
-            return (Map)Util.map("personal",addr.getPersonal(), "user", rawAddr.substring(0, idx), "domain",rawAddr.substring(idx+1));
-        } catch(AddressException adr) {
-            return null;
+            return extractEmail(value);
+        } catch (NoClassDefFoundError e) {
+            throw new MissingDependencyException(EMAIL_MISSING_DEPS_ERROR);
         }
     }
 }

--- a/extended/src/main/java/apoc/data/email/ExtractEmailHandler.java
+++ b/extended/src/main/java/apoc/data/email/ExtractEmailHandler.java
@@ -1,0 +1,26 @@
+package apoc.data.email;
+
+import apoc.util.Util;
+
+import javax.mail.internet.*;
+import java.util.Map;
+
+/**
+ * Separated class in order to throw MissingDependencyException if `javax.mail` is not present
+ */
+public class ExtractEmailHandler {
+    public static Map<String,String> extractEmail(String value) {
+        if (value == null || value.indexOf('@') == -1) {
+            return null;
+        }
+        try {
+            InternetAddress addr = new InternetAddress(value);
+            String rawAddr = addr.getAddress();
+            int idx = rawAddr.indexOf('@');
+
+            return Util.map("personal", addr.getPersonal(), "user", rawAddr.substring(0, idx), "domain", rawAddr.substring(idx + 1));
+        } catch(AddressException adr) {
+            return null;
+        }
+    }
+}

--- a/extended/src/main/java/apoc/export/parquet/ParquetConfig.java
+++ b/extended/src/main/java/apoc/export/parquet/ParquetConfig.java
@@ -7,6 +7,10 @@ import java.util.Collections;
 import java.util.Map;
 
 public class ParquetConfig {
+    public static final String PARQUET_MISSING_DEPS_ERROR = """
+        Cannot find the Hadoop jar (required by Parquet procedures).
+        Please put the apoc-hadoop-dependencies-5.x.x-all.jar into plugin folder.
+        See the documentation: https://neo4j.com/labs/apoc/5/export/parquet/#_library_requirements""";
 
     private final int batchSize;
 
@@ -15,11 +19,7 @@ public class ParquetConfig {
 
     public ParquetConfig(Map<String, Object> config) {
         if (!Util.classExists("org.apache.parquet.schema.MessageType")) {
-            String errorMsg = """
-                    Cannot find the Hadoop jar (required by Parquet procedures).
-                    Please put the apoc-hadoop-dependencies-5.x.x-all.jar into plugin folder.
-                    See the documentation: https://neo4j.com/labs/apoc/5/export/parquet/#_library_requirements""";
-            throw new MissingDependencyException(errorMsg);
+            throw new MissingDependencyException(PARQUET_MISSING_DEPS_ERROR);
         }
         
         this.config = config == null ? Collections.emptyMap() : config;

--- a/extended/src/main/java/apoc/export/parquet/ParquetConfig.java
+++ b/extended/src/main/java/apoc/export/parquet/ParquetConfig.java
@@ -1,5 +1,6 @@
 package apoc.export.parquet;
 
+import apoc.util.MissingDependencyException;
 import apoc.util.Util;
 
 import java.util.Collections;
@@ -13,6 +14,14 @@ public class ParquetConfig {
     private final Map<String, Object> mapping;
 
     public ParquetConfig(Map<String, Object> config) {
+        if (!Util.classExists("org.apache.parquet.schema.MessageType")) {
+            String errorMsg = """
+                    Cannot find the Hadoop jar (required by Parquet procedures).
+                    Please put the apoc-hadoop-dependencies-5.x.x-all.jar into plugin folder.
+                    See the documentation: https://neo4j.com/labs/apoc/5/export/parquet/#_library_requirements""";
+            throw new MissingDependencyException(errorMsg);
+        }
+        
         this.config = config == null ? Collections.emptyMap() : config;
         this.batchSize = Util.toInteger(this.config.getOrDefault("batchSize", 20000));
         this.mapping = (Map<String, Object>) this.config.getOrDefault("mapping", Map.of());

--- a/extended/src/main/java/apoc/export/xls/ExportXls.java
+++ b/extended/src/main/java/apoc/export/xls/ExportXls.java
@@ -2,34 +2,28 @@ package apoc.export.xls;
 
 import apoc.ApocConfig;
 import apoc.Extended;
-import apoc.export.util.ExportConfig;
 import apoc.export.util.NodesAndRelsSubGraph;
-import apoc.export.util.ProgressReporter;
 import apoc.result.ProgressInfo;
+import apoc.util.MissingDependencyException;
 import apoc.util.Util;
-import org.apache.commons.collections4.ListUtils;
-import org.apache.commons.lang3.tuple.Triple;
-import org.apache.poi.ss.usermodel.*;
-import org.apache.poi.xssf.streaming.SXSSFSheet;
-import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.neo4j.cypher.export.DatabaseSubGraph;
-import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import java.io.OutputStream;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import static apoc.util.FileUtils.getOutputStream;
+import static apoc.export.xls.ExportXlsHandler.XLS_MISSING_DEPS_ERROR;
 
 @Extended
 public class ExportXls {
@@ -78,212 +72,11 @@ public class ExportXls {
     }
 
     private Stream<ProgressInfo> exportXls(@Name("file") String fileName, String source, Object data, Map<String,Object> configMap) throws Exception {
-        ExportConfig c = new ExportConfig(configMap);
-        apocConfig.checkWriteAllowed(c, fileName);
-        try (Transaction tx = db.beginTx();
-             OutputStream out = getOutputStream(fileName, c);
-             SXSSFWorkbook wb = new SXSSFWorkbook(-1)) {
-
-            XlsExportConfig config = new XlsExportConfig(configMap);
-            ProgressInfo progressInfo = new ProgressInfo(fileName, source, "xls");
-            progressInfo.batchSize = config.getBatchSize();
-            ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
-
-            Map<Class, CellStyle> styles = buildCellStyles(config, wb);
-
-            if (data instanceof SubGraph) {
-                dumpSubGraph((SubGraph) data, config, reporter, wb, styles);
-
-            } else if (data instanceof Result ) {
-                Result result = (Result) data;
-                dumpResult(result, config, wb, styles);
-            } else {
-                throw new UnsupportedOperationException("cannot handle " + data.getClass());
-            }
-
-            wb.write(out);
-            wb.dispose();
-            reporter.done();
-            tx.commit();
-            return reporter.stream();
+        try {
+            return ExportXlsHandler.getProgressInfoStream(fileName, source, data, configMap, apocConfig, db);
+        } catch (NoClassDefFoundError e) {
+            throw new MissingDependencyException(XLS_MISSING_DEPS_ERROR);
         }
-    }
-
-    private void dumpResult(Result result, XlsExportConfig config, SXSSFWorkbook wb, Map<Class, CellStyle> styles) {
-        SXSSFSheet sheet = wb.createSheet();
-        sheet.trackAllColumnsForAutoSizing();
-
-        // header row
-        int columnNum = 0;
-        int rowNum = 0;
-        Row headerRow = sheet.createRow(rowNum++);
-
-        for (String header: result.columns()) {
-            Cell cell = headerRow.createCell(columnNum);
-            sheet.autoSizeColumn(columnNum);
-            cell.setCellValue(header);
-            columnNum++;
-        }
-
-        while (result.hasNext()) {
-            Map<String, Object> map = result.next();
-            Row row = sheet.createRow(rowNum++);
-            columnNum = 0;
-            for (String header: result.columns()) {
-                columnNum = amendCell(row, columnNum, map.get(header), config, styles);
-            }
-        }
-    }
-
-    private void dumpSubGraph(SubGraph subgraph, XlsExportConfig config, ProgressReporter reporter, SXSSFWorkbook wb, Map<Class, CellStyle> styles) {
-        // what's in the triple used below?
-        // left: sheet instance
-        // middle: list of "magic" property keys: <id> for nodes, <startNodeId> and <endNodeId> for rels
-        // right: list of  "normal" property keys
-        Map<String, Triple<SXSSFSheet, List<String>, List<String>>> sheetAndPropsForName = new HashMap<>();
-
-        for (Node node : subgraph.getNodes()) {
-            final List<String> labels;
-            if (config.isJoinLabels()) {
-                labels = Collections.singletonList(StreamSupport.stream(node.getLabels().spliterator(), false)
-                        .map(Label::name)
-                        .collect(Collectors.joining(",")));
-            } else {
-                labels = StreamSupport.stream(node.getLabels().spliterator(), false)
-                        .map(Label::name)
-                        .collect(Collectors.toList());
-            }
-            for (String label :labels) {
-                String labelName = (config.isPrefixSheetWithEntityType() ? "Node-" : "") + label;
-                createRowForEntity(wb, sheetAndPropsForName, node, labelName, reporter, config, styles);
-            }
-        }
-        for (Relationship relationship: subgraph.getRelationships()) {
-            String relationshipType = (config.isPrefixSheetWithEntityType() ? "Rel-" : "") + relationship.getType().name();
-            createRowForEntity(wb, sheetAndPropsForName, relationship, relationshipType, reporter, config,styles);
-        }
-
-        // spit out header lines
-        for (Triple<SXSSFSheet,List<String>, List<String>> triple: sheetAndPropsForName.values()) {
-            Sheet sheet = triple.getLeft();
-
-            List<String> magicKeys = triple.getMiddle();
-            List<String> keys = triple.getRight();
-            Row row = sheet.getRow(0);
-            int cellNum = 0;
-            for (String key: ListUtils.union(magicKeys,keys)) {
-                sheet.autoSizeColumn(cellNum);
-                Cell cell = row.createCell(cellNum++);
-                cell.setCellValue(key);
-
-            }
-        }
-    }
-
-    private Map<Class, CellStyle> buildCellStyles(XlsExportConfig config, SXSSFWorkbook wb) {
-        CreationHelper createHelper = wb.getCreationHelper();
-        CellStyle dateTimeCellStyle = wb.createCellStyle();
-        dateTimeCellStyle.setDataFormat(createHelper.createDataFormat().getFormat(config.getDateTimeStyle()));
-        CellStyle dateCellStyle = wb.createCellStyle();
-        dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat(config.getDateStyle()));
-
-        Map<Class, CellStyle> styles = new HashMap<>();
-        styles.put(ZonedDateTime.class, dateTimeCellStyle);
-        styles.put(LocalDate.class, dateCellStyle);
-        return styles;
-    }
-
-    private void createRowForEntity(Workbook wb, Map<String, Triple<SXSSFSheet, List<String>, List<String>>> sheetAndPropsForName, Entity entity, String sheetName, ProgressReporter reporter, XlsExportConfig config, Map<Class, CellStyle> styles) {
-        Triple<SXSSFSheet, List<String>, List<String>> triple = sheetAndPropsForName.computeIfAbsent(sheetName, s -> {
-            SXSSFSheet sheet = (SXSSFSheet) wb.createSheet(sheetName);
-            sheet.trackAllColumnsForAutoSizing();
-            sheet.createRow(0); // placeholder for header line
-            return Triple.of(
-                    sheet,
-                    entity instanceof Node ?
-                            Arrays.asList(config.getHeaderNodeId()) :
-                            Arrays.asList(config.getHeaderRelationshipId(), config.getHeaderStartNodeId(), config.getHeaderEndNodeId()),
-                    new ArrayList<>());
-        });
-        Sheet sheet = triple.getLeft();
-        List<String> propertyKeys = triple.getRight();
-
-        int lastRowNum = sheet.getLastRowNum();
-        Row row = sheet.createRow(lastRowNum+1);
-        int cellNum = 0;
-        SortedMap<String, Object> props = new TreeMap<>(entity.getAllProperties()); // copy props
-
-        if (entity instanceof Node) {
-            Node node = (Node) entity;
-            Cell idCell = row.createCell(cellNum++);
-            idCell.setCellValue(((Long)(node.getId())).doubleValue());
-            reporter.update(1, 0, props.size());
-        } else if (entity instanceof Relationship) {
-            Relationship relationship = (Relationship) entity;
-            Cell idCell = row.createCell(cellNum++);
-            idCell.setCellValue(((Long)(relationship.getId())).doubleValue());
-            Cell fromCell = row.createCell(cellNum++);
-            fromCell.setCellValue(((Long)(relationship.getStartNodeId())).doubleValue());
-            Cell toCell = row.createCell(cellNum++);
-            toCell.setCellValue(((Long)(relationship.getEndNodeId())).doubleValue());
-            reporter.update(0, 1, props.size());
-        }
-
-        // deal with property keys already being known
-        for (String key: propertyKeys) {
-            cellNum = amendCell(row, cellNum, props.remove(key), config, styles);
-        }
-
-        // add remaining properties as new keys
-        for (String key: props.keySet()) {
-            propertyKeys.add(key);
-            cellNum = amendCell(row, cellNum, props.get(key), config, styles);
-        }
-    }
-
-    private int amendCell(Row row, int cellNum, Object value, XlsExportConfig config, Map<Class, CellStyle> styles) {
-        Cell cell = row.createCell(cellNum++);
-
-        if (value == null) {
-            cell.setCellType(CellType.BLANK);
-        } else {
-
-            CellStyle cellStyle = styles.get(value.getClass());
-            if (cellStyle!=null) {
-                cell.setCellStyle(cellStyle);
-            }
-
-            if (value instanceof String) {
-                cell.setCellValue((String) value);
-            } else if (value instanceof Number) {
-                cell.setCellValue(((Number) value).doubleValue());
-            } else if (value instanceof Boolean) {
-                cell.setCellValue(((Boolean) value).booleanValue());
-            } else if (value instanceof String[]) {
-                String[] values = (String[]) value;
-                cell.setCellValue(Arrays.stream(values).collect(Collectors.joining(config.getArrayDelimiter())));
-            } else if (value instanceof long[]) {
-                long[] values = (long[]) value;
-                cell.setCellValue(Arrays.stream(values).mapToObj(Long::toString).collect(Collectors.joining(config.getArrayDelimiter())));
-            } else if (value instanceof double[]) {
-                double[] values = (double[]) value;
-                cell.setCellValue(Arrays.stream(values).mapToObj(Double::toString).collect(Collectors.joining(config.getArrayDelimiter())));
-            } else if (value instanceof List) {
-                List values = (List) value;
-                String collect = ((Stream<String>) values.stream().map(x -> x.toString())).collect(Collectors.joining(config.getArrayDelimiter()));
-                cell.setCellValue(collect);
-            } else if (value instanceof LocalDate) {
-                LocalDate localDate = (LocalDate) value;
-                cell.setCellValue( Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
-            } else if (value instanceof ZonedDateTime) {
-                ZonedDateTime zondedDateTime = (ZonedDateTime) value;
-                cell.setCellValue( Date.from(zondedDateTime.toInstant()));
-            } else {
-                cell.setCellValue(value.toString());
-                //throw new IllegalArgumentException("dunno know how to handle type " + value.getClass() + ". Please report this as a bug.");
-            }
-        }
-        return cellNum;
     }
 
 }

--- a/extended/src/main/java/apoc/export/xls/ExportXlsHandler.java
+++ b/extended/src/main/java/apoc/export/xls/ExportXlsHandler.java
@@ -1,0 +1,260 @@
+package apoc.export.xls;
+
+import apoc.ApocConfig;
+import apoc.export.util.ExportConfig;
+import apoc.export.util.ProgressReporter;
+import apoc.result.ProgressInfo;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static apoc.util.FileUtils.getOutputStream;
+
+public class ExportXlsHandler {
+    public static final String XLS_MISSING_DEPS_ERROR = "Cannot find the needed jar into the plugins folder in order to use . \n" +
+                                                        "Please see the documentation: https://neo4j.com/labs/apoc/5/overview/apoc.export/apoc.export.xls.all/#_install_dependencies";
+
+
+    public static Stream<ProgressInfo> getProgressInfoStream(String fileName, String source, Object data, Map<String, Object> configMap, ApocConfig apocConfig, GraphDatabaseService db) throws IOException {
+        ExportConfig c = new ExportConfig(configMap);
+        apocConfig.checkWriteAllowed(c, fileName);
+        try (Transaction tx = db.beginTx();
+             OutputStream out = getOutputStream(fileName, c);
+             SXSSFWorkbook wb = new SXSSFWorkbook(-1)) {
+
+            XlsExportConfig config = new XlsExportConfig(configMap);
+            ProgressInfo progressInfo = new ProgressInfo(fileName, source, "xls");
+            progressInfo.batchSize = config.getBatchSize();
+            ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
+
+            Map<Class, CellStyle> styles = buildCellStyles(config, wb);
+
+            if (data instanceof SubGraph) {
+                dumpSubGraph((SubGraph) data, config, reporter, wb, styles);
+
+            } else if (data instanceof Result) {
+                Result result = (Result) data;
+                dumpResult(result, config, wb, styles);
+            } else {
+                throw new UnsupportedOperationException("cannot handle " + data.getClass());
+            }
+
+            wb.write(out);
+            wb.dispose();
+            reporter.done();
+            tx.commit();
+            return reporter.stream();
+        }
+    }
+
+    private static void dumpResult(Result result, XlsExportConfig config, SXSSFWorkbook wb, Map<Class, CellStyle> styles) {
+        SXSSFSheet sheet = wb.createSheet();
+        sheet.trackAllColumnsForAutoSizing();
+
+        // header row
+        int columnNum = 0;
+        int rowNum = 0;
+        Row headerRow = sheet.createRow(rowNum++);
+
+        for (String header: result.columns()) {
+            Cell cell = headerRow.createCell(columnNum);
+            sheet.autoSizeColumn(columnNum);
+            cell.setCellValue(header);
+            columnNum++;
+        }
+
+        while (result.hasNext()) {
+            Map<String, Object> map = result.next();
+            Row row = sheet.createRow(rowNum++);
+            columnNum = 0;
+            for (String header: result.columns()) {
+                columnNum = amendCell(row, columnNum, map.get(header), config, styles);
+            }
+        }
+    }
+
+    private static void dumpSubGraph(SubGraph subgraph, XlsExportConfig config, ProgressReporter reporter, SXSSFWorkbook wb, Map<Class, CellStyle> styles) {
+        // what's in the triple used below?
+        // left: sheet instance
+        // middle: list of "magic" property keys: <id> for nodes, <startNodeId> and <endNodeId> for rels
+        // right: list of  "normal" property keys
+        Map<String, Triple<SXSSFSheet, List<String>, List<String>>> sheetAndPropsForName = new HashMap<>();
+
+        for (Node node : subgraph.getNodes()) {
+            final List<String> labels;
+            if (config.isJoinLabels()) {
+                labels = Collections.singletonList(StreamSupport.stream(node.getLabels().spliterator(), false)
+                        .map(Label::name)
+                        .collect(Collectors.joining(",")));
+            } else {
+                labels = StreamSupport.stream(node.getLabels().spliterator(), false)
+                        .map(Label::name)
+                        .collect(Collectors.toList());
+            }
+            for (String label :labels) {
+                String labelName = (config.isPrefixSheetWithEntityType() ? "Node-" : "") + label;
+                createRowForEntity(wb, sheetAndPropsForName, node, labelName, reporter, config, styles);
+            }
+        }
+        for (Relationship relationship: subgraph.getRelationships()) {
+            String relationshipType = (config.isPrefixSheetWithEntityType() ? "Rel-" : "") + relationship.getType().name();
+            createRowForEntity(wb, sheetAndPropsForName, relationship, relationshipType, reporter, config,styles);
+        }
+
+        // spit out header lines
+        for (Triple<SXSSFSheet,List<String>, List<String>> triple: sheetAndPropsForName.values()) {
+            Sheet sheet = triple.getLeft();
+
+            List<String> magicKeys = triple.getMiddle();
+            List<String> keys = triple.getRight();
+            Row row = sheet.getRow(0);
+            int cellNum = 0;
+            for (String key: ListUtils.union(magicKeys,keys)) {
+                sheet.autoSizeColumn(cellNum);
+                Cell cell = row.createCell(cellNum++);
+                cell.setCellValue(key);
+
+            }
+        }
+    }
+
+    private static Map<Class, CellStyle> buildCellStyles(XlsExportConfig config, SXSSFWorkbook wb) {
+        CreationHelper createHelper = wb.getCreationHelper();
+        CellStyle dateTimeCellStyle = wb.createCellStyle();
+        dateTimeCellStyle.setDataFormat(createHelper.createDataFormat().getFormat(config.getDateTimeStyle()));
+        CellStyle dateCellStyle = wb.createCellStyle();
+        dateCellStyle.setDataFormat(createHelper.createDataFormat().getFormat(config.getDateStyle()));
+
+        Map<Class, CellStyle> styles = new HashMap<>();
+        styles.put(ZonedDateTime.class, dateTimeCellStyle);
+        styles.put(LocalDate.class, dateCellStyle);
+        return styles;
+    }
+
+    private static void createRowForEntity(Workbook wb, Map<String, Triple<SXSSFSheet, List<String>, List<String>>> sheetAndPropsForName, Entity entity, String sheetName, ProgressReporter reporter, XlsExportConfig config, Map<Class, CellStyle> styles) {
+        Triple<SXSSFSheet, List<String>, List<String>> triple = sheetAndPropsForName.computeIfAbsent(sheetName, s -> {
+            SXSSFSheet sheet = (SXSSFSheet) wb.createSheet(sheetName);
+            sheet.trackAllColumnsForAutoSizing();
+            sheet.createRow(0); // placeholder for header line
+            return Triple.of(
+                    sheet,
+                    entity instanceof Node ?
+                            Arrays.asList(config.getHeaderNodeId()) :
+                            Arrays.asList(config.getHeaderRelationshipId(), config.getHeaderStartNodeId(), config.getHeaderEndNodeId()),
+                    new ArrayList<>());
+        });
+        Sheet sheet = triple.getLeft();
+        List<String> propertyKeys = triple.getRight();
+
+        int lastRowNum = sheet.getLastRowNum();
+        Row row = sheet.createRow(lastRowNum+1);
+        int cellNum = 0;
+        SortedMap<String, Object> props = new TreeMap<>(entity.getAllProperties()); // copy props
+
+        if (entity instanceof Node) {
+            Node node = (Node) entity;
+            Cell idCell = row.createCell(cellNum++);
+            idCell.setCellValue(((Long)(node.getId())).doubleValue());
+            reporter.update(1, 0, props.size());
+        } else if (entity instanceof Relationship) {
+            Relationship relationship = (Relationship) entity;
+            Cell idCell = row.createCell(cellNum++);
+            idCell.setCellValue(((Long)(relationship.getId())).doubleValue());
+            Cell fromCell = row.createCell(cellNum++);
+            fromCell.setCellValue(((Long)(relationship.getStartNodeId())).doubleValue());
+            Cell toCell = row.createCell(cellNum++);
+            toCell.setCellValue(((Long)(relationship.getEndNodeId())).doubleValue());
+            reporter.update(0, 1, props.size());
+        }
+
+        // deal with property keys already being known
+        for (String key: propertyKeys) {
+            cellNum = amendCell(row, cellNum, props.remove(key), config, styles);
+        }
+
+        // add remaining properties as new keys
+        for (String key: props.keySet()) {
+            propertyKeys.add(key);
+            cellNum = amendCell(row, cellNum, props.get(key), config, styles);
+        }
+    }
+
+    private static int amendCell(Row row, int cellNum, Object value, XlsExportConfig config, Map<Class, CellStyle> styles) {
+        Cell cell = row.createCell(cellNum++);
+
+        if (value == null) {
+            cell.setCellType(CellType.BLANK);
+        } else {
+
+            CellStyle cellStyle = styles.get(value.getClass());
+            if (cellStyle!=null) {
+                cell.setCellStyle(cellStyle);
+            }
+
+            if (value instanceof String) {
+                cell.setCellValue((String) value);
+            } else if (value instanceof Number) {
+                cell.setCellValue(((Number) value).doubleValue());
+            } else if (value instanceof Boolean) {
+                cell.setCellValue(((Boolean) value).booleanValue());
+            } else if (value instanceof String[]) {
+                String[] values = (String[]) value;
+                cell.setCellValue(Arrays.stream(values).collect(Collectors.joining(config.getArrayDelimiter())));
+            } else if (value instanceof long[]) {
+                long[] values = (long[]) value;
+                cell.setCellValue(Arrays.stream(values).mapToObj(Long::toString).collect(Collectors.joining(config.getArrayDelimiter())));
+            } else if (value instanceof double[]) {
+                double[] values = (double[]) value;
+                cell.setCellValue(Arrays.stream(values).mapToObj(Double::toString).collect(Collectors.joining(config.getArrayDelimiter())));
+            } else if (value instanceof List) {
+                List values = (List) value;
+                String collect = ((Stream<String>) values.stream().map(x -> x.toString())).collect(Collectors.joining(config.getArrayDelimiter()));
+                cell.setCellValue(collect);
+            } else if (value instanceof LocalDate) {
+                LocalDate localDate = (LocalDate) value;
+                cell.setCellValue( Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()));
+            } else if (value instanceof ZonedDateTime) {
+                ZonedDateTime zondedDateTime = (ZonedDateTime) value;
+                cell.setCellValue( Date.from(zondedDateTime.toInstant()));
+            } else {
+                cell.setCellValue(value.toString());
+                //throw new IllegalArgumentException("dunno know how to handle type " + value.getClass() + ". Please report this as a bug.");
+            }
+        }
+        return cellNum;
+    }
+}

--- a/extended/src/main/java/apoc/load/LoadHtml.java
+++ b/extended/src/main/java/apoc/load/LoadHtml.java
@@ -39,6 +39,10 @@ public class LoadHtml {
     public static final String KEY_ERROR = "errorList";
     public static final String INVALID_CONFIG_ERR = "Invalid config: ";
     public static final String UNSUPPORTED_CHARSET_ERR = "Unsupported charset: ";
+    public static final String SELENIUM_MISSING_DEPS_ERROR = """
+            Cannot find the Selenium client jar.
+            Please put the apoc-selenium-dependencies-5.x.x-all.jar into plugin folder.
+            See the documentation: https://neo4j.com/labs/apoc/5/overview/apoc.load/apoc.load.html/#selenium-dependencies""";
 
     @Context
     public GraphDatabaseService db;
@@ -181,8 +185,7 @@ public class LoadHtml {
         try {
             return action.get();
         } catch (NoClassDefFoundError e) {
-            throw new MissingDependencyException("Cannot find jars into the plugins folder.\n" +
-                    "See the documentation: https://neo4j.com/labs/apoc/4.1/overview/apoc.load/apoc.load.html/#selenium-depencencies");
+            throw new MissingDependencyException(SELENIUM_MISSING_DEPS_ERROR);
         }
     }
 

--- a/extended/src/main/java/apoc/load/xls/LoadXlsHandler.java
+++ b/extended/src/main/java/apoc/load/xls/LoadXlsHandler.java
@@ -1,0 +1,126 @@
+package apoc.load.xls;
+
+import apoc.export.util.CountingInputStream;
+import org.apache.poi.ss.usermodel.*;
+import org.neo4j.values.storable.LocalDateTimeValue;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+
+import static apoc.util.Util.cleanUrl;
+
+public class LoadXlsHandler {
+
+    public static class XLSSpliterator extends Spliterators.AbstractSpliterator<LoadXls.XLSResult> {
+        private final Sheet sheet;
+        private final LoadXls.Selection selection;
+        private final String[] header;
+        private final String url;
+        private final long limit;
+        private final boolean ignore;
+        private final Map<String, LoadXls.Mapping> mapping;
+        private final List<Object> nullValues;
+        private final long skip;
+        long lineNo;
+
+        public XLSSpliterator(Sheet sheet, LoadXls.Selection selection, String[] header, String url, long skip, long limit, boolean ignore, Map<String, LoadXls.Mapping> mapping, List<Object> nullValues) throws IOException {
+            super(Long.MAX_VALUE, Spliterator.ORDERED);
+            this.sheet = sheet;
+            this.selection = selection;
+            this.header = header;
+            this.url = url;
+            this.ignore = ignore;
+            this.mapping = mapping;
+            this.nullValues = nullValues;
+            int headerOffset = header != null ? 1 : 0;
+            this.skip = skip + selection.getOrDefault(selection.top, sheet.getFirstRowNum()) + headerOffset;
+            this.limit = limit == Long.MAX_VALUE ? selection.getOrDefault(selection.bottom, sheet.getLastRowNum()) : skip + limit;
+            lineNo = this.skip;
+        }
+
+        @Override
+        public boolean tryAdvance(Consumer<? super LoadXls.XLSResult> action) {
+            try {
+                Row row = sheet.getRow((int)lineNo);
+                if (row != null && lineNo <= limit) {
+                    Object[] list = extract(row, selection);
+                    action.accept(new LoadXls.XLSResult(header, list, lineNo - skip, ignore,mapping, nullValues));
+                    lineNo++;
+                    return true;
+                }
+                return false;
+            } catch (Exception e) {
+                throw new RuntimeException("Error reading XLS from URL " + cleanUrl(url) + " at " + lineNo, e);
+            }
+        }
+    }
+
+    public static XLSSpliterator getXlsSpliterator(String url, CountingInputStream stream, LoadXls.Selection selection, long skip, boolean hasHeader, long limit, List<String> ignore, List<Object> nullValues, Map<String, LoadXls.Mapping> mappings) throws IOException {
+        Workbook workbook = WorkbookFactory.create(stream);
+        Sheet sheet = workbook.getSheet(selection.sheet);
+        if (sheet==null) throw new IllegalStateException("Sheet " + selection.sheet + " not found");
+        selection.updateVertical(sheet.getFirstRowNum(),sheet.getLastRowNum());
+        Row firstRow = sheet.getRow(selection.top);
+        selection.updateHorizontal(firstRow.getFirstCellNum(), firstRow.getLastCellNum());
+
+        String[] header = getHeader(hasHeader, firstRow, selection, ignore, mappings);
+        boolean checkIgnore = !ignore.isEmpty() || mappings.values().stream().anyMatch(m -> m.ignore);
+        XLSSpliterator xlsSpliterator = new XLSSpliterator(sheet, selection, header, url, skip, limit, checkIgnore, mappings, nullValues);
+        return xlsSpliterator;
+    }
+
+    private static String[] getHeader(boolean hasHeader, Row header, LoadXls.Selection selection, List<String> ignore, Map<String, LoadXls.Mapping> mapping) throws IOException {
+        if (!hasHeader) return null;
+
+        String[] result = new String[selection.right - selection.left];
+        for (int i = selection.left; i < selection.right; i++) {
+            Cell cell = header.getCell(i);
+            if (cell == null) throw new IllegalStateException("Header at position "+i+" doesn't have a value");
+            String value = cell.getStringCellValue();
+            result[i- selection.left] = ignore.contains(value) || mapping.getOrDefault(value, LoadXls.Mapping.EMPTY).ignore ? null : value;
+        }
+        return result;
+    }
+
+    private static Object[] extract(Row row, LoadXls.Selection selection) {
+        // selection.updateHorizontal(row.getFirstCellNum(),row.getLastCellNum());
+        Object[] result = new Object[selection.right-selection.left];
+        for (int i = selection.left; i < selection.right; i++) {
+            Cell cell = row.getCell(i);
+            if (cell == null) continue;
+            result[i-selection.left] = getValue(cell, cell.getCellType());
+        }
+        return result;
+
+    }
+    
+    private static Object getValue(Cell cell, CellType type) {
+        switch (type) {
+            case NUMERIC: // In excel the date is NUMERIC Type
+                if (DateUtil.isCellDateFormatted(cell)) {
+                    Calendar cal = Calendar.getInstance();
+                    cal.setTime(cell.getDateCellValue());
+                    LocalDateTime localDateTime = LocalDateTime.of(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1, cal.get(Calendar.DAY_OF_MONTH),
+                            cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), cal.get(Calendar.SECOND));
+                    return LocalDateTimeValue.localDateTime(localDateTime);
+//                    return LocalDateTimeValue.localDateTime(cell.getDateCellValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+                }
+                double value = cell.getNumericCellValue();
+                if (value == Math.floor(value)) return (long) value;
+                return value;
+            case STRING: return cell.getStringCellValue();
+            case FORMULA: return getValue(cell,cell.getCachedFormulaResultType());
+            case BOOLEAN: return cell.getBooleanCellValue();
+            case _NONE: return null;
+            case BLANK: return null;
+            case ERROR: return null;
+            default: return null;
+        }
+    }
+}

--- a/extended/src/main/java/apoc/mongodb/Mongo.java
+++ b/extended/src/main/java/apoc/mongodb/Mongo.java
@@ -4,7 +4,6 @@ import apoc.Extended;
 import apoc.result.LongResult;
 import apoc.result.MapResult;
 import apoc.util.JsonUtil;
-import org.bson.Document;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -18,24 +17,22 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static apoc.mongodb.MongoDBUtils.Coll;
 import static apoc.mongodb.MongoDBUtils.getDocument;
-import static apoc.mongodb.MongoDBUtils.getMongoColl;
+import static apoc.mongodb.MongoDBUtils.getDocuments;
+import static apoc.mongodb.MongoDBUtils.getMongoConfig;
 
 @Extended
 public class Mongo {
-
     @Context
     public Log log;
 
     @Procedure("apoc.mongo.aggregate")
     @Description("apoc.mongo.aggregate(uri, pipeline, $config) yield value - perform an aggregate operation on mongodb collection")
     public Stream<MapResult> aggregate(@Name("uri") String uri, @Name("pipeline") List<Map<String, Object>> pipeline, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        MongoDbConfig conf = new MongoDbConfig(config);
+        MongoDbConfig conf = getMongoConfig(config);
         return executeMongoQuery(uri, conf, 
                 coll -> {
-                    final List<Document> pipelineDocs = pipeline.stream().map(MongoDBUtils::getDocument).collect(Collectors.toList());
-                    return coll.aggregate(pipelineDocs).map(MapResult::new);
+                    return coll.aggregate(getDocuments(pipeline)).map(MapResult::new);
                 }, 
                 getExceptionConsumer("apoc.mongo.aggregate", uri, config));
     }
@@ -43,7 +40,7 @@ public class Mongo {
     @Procedure("apoc.mongo.count")
     @Description("apoc.mongo.count(uri, query, $config) yield value - perform a count operation on mongodb collection")
     public Stream<LongResult> count(@Name("uri") String uri, @Name("query") Object query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        MongoDbConfig conf = new MongoDbConfig(config);
+        MongoDbConfig conf = getMongoConfig(config);
         return executeMongoQuery(uri, conf, coll -> {
             long count = coll.count(getDocument(query));
             return Stream.of(new LongResult(count));
@@ -53,7 +50,7 @@ public class Mongo {
     @Procedure("apoc.mongo.find")
     @Description("apoc.mongo.find(uri, query, $config) yield value - perform a find operation on mongodb collection")
     public Stream<MapResult> find(@Name("uri") String uri, @Name(value = "query", defaultValue = "null") Object query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        MongoDbConfig conf = new MongoDbConfig(config);
+        MongoDbConfig conf = getMongoConfig(config);
         return executeMongoQuery(uri, conf, 
                 coll -> coll.find(getDocument(query), conf.getProject(), conf.getSort(), conf.getSkip(), conf.getLimit()).map(MapResult::new),
                 getExceptionConsumer("apoc.mongo.find", uri, config));
@@ -62,8 +59,8 @@ public class Mongo {
     @Procedure("apoc.mongo.insert")
     @Description("apoc.mongo.insert(uri, documents, $config) yield value - inserts the given documents into the mongodb collection")
     public void insert(@Name("uri") String uri, @Name("documents") List<Object> documents, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        MongoDbConfig conf = new MongoDbConfig(config);
-        try (Coll coll = getMongoColl(() -> getColl(uri, conf))) {
+        MongoDbConfig conf = getMongoConfig(config);
+        try (MongoDbCollInterface coll = getColl(uri, conf)) {
             coll.insertDocs(documents.stream().map(MongoDBUtils::getDocument).collect(Collectors.toList()));
         } catch (Exception e) {
             mongoErrorLog("apoc.mongo.insert", uri, config, e, "documents = " + documents + ",");
@@ -74,7 +71,7 @@ public class Mongo {
     @Procedure("apoc.mongo.update")
     @Description("apoc.mongo.update(uri, query, update, $config) - updates the given documents from the mongodb collection and returns the number of affected documents")
     public Stream<LongResult> update(@Name("uri") String uri, @Name("query") Object query, @Name("update") Object update, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        MongoDbConfig conf = new MongoDbConfig(config);
+        MongoDbConfig conf = getMongoConfig(config);
         return executeMongoQuery(uri, conf, coll -> Stream.of(new LongResult(coll.update(getDocument(query), getDocument(update)))),
                 getExceptionConsumer("apoc.mongo.update", uri, config, "query = " + query + ",  update = " + update + ","));
     }
@@ -82,7 +79,7 @@ public class Mongo {
     @Procedure("apoc.mongo.delete")
     @Description("apoc.mongo.delete(uri, query, $config) - delete the given documents from the mongodb collection and returns the number of affected documents")
     public Stream<LongResult> delete(@Name("uri") String uri, @Name("query") Object query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        MongoDbConfig conf = new MongoDbConfig(config);
+        MongoDbConfig conf = getMongoConfig(config);
         return executeMongoQuery(uri, conf, coll -> Stream.of(new LongResult(coll.delete(getDocument(query)))),
                 getExceptionConsumer("apoc.mongo.delete", uri, config, "query = " + query + ","));
     }
@@ -99,22 +96,22 @@ public class Mongo {
         log.error(procedureName + " - uri = '" + uri + "', " + optionalOthers + " config = " + JsonUtil.writeValueAsString(config), e);
     }
 
-    private <T> Stream<T> executeMongoQuery(String uri, MongoDbConfig conf, Function<MongoDBUtils.Coll, Stream<T>> execute, Consumer<Exception> onError) {
-        Coll coll = null;
+    private <T> Stream<T> executeMongoQuery(String uri, MongoDbConfig conf, Function<MongoDbCollInterface, Stream<T>> execute, Consumer<Exception> onError) {
+        MongoDbCollInterface coll = null;
         try {
-            coll = getMongoColl(() -> getColl(uri, conf));
+            coll = getColl(uri, conf);
             return execute.apply(coll).onClose(coll::safeClose);
         } catch (Exception e) {
             if (coll != null) {
                 coll.safeClose();
             }
             onError.accept(e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("Error during connection", e);
         }
     }
 
-    private MongoDBUtils.Coll getColl(@Name("url") String url, MongoDbConfig conf) {
-        return Coll.Factory.create(url, conf);
+    private MongoDbCollInterface getColl(@Name("url") String url, MongoDbConfig conf) {
+        return MongoDbCollInterface.Factory.create(url, conf);
     }
 
 }

--- a/extended/src/main/java/apoc/mongodb/MongoDBColl.java
+++ b/extended/src/main/java/apoc/mongodb/MongoDBColl.java
@@ -40,7 +40,7 @@ import static java.lang.String.format;
  * @author mh
  * @since 30.06.16
  */
-class MongoDBColl implements MongoDBUtils.Coll {
+class MongoDBColl implements MongoDbCollInterface {
 
     private static final ObjectMapper jsonMapper = new ObjectMapper().enable(DeserializationFeature.USE_LONG_FOR_INTS);
     public static final String ID = "_id";

--- a/extended/src/main/java/apoc/mongodb/MongoDBUtils.java
+++ b/extended/src/main/java/apoc/mongodb/MongoDBUtils.java
@@ -2,84 +2,18 @@ package apoc.mongodb;
 
 import apoc.util.JsonUtil;
 import apoc.util.MissingDependencyException;
-import apoc.util.Util;
 import org.bson.Document;
 
-import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 public class MongoDBUtils {
-    interface Coll extends Closeable {
-        Map<String, Object> first(Map<String, Object> params);
+    public static final String MONGO_MISSING_DEPS_ERROR = """
+            Cannot find the jar into the plugins folder.\s
+            Please put the apoc-mongodb-dependencies-5.x.x-all.jar into plugin folder.
+            See the documentation: See the documentation: https://neo4j.com/labs/apoc/5/database-integration/mongo/#mongodb-dependencies""";
 
-        Stream<Map<String, Object>> all(Map<String, Object> query, Long skip, Long limit);
-
-        long count(Map<String, Object> query);
-        long count(Document query);
-
-        Stream<Map<String, Object>> aggregate(List<Document> pipeline);
-
-        Stream<Map<String, Object>> find(Map<String, Object> query, Map<String, Object> project, Map<String, Object> sort, Long skip, Long limit);
-        Stream<Map<String, Object>> find(Document query, Document project, Document sort, int skip, int limit);
-
-        void insert(List<Map<String, Object>> docs);
-        void insertDocs(List<Document> docs);
-
-        long update(Map<String, Object> query, Map<String, Object> update);
-        long update(Document query, Document update);
-
-        long delete(Map<String, Object> query);
-        long delete(Document query);
-
-        default void safeClose() {
-            Util.close(this);
-        }
-
-        class Factory {
-            public static Coll create(String url, String db, String coll, boolean compatibleValues,
-                                      boolean extractReferences,
-                                      boolean objectIdAsMap) {
-                try {
-                    return new MongoDBColl(url, db, coll, compatibleValues, extractReferences, objectIdAsMap);
-                } catch (Exception e) {
-                    throw new RuntimeException("Could not create MongoDBColl instance", e);
-                }
-            }
-
-            public static Coll create(String url, MongoDbConfig conf) {
-                try {
-                    return new MongoDBColl(url, conf);
-                } catch (Exception e) {
-                    throw new RuntimeException("Could not create MongoDBColl instance", e);
-                }
-            }
-        }
-    }
-
-    protected static MongoDBUtils.Coll getMongoColl(Supplier<Coll> action) {
-        Coll coll = null;
-        try {
-            coll = action.get();
-        } catch (NoClassDefFoundError e) {
-            throw new MissingDependencyException(String.format("Cannot find the jar into the plugins folder. \n" +
-                    "Please put these jar in the plugins folder :\n\n" +
-                    "bson-x.y.z.jar\n" +
-                    "\n" +
-                    "mongo-java-driver-x.y.z.jar\n" +
-                    "\n" +
-                    "mongodb-driver-x.y.z.jar\n" +
-                    "\n" +
-                    "mongodb-driver-core-x.y.z.jar\n" +
-                    "\n" +
-                    "jackson-annotations-x.y.z.jar\n\njackson-core-x.y.z.jar\n\njackson-databind-x.y.z.jar\n\nSee the documentation: https://neo4j.com/labs/apoc/4.4/database-integration/mongodb/"));
-        } catch (Exception e) {
-            throw new RuntimeException("Error during connection", e);
-        }
-        return coll;
-    }
 
     protected static Document getDocument(Object query) {
         if (query == null) {
@@ -88,5 +22,19 @@ public class MongoDBUtils {
         return Document.parse(query instanceof String
                 ? (String) query
                 : JsonUtil.writeValueAsString(query));
+    }
+
+    protected static List<Document> getDocuments(List<Map<String, Object>> pipeline) {
+        return pipeline.stream()
+                .map(MongoDBUtils::getDocument)
+                .collect(Collectors.toList());
+    }
+
+    protected static MongoDbConfig getMongoConfig(Map<String, Object> config) {
+        try {
+            return new MongoDbConfig(config);
+        } catch (NoClassDefFoundError e) {
+            throw new MissingDependencyException(MONGO_MISSING_DEPS_ERROR);
+        }
     }
 }

--- a/extended/src/main/java/apoc/mongodb/MongoDbCollInterface.java
+++ b/extended/src/main/java/apoc/mongodb/MongoDbCollInterface.java
@@ -1,0 +1,56 @@
+package apoc.mongodb;
+
+import apoc.util.Util;
+import org.bson.Document;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public interface MongoDbCollInterface extends Closeable {
+    Map<String, Object> first(Map<String, Object> params);
+
+    Stream<Map<String, Object>> all(Map<String, Object> query, Long skip, Long limit);
+
+    long count(Map<String, Object> query);
+    long count(Document query);
+
+    Stream<Map<String, Object>> aggregate(List<Document> pipeline);
+
+    Stream<Map<String, Object>> find(Map<String, Object> query, Map<String, Object> project, Map<String, Object> sort, Long skip, Long limit);
+    Stream<Map<String, Object>> find(Document query, Document project, Document sort, int skip, int limit);
+
+    void insert(List<Map<String, Object>> docs);
+    void insertDocs(List<Document> docs);
+
+    long update(Map<String, Object> query, Map<String, Object> update);
+    long update(Document query, Document update);
+
+    long delete(Map<String, Object> query);
+    long delete(Document query);
+
+    default void safeClose() {
+        Util.close(this);
+    }
+
+    class Factory {
+        public static MongoDbCollInterface create(String url, String db, String coll, boolean compatibleValues,
+                                  boolean extractReferences,
+                                  boolean objectIdAsMap) {
+            try {
+                return new MongoDBColl(url, db, coll, compatibleValues, extractReferences, objectIdAsMap);
+            } catch (Exception e) {
+                throw new RuntimeException("Could not create MongoDBColl instance", e);
+            }
+        }
+
+        public static MongoDbCollInterface create(String url, MongoDbConfig conf) {
+            try {
+                return new MongoDBColl(url, conf);
+            } catch (Exception e) {
+                throw new RuntimeException("Could not create MongoDBColl instance", e);
+            }
+        }
+    }
+}

--- a/extended/src/main/java/apoc/redis/RedisConfig.java
+++ b/extended/src/main/java/apoc/redis/RedisConfig.java
@@ -12,6 +12,11 @@ import java.util.Map;
 import static io.lettuce.core.RedisURI.DEFAULT_TIMEOUT;
 
 public class RedisConfig {
+    public static final String REDIS_MISSING_DEPS_ERROR = """
+            Cannot find the Redis client jar.
+            Please put the apoc-redis-dependencies-5.x.x-all.jar into plugin folder.
+            See the documentation: https://neo4j.com/labs/apoc/5/database-integration/redis/#redis-dependencies""";
+
     public enum Codec { 
         STRING(StringRedisConnection.class), BYTE_ARRAY(ByteArrayRedisConnection.class);
 
@@ -27,9 +32,7 @@ public class RedisConfig {
                 Constructor<?> constructor = redisConnectionClass.getConstructor(String.class, RedisConfig.class);
                 return (RedisConnection) constructor.newInstance(uri, redisConfig);
             } catch (NoClassDefFoundError e) {
-                throw new MissingDependencyException("Cannot find the Redis client jar. \n" +
-                        "Please put the lettuce-core-6.1.1.RELEASE.jar into plugin folder. \n" +
-                        "See the documentation: https://neo4j.com/labs/apoc/4.1/database-integration/redis/");
+                throw new MissingDependencyException(REDIS_MISSING_DEPS_ERROR);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/extended/src/test/java/apoc/MissingExtraDependenciesTest.java
+++ b/extended/src/test/java/apoc/MissingExtraDependenciesTest.java
@@ -1,0 +1,174 @@
+package apoc;
+
+import apoc.util.MissingDependencyException;
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestContainerUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.Session;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import static apoc.couchbase.Couchbase.COUCHBASE_MISSING_DEPS_ERROR;
+import static apoc.data.email.ExtractEmail.EMAIL_MISSING_DEPS_ERROR;
+import static apoc.export.parquet.ParquetConfig.PARQUET_MISSING_DEPS_ERROR;
+import static apoc.export.xls.ExportXlsHandler.XLS_MISSING_DEPS_ERROR;
+import static apoc.load.LoadHtml.SELENIUM_MISSING_DEPS_ERROR;
+import static apoc.mongodb.MongoDBUtils.MONGO_MISSING_DEPS_ERROR;
+import static apoc.redis.RedisConfig.REDIS_MISSING_DEPS_ERROR;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testCall;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test verifies that, if the `extra-dependencies` jars are not present, 
+ * the procedures that require them fail with {@link apoc.util.MissingDependencyException}
+ */
+public class MissingExtraDependenciesTest {
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.EXTENDED), true);
+        neo4jContainer.start();
+
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        session.close();
+        neo4jContainer.close();
+    }
+
+    @Test
+    public void testParquet() {
+        assertParquetFails("CALL apoc.export.parquet.all('test.parquet')");
+        assertParquetFails("CALL apoc.import.parquet('test.parquet')");
+        assertParquetFails("CALL apoc.load.parquet('test.parquet')");
+    }
+
+    private static void assertParquetFails(String query) {
+        assertFails(query, PARQUET_MISSING_DEPS_ERROR);
+    }
+
+    @Test
+    public void testCouchbase() {
+        assertCouchbaseFails("CALL apoc.couchbase.get('host', 'bucket', 'documentId')");
+        assertCouchbaseFails("CALL apoc.couchbase.exists('host', 'bucket', 'documentId')");
+        assertCouchbaseFails("CALL apoc.couchbase.remove('host', 'bucket', 'documentId')");
+        assertCouchbaseFails("CALL apoc.couchbase.replace('host', 'bucket', 'documentId', '{}')");
+        assertCouchbaseFails("CALL apoc.couchbase.insert('host', 'bucket', 'documentId', '{}')");
+        assertCouchbaseFails("CALL apoc.couchbase.upsert('host', 'bucket', 'documentId', '{}')");
+        assertCouchbaseFails("CALL apoc.couchbase.query('host', 'bucket', 'documentId')");
+        assertCouchbaseFails("CALL apoc.couchbase.posParamsQuery('host', 'bucket', 'documentId', [''])");
+        assertCouchbaseFails("CALL apoc.couchbase.namedParamsQuery('host', 'bucket', 'documentId', [''], [''])");
+        
+        Map<String, Object> params = Map.of("content", "zzz".getBytes());
+        assertFails("CALL apoc.couchbase.append('host', 'bucket', 'documentId', $content)", params, COUCHBASE_MISSING_DEPS_ERROR);
+        assertFails("CALL apoc.couchbase.prepend('host', 'bucket', 'documentId', $content)", params, COUCHBASE_MISSING_DEPS_ERROR);
+    }
+
+    private static void assertCouchbaseFails(String query) {
+        assertFails(query, COUCHBASE_MISSING_DEPS_ERROR);
+    }
+
+    @Test
+    public void testRedis() {
+        assertRedisFails("CALL apoc.redis.getSet('host', 'key', 'value')");
+        assertRedisFails("CALL apoc.redis.get('host', 'key')");
+        assertRedisFails("CALL apoc.redis.append('host', 'key', 1)");
+        assertRedisFails("CALL apoc.redis.incrby('host', 'key', 1)");
+        assertRedisFails("CALL apoc.redis.hdel('host', 'key', ['1'])");
+        assertRedisFails("CALL apoc.redis.hexists('host', 'key', 'field')");
+        assertRedisFails("CALL apoc.redis.hget('host', 'key', 1)");
+        assertRedisFails("CALL apoc.redis.hincrby('host', 'key', '1', 1)");
+        assertRedisFails("CALL apoc.redis.hgetall('host', 'key')");
+        assertRedisFails("CALL apoc.redis.hset('host', 'key', '1', '1')");
+        assertRedisFails("CALL apoc.redis.push('host', 'key', ['1'])");
+        assertRedisFails("CALL apoc.redis.pop('host', 'key')");
+        assertRedisFails("CALL apoc.redis.lrange('host', 'key', 1, 2)");
+        assertRedisFails("CALL apoc.redis.sadd('host', 'key', [1, 2])");
+        assertRedisFails("CALL apoc.redis.scard('host', 'key')");
+        assertRedisFails("CALL apoc.redis.spop('host', 'key')");
+        assertRedisFails("CALL apoc.redis.smembers('host', 'key')");
+        assertRedisFails("CALL apoc.redis.sunion('host', ['key'])");
+        assertRedisFails("CALL apoc.redis.zadd('host', 'key', ['key'])");
+        assertRedisFails("CALL apoc.redis.zcard('host', 'key')");
+        assertRedisFails("CALL apoc.redis.zrangebyscore('host', 'key', 1, 2)");
+        assertRedisFails("CALL apoc.redis.zrem('host', 'key', [1, 2])");
+        assertRedisFails("CALL apoc.redis.eval('host', 'key', 'type', ['keys'], ['vals'])");
+        assertRedisFails("CALL apoc.redis.copy('host', 'src', 'dest')");
+        assertRedisFails("CALL apoc.redis.exists('host', ['src'])");
+        assertRedisFails("CALL apoc.redis.exists('host', ['key'])");
+        assertRedisFails("CALL apoc.redis.persist('host', 'key')");
+        assertRedisFails("CALL apoc.redis.pttl('host', 'key')");
+        assertRedisFails("CALL apoc.redis.info('host')");
+        assertRedisFails("CALL apoc.redis.configGet('host', 'par')");
+        assertRedisFails("CALL apoc.redis.configSet('host', 'par', 'val')");
+    }
+
+    private static void assertRedisFails(String query) {
+        assertFails(query, REDIS_MISSING_DEPS_ERROR);
+    }
+
+    @Test
+    public void testMongoDb() {
+        assertMongoFails("CALL apoc.mongo.aggregate('uri', [{a: '1'}])");
+        assertMongoFails("CALL apoc.mongo.count('uri', 'query')");
+        assertMongoFails("CALL apoc.mongo.find('uri', 'query')");
+        assertMongoFails("CALL apoc.mongo.insert('uri', ['docs'])");
+        assertMongoFails("CALL apoc.mongo.update('uri', 'query', 'update')");
+        assertMongoFails("CALL apoc.mongo.delete('uri', 'query')");
+        assertMongoFails("CALL apoc.mongodb.get.byObjectId('uri', 'db', 'coll', 'objIdVal')");
+    }
+
+    private static void assertMongoFails(String query) {
+        assertFails(query, MONGO_MISSING_DEPS_ERROR);
+    }
+
+    @Test
+    public void testEmail() {
+        assertFails("RETURN apoc.data.email('email@gmail.com')", EMAIL_MISSING_DEPS_ERROR);
+    }
+
+    @Test
+    public void testSelenium() {
+        assertFails("CALL apoc.load.html('https://www.google.com/', {a: 'a'}, {browser: 'CHROME'})", SELENIUM_MISSING_DEPS_ERROR);
+        assertFails("CALL apoc.load.html('https://www.google.com/', {a: 'a'}, {browser: 'FIREFOX'})", SELENIUM_MISSING_DEPS_ERROR);
+    }
+
+    @Test
+    public void testXls() throws MalformedURLException {
+        String url = new URL("https://github.com/neo4j-contrib/neo4j-apoc-procedures/raw/5.13/extended/src/test/resources/load_test.xlsx")
+                .toString();
+        assertFails("CALL apoc.load.xls($url,'sheet')", Map.of("url", url), XLS_MISSING_DEPS_ERROR);
+        assertFails("CALL apoc.export.xls.all('file.xls', {})", XLS_MISSING_DEPS_ERROR);
+    }
+
+    private static void assertFails(String query, String errorMessage) {
+        assertFails(query, Map.of(), errorMessage, session);
+    }
+
+    private static void assertFails(String query, Map<String, Object> params, String errorMessage) {
+        assertFails(query, params, errorMessage, session);
+    }
+
+    public static void assertFails(String query, Map<String, Object> params, String errorMessage, Session session) {
+        try {
+            testCall(session, query, params, (row) ->fail("Should fail due to `MissingDependencyException`"));
+        } catch (RuntimeException e) {
+            String message = e.getMessage();
+            // String of type `apoc.util.MissingDependencyException: <errorMessage>`
+            String expected = "%s: %s".formatted(MissingDependencyException.class.getName(), errorMessage);
+            assertTrue("Actual error message is: " + message, message.contains(expected));
+        }
+    }
+
+}

--- a/extended/src/test/java/apoc/MissingExtraDependenciesTest.java
+++ b/extended/src/test/java/apoc/MissingExtraDependenciesTest.java
@@ -49,7 +49,19 @@ public class MissingExtraDependenciesTest {
 
     @Test
     public void testParquet() {
+        // export file
         assertParquetFails("CALL apoc.export.parquet.all('test.parquet')");
+        assertParquetFails("CALL apoc.export.parquet.data([], [], 'test.parquet')");
+        assertParquetFails("CALL apoc.export.parquet.graph({nodes: [], relationships: []}, 'test.parquet')");
+        assertParquetFails("CALL apoc.export.parquet.query('MATCH (n:ParquetNode) RETURN n', 'test.parquet')");
+
+        // export stream
+        assertParquetFails("CALL apoc.export.parquet.all.stream()");
+        assertParquetFails("CALL apoc.export.parquet.data.stream([], [])");
+        assertParquetFails("CALL apoc.export.parquet.graph.stream({nodes: [], relationships: []})");
+        assertParquetFails("CALL apoc.export.parquet.query.stream('MATCH (n:ParquetNode) RETURN n')");
+
+        // import and load
         assertParquetFails("CALL apoc.import.parquet('test.parquet')");
         assertParquetFails("CALL apoc.load.parquet('test.parquet')");
     }

--- a/extended/src/test/java/apoc/export/csv/ExportXlsTest.java
+++ b/extended/src/test/java/apoc/export/csv/ExportXlsTest.java
@@ -2,7 +2,7 @@ package apoc.export.csv;
 
 import apoc.export.xls.ExportXls;
 import apoc.graph.Graphs;
-import apoc.load.LoadXls;
+import apoc.load.xls.LoadXls;
 import apoc.util.CompressionAlgo;
 import apoc.util.CompressionConfig;
 import apoc.util.TestUtil;

--- a/extended/src/test/java/apoc/load/LoadExtendedSecurityTest.java
+++ b/extended/src/test/java/apoc/load/LoadExtendedSecurityTest.java
@@ -1,6 +1,7 @@
 package apoc.load;
 
 import apoc.ApocConfig;
+import apoc.load.xls.LoadXls;
 import apoc.util.FileUtils;
 import apoc.util.SensitivePathGenerator;
 import apoc.util.TestUtil;

--- a/extended/src/test/java/apoc/load/LoadXlsTest.java
+++ b/extended/src/test/java/apoc/load/LoadXlsTest.java
@@ -1,5 +1,6 @@
 package apoc.load;
 
+import apoc.load.xls.LoadXls;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;

--- a/extended/src/test/java/apoc/load/xls/LoadXlsTest.java
+++ b/extended/src/test/java/apoc/load/xls/LoadXlsTest.java
@@ -1,6 +1,5 @@
-package apoc.load;
+package apoc.load.xls;
 
-import apoc.load.xls.LoadXls;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;

--- a/extended/src/test/java/apoc/mongodb/MongoDBTest.java
+++ b/extended/src/test/java/apoc/mongodb/MongoDBTest.java
@@ -57,7 +57,7 @@ public class MongoDBTest extends MongoTestBase {
         boolean hasException = false;
         String url = new UrlResolver("mongodb", mongo.getContainerIpAddress(), mongo.getMappedPort(MONGO_DEFAULT_PORT))
                 .getUrl("mongodb", mongo.getContainerIpAddress());
-        try (MongoDBUtils.Coll coll = MongoDBUtils.Coll.Factory.create(url, "test", "person", false, true, false)) {
+        try (MongoDbCollInterface coll = MongoDbCollInterface.Factory.create(url, "test", "person", false, true, false)) {
             Map<String, Object> document = coll.first(Collections.emptyMap());
             assertTrue(document.get("_id") instanceof String);
             assertEquals("Andrea Santurbano", document.get("name"));
@@ -86,7 +86,7 @@ public class MongoDBTest extends MongoTestBase {
         boolean hasException = false;
         String url = new UrlResolver("mongodb", mongo.getContainerIpAddress(), mongo.getMappedPort(MONGO_DEFAULT_PORT))
                 .getUrl("mongodb", mongo.getContainerIpAddress());
-        try (MongoDBUtils.Coll coll = MongoDBUtils.Coll.Factory.create(url, "test", "person", false, false, false)) {
+        try (MongoDbCollInterface coll = MongoDbCollInterface.Factory.create(url, "test", "person", false, false, false)) {
             Map<String, Object> document = coll.first(MapUtil.map("name", "Andrea Santurbano"));
             assertTrue(document.get("_id") instanceof String);
             Collection<String> bought = (Collection<String>) document.get("bought");
@@ -102,7 +102,7 @@ public class MongoDBTest extends MongoTestBase {
         boolean hasException = false;
         String url = new UrlResolver("mongodb", mongo.getContainerIpAddress(), mongo.getMappedPort(MONGO_DEFAULT_PORT))
                 .getUrl("mongodb", mongo.getContainerIpAddress());
-        try (MongoDBUtils.Coll coll = MongoDBUtils.Coll.Factory.create(url, "test", "test", true, false, true)) {
+        try (MongoDbCollInterface coll = MongoDbCollInterface.Factory.create(url, "test", "test", true, false, true)) {
             Map<String, Object> document = coll.first(MapUtil.map("name", "testDocument"));
             assertNotNull(((Map<String, Object>) document.get("_id")).get("timestamp"));
             assertEquals(LocalDateTime.from(currentTime.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime()), document.get("date"));


### PR DESCRIPTION
Fixes 3831: Improve Parquet error in case of missing dependency

Messo il controllo in ParquetConfig in quanto viene richiamato da tutte le export, import e load

---

Il problema sembra presentarsi anche in Couchbase, presumibilmente a seguito di qualche modifica.
Potrei fixarlo in questa pr, aggiornando il testo della issue e creando magari un integration test dockerizzato che verifichi che, con il jar `extended` ma senza gli `extra-dependencies`, le procedure che ne hanno bisogno diano tutte `MissingDependencyException`?
Oppure faccio una issue a parte.


---
Per le apoc.nlp non è possibile creare il `MissingDependencyException`, in quanto utilizzano kotlin che è incluso in`nlp-dependencies` (ovvero: `implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'`), 
quindi se non lo mettiamo ricevo un `There is no procedure with the name apoc.nlp.. ` in quanto non compila proprio senza `kotlin-stdlib-jdk8`