### PR TITLE
Issue 3156: apoc.load.csv, failure despite failOnError:false

### DIFF
--- a/extended/src/main/java/apoc/load/LoadCsv.java
+++ b/extended/src/main/java/apoc/load/LoadCsv.java
@@ -29,6 +29,7 @@ import static java.util.Collections.emptyList;
 
 @Extended
 public class LoadCsv {
+    public static final String ERROR_WRONG_COL_SEPARATOR = ". Please check whether you included a delimiter before a column separator or forgot a column separator.";
 
     @Context
     public GraphDatabaseService db;
@@ -76,7 +77,7 @@ public class LoadCsv {
         String[] header = getHeader(csv, config);
         boolean checkIgnore = !config.getIgnore().isEmpty() || config.getMappings().values().stream().anyMatch(m -> m.ignore);
         return StreamSupport.stream(new CSVSpliterator(csv, header, url, config.getSkip(), config.getLimit(),
-                checkIgnore, config.getMappings(), config.getNullValues(), config.getResults(), config.getIgnoreErrors()), false)
+                checkIgnore, config.getMappings(), config.getNullValues(), config.getResults(), config.isFailOnError()), false)
                 .onClose(() -> closeReaderSafely(reader));
     }
 
@@ -107,10 +108,10 @@ public class LoadCsv {
         private final Map<String, Mapping> mapping;
         private final List<String> nullValues;
         private final EnumSet<Results> results;
-        private final boolean ignoreErrors;
+        private final boolean failOnError;
         long lineNo;
 
-        public CSVSpliterator(CSVReader csv, String[] header, String url, long skip, long limit, boolean ignore, Map<String, Mapping> mapping, List<String> nullValues, EnumSet<Results> results, boolean ignoreErrors) throws IOException, CsvValidationException {
+        public CSVSpliterator(CSVReader csv, String[] header, String url, long skip, long limit, boolean ignore, Map<String, Mapping> mapping, List<String> nullValues, EnumSet<Results> results, boolean failOnError) throws IOException, CsvValidationException {
             super(Long.MAX_VALUE, Spliterator.ORDERED);
             this.csv = csv;
             this.header = header;
@@ -119,7 +120,7 @@ public class LoadCsv {
             this.mapping = mapping;
             this.nullValues = nullValues;
             this.results = results;
-            this.ignoreErrors = ignoreErrors;
+            this.failOnError = failOnError;
             this.limit = ExtendedUtil.isSumOutOfRange(skip, limit) ? Long.MAX_VALUE : (skip + limit);
             lineNo = skip;
             while (skip-- > 0) {
@@ -129,6 +130,7 @@ public class LoadCsv {
 
         @Override
         public boolean tryAdvance(Consumer<? super CSVResult> action) {
+            final String message = "Error reading CSV from " + (url == null ? "binary" : " URL " + cleanUrl(url)) + " at " + lineNo;
             try {
                 String[] row = csv.readNext();
                 if (row != null && lineNo < limit) {
@@ -138,9 +140,16 @@ public class LoadCsv {
                 }
                 return false;
             } catch (IOException | CsvValidationException e) {
-                throw new RuntimeException("Error reading CSV from " + (url == null ? "binary" : " URL " + cleanUrl(url)) + " at " + lineNo, e);
+                if (failOnError) {
+                    throw new RuntimeException(message, e);
+                }
+                return true;
             } catch (ArrayIndexOutOfBoundsException e) {
-                throw new RuntimeException("Error reading CSV from " + (url == null ? "binary" : " URL " + cleanUrl(url)) + " at " + lineNo + ". Please check whether you included a delimiter before a column separator or forgot a column separator.");
+                if (failOnError) {
+                    String messageIdxOfBound = message + ERROR_WRONG_COL_SEPARATOR;
+                    throw new RuntimeException(messageIdxOfBound);
+                }
+                return true;
             }
         }
     }

--- a/extended/src/main/java/apoc/load/LoadCsv.java
+++ b/extended/src/main/java/apoc/load/LoadCsv.java
@@ -140,17 +140,21 @@ public class LoadCsv {
                 }
                 return false;
             } catch (IOException | CsvValidationException e) {
-                if (failOnError) {
-                    throw new RuntimeException(message, e);
-                }
-                return true;
+                RuntimeException exception = new RuntimeException(message, e);
+                return skipOrFail(exception);
             } catch (ArrayIndexOutOfBoundsException e) {
-                if (failOnError) {
-                    String messageIdxOfBound = message + ERROR_WRONG_COL_SEPARATOR;
-                    throw new RuntimeException(messageIdxOfBound);
-                }
-                return true;
+                String messageIdxOfBound = message + ERROR_WRONG_COL_SEPARATOR;
+                RuntimeException exception = new RuntimeException(messageIdxOfBound);
+                return skipOrFail(exception);
             }
+        }
+
+        private boolean skipOrFail(RuntimeException exception) {
+            if (failOnError) {
+                throw exception;
+            }
+            lineNo++;
+            return true;
         }
     }
 }

--- a/extended/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/extended/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -18,7 +18,6 @@ public class LoadCsvConfig extends CompressionConfig {
     // this is the same value as ICSVParser.DEFAULT_ESCAPE_CHARACTER
     public static final char DEFAULT_ESCAPE_CHAR = '\\';
 
-    private final boolean ignoreErrors;
     private char separator;
     private char arraySep;
     private char quoteChar;
@@ -42,7 +41,6 @@ public class LoadCsvConfig extends CompressionConfig {
         if (config == null) {
             config = Collections.emptyMap();
         }
-        ignoreErrors = Util.toBoolean(config.getOrDefault("ignoreErrors", false));
         separator = parseCharFromConfig(config, "sep", DEFAULT_SEP);
         arraySep = parseCharFromConfig(config, "arraySep", DEFAULT_ARRAY_SEP);
         quoteChar = parseCharFromConfig(config,"quoteChar", DEFAULT_QUOTE_CHAR);
@@ -118,10 +116,6 @@ public class LoadCsvConfig extends CompressionConfig {
 
     public char getEscapeChar() {
         return escapeChar;
-    }
-
-    public boolean getIgnoreErrors() {
-        return ignoreErrors;
     }
 
     public boolean isIgnoreQuotations() {

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -461,13 +461,13 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertEquals(1L, row.get("lineNo"));
                     assertEquals(List.of("Belem Tower","Lisbon","","30"), row.get("list"));
                     row = r.next();
-                    assertEquals(2L, row.get("lineNo"));
+                    assertEquals(3L, row.get("lineNo"));
                     assertEquals(List.of("","London","United Kingdom","96"), row.get("list"));
                     row = r.next();
-                    assertEquals(3L, row.get("lineNo"));
+                    assertEquals(4L, row.get("lineNo"));
                     assertEquals(List.of("Leaning tower","Pisa","Italia","56"), row.get("list"));
                     row = r.next();
-                    assertEquals(4L, row.get("lineNo"));
+                    assertEquals(5L, row.get("lineNo"));
                     assertEquals(List.of("Eiffel Tower","Paris","France","300"), row.get("list"));
                     assertFalse(r.hasNext());
                 });

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
+import static apoc.load.LoadCsv.ERROR_WRONG_COL_SEPARATOR;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.CompressionConfig.COMPRESSION;
 import static apoc.util.MapUtil.map;
@@ -446,6 +447,45 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertEquals(Util.map("name","Selina","age","18"), row.get("map"));
                     assertEquals(false, r.hasNext());
                 });
+    }
+
+    @Test
+    public void testIssue3156FailOnErrorFalse() {
+        String url = getUrlFileName("faulty.csv").getPath();
+        testResult(db, "CALL apoc.load.csv($url, {failOnError: false})", map("url",url),
+                (r) -> {
+                    Map<String, Object> row = r.next();
+                    assertEquals(0L, row.get("lineNo"));
+                    assertEquals(List.of("Galata Tower", "", "Turkey", "67"), row.get("list"));
+                    row = r.next();
+                    assertEquals(1L, row.get("lineNo"));
+                    assertEquals(List.of("Belem Tower","Lisbon","","30"), row.get("list"));
+                    row = r.next();
+                    assertEquals(2L, row.get("lineNo"));
+                    assertEquals(List.of("","London","United Kingdom","96"), row.get("list"));
+                    row = r.next();
+                    assertEquals(3L, row.get("lineNo"));
+                    assertEquals(List.of("Leaning tower","Pisa","Italia","56"), row.get("list"));
+                    row = r.next();
+                    assertEquals(4L, row.get("lineNo"));
+                    assertEquals(List.of("Eiffel Tower","Paris","France","300"), row.get("list"));
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void testIssue3156FailOnErrorTrue() {
+        String url = getUrlFileName("faulty.csv").getPath();
+        try {
+            testResult(db, "CALL apoc.load.csv($url, {failOnError: true})", map("url", url),
+                    Result::resultAsString);
+        } catch (RuntimeException e) {
+            String message = e.getMessage();
+            assertTrue("Actual error message is: " + message, 
+                    message.contains(ERROR_WRONG_COL_SEPARATOR)
+            );
+        }
+                
     }
 
     @Test public void testLoadCsvZip() throws Exception {

--- a/extended/src/test/resources/faulty.csv
+++ b/extended/src/test/resources/faulty.csv
@@ -1,0 +1,7 @@
+name,town,country,height
+Galata Tower,,Turkey,67
+Belem Tower,Lisbon,,30
+CN Tower,,553
+,London,United Kingdom,96
+Leaning tower,Pisa,Italia,56
+Eiffel Tower,Paris,France,300


### PR DESCRIPTION
Issue 3156

- Added `if (failOnError) { throws new RuntimeException(...)}` in CSVSpliterator
  - Consistent with [apoc.load.json](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/load/LoadJsonUtils.java#L68), it doesn't log anything
- Removed `ignoreErrors` config, which is unused, not documented anywhere, and can get confusing as there is the config `failOnError`.
