### PR TITLE
Issue 3367: Test to check return type of apoc.any.rebind with a Path

### DIFF
--- a/extended/src/test/java/apoc/nodes/NodesExtendedTest.java
+++ b/extended/src/test/java/apoc/nodes/NodesExtendedTest.java
@@ -33,7 +33,7 @@ public class NodesExtendedTest {
     @Test
     public void rebind() {
         TestUtil.testCall(db, "CREATE (a:Foo)-[r1:MY_REL]->(b:Bar)-[r2:ANOTHER_REL]->(c:Baz) WITH a,b,c,r1,r2 \n" +
-                        "RETURN apoc.any.rebind({first: a, second: b, third: c, rels: [r1, r2]}) as rebind",
+                        "WITH apoc.any.rebind({first: a, second: b, third: c, rels: [r1, r2]}) as rebind RETURN rebind, valueType(rebind) as value",
                 (row) -> {
                     final Map<String, Object> rebind = (Map<String, Object>) row.get("rebind");
                     final List<Relationship> rels = (List<Relationship>) rebind.get("rels");
@@ -51,10 +51,29 @@ public class NodesExtendedTest {
                     final List<Path> rebindList = (List<Path>) row.get("rebind");
                     assertEquals(2, rebindList.size());
                     final Path firstPath = rebindList.get(0);
-                    assertPath(firstPath, List.of("Foo", "Bar"), List.of("MY_REL"));
+                    assertFooBarPath(firstPath);
                     final Path secondPath = rebindList.get(1);
                     assertPath(secondPath, List.of("Bar", "Baz"), List.of("ANOTHER_REL"));
                 });
+
+        // check via `valueType()` that, even if the return type is Object, 
+        // the output of a rebound Path is also a Path (i.e.: `PATH NOT NULL`)
+        TestUtil.testCall(db, """
+                        CREATE path=(a:Foo)-[r1:MY_REL]->(b:Bar)\s
+                        WITH apoc.path.rebind(path) AS rebind
+                        RETURN rebind, valueType(rebind) as valueType""",
+                (row) -> {
+                    final String valueType = (String) row.get("valueType");
+                    assertEquals("PATH NOT NULL", valueType);
+                    
+                    final Path pathRebind = (Path) row.get("rebind");
+                    assertFooBarPath(pathRebind);
+
+                });
+    }
+
+    private void assertFooBarPath(Path pathRebind) {
+        assertPath(pathRebind, List.of("Foo", "Bar"), List.of("MY_REL"));
     }
 
     private void assertPath(Path rebind, List<String> labels, List<String> relTypes) {


### PR DESCRIPTION
Issue 3367


Aggiunto test con [valueType](https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-valueType),
per verificare che non è necessaria la funzione `apoc.path.rebind`, in quanto facendo il rebind di un Path viene ritornato un Path ed il tipo di dato non viene perso anche se la funzione `apoc.path.rebind` ritorna Object.

Funziona anche con neo4j 4.4, usando la `apoc.meta.cypher.type`