### PR TITLE
Make Bedrock chat body request compatible with OpenAI

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/bedrock.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/bedrock.adoc
@@ -42,6 +42,8 @@ instead of returning a generic `Object` as a result
 | model | String | see below | (This config is ignored with the `bedrock.list` proc.) The Bedrock Model 
 | path | String | "foundation-models" | (Valid only with the `bedrock.list`) The endpoint path. 
     It will create an endpoint of the type `https://bedrock.<regionConfigValue>.amazonaws.com/<path>`, i.e. with default `https://bedrock.us-east-1.amazonaws.com/foundation-models`
+| openAICompatible | String | false | To pass a body request compatible with OpenAI Chat Completions API, using the apoc.ml.bedrock.chat,
+    for example: `{role:"system", content:"Only answer with a single word"} ,{role:"user", content:"What planet do humans live on?"}`
 |===
 
 The `endpoint` config takes precedence over the `model` one.

--- a/docs/asciidoc/modules/ROOT/pages/ml/bedrock.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/bedrock.adoc
@@ -108,6 +108,31 @@ CALL apoc.ml.bedrock.chat([
 | {"stop_reason": "stop_sequence","completion": " Hello!"}
 |===
 
+
+We can use the config `openAICompatible: true`, to use a `message` body request consistent with the apoc.ml.openai.chat procedure.
+With this config, the `prompt` request will be placed in an entry `{content: '<promts>'}` 
+and will have a default "\n\nHuman:"` prefix and `\n\nAssistant:` suffix, if not present.
+
+For example, instead of:
+
+.apoc.ml.bedrock.chat (with openAICompatible: false)
+[source,cypher]
+----
+CALL apoc.ml.bedrock.chat(
+    [ {prompt: "\n\nHuman: Hello world\n\nAssistant:",max_tokens_to_sample: 200} ]
+)
+----
+
+we can execute this query (note that the `role:"system"` entry is optional, it is just to be consistent with the OpenAI body):
+
+.apoc.ml.bedrock.chat (with openAICompatible: true)
+[source,cypher]
+----
+CALL apoc.ml.bedrock.chat([
+    {role:"system", content:"Hello world"}
+])
+----
+
 === Text Completion API
 
 This procedure `apoc.ml.bedrock.completion` can continue/complete a given text.

--- a/extended/src/main/java/apoc/ml/bedrock/AwsSignatureV4Generator.java
+++ b/extended/src/main/java/apoc/ml/bedrock/AwsSignatureV4Generator.java
@@ -31,9 +31,9 @@ public class AwsSignatureV4Generator {
      */
     public static void calculateAuthorizationHeaders(
             BedrockConfig conf,
-            String bodyString
+            String bodyString,
+            Map<String, Object> headers
     ) throws MalformedURLException {
-        Map<String, Object> headers = conf.getHeaders();
         
         // skip if "Authorization" has already been valued
         if (headers.containsKey(AUTHORIZATION_KEY)) {

--- a/extended/src/main/java/apoc/ml/bedrock/Bedrock.java
+++ b/extended/src/main/java/apoc/ml/bedrock/Bedrock.java
@@ -10,6 +10,7 @@ import apoc.Description;
 import apoc.result.MapResult;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
@@ -51,19 +52,36 @@ public class Bedrock {
     @Procedure("apoc.ml.bedrock.chat")
     @Description("apoc.ml.bedrock.chat(messages, $conf) - prompts the completion API")
     public Stream<MapResult> chatCompletion(
-            @Name("messages") List<Map<String, String>> messages,
+            @Name("messages") List<Map<String, Object>> messages,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
 
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, ANTHROPIC_CLAUDE_V2);
 
-        BedrockConfig conf = new BedrockInvokeConfig(config);
-        
+        BedrockInvokeConfig conf = new BedrockInvokeConfig(config);
+
         return messages
                 .stream()
-                .flatMap(message -> executeRequestReturningMap(message, conf)
-                        .map(MapResult::new)
-                );
+                .flatMap(message -> {
+                    if (conf.isOpenAICompatible()) {
+                        transformOpenAiToBedrockRequestBody(message);
+                    }
+                    // default body value
+                    message.putIfAbsent("max_tokens_to_sample", 200);
+                    
+                    return executeRequestReturningMap(message, conf)
+                            .map(MapResult::new);
+                });
+    }
+
+    private void transformOpenAiToBedrockRequestBody(Map<String, Object> message) {
+        String content = (String) message.get("content");
+
+        content = StringUtils.prependIfMissing(content, "\n\nHuman:");
+        content = StringUtils.appendIfMissing(content, "\n\nAssistant:");
+        
+        message.clear();
+        message.put("prompt", content);
     }
 
     @Procedure("apoc.ml.bedrock.completion")
@@ -127,15 +145,15 @@ public class Bedrock {
                 bodyString = OBJECT_MAPPER.writeValueAsString(body);
             }
             
-            Map<String, Object> headers = conf.getHeaders();
+            Map<String, Object> headers = new HashMap<>(conf.getHeaders());
             headers.putIfAbsent("Content-Type", "application/json");
             headers.putIfAbsent("accept", "*/*");
 
             if (!headers.containsKey("Authorization")) {
-                AwsSignatureV4Generator.calculateAuthorizationHeaders(conf, bodyString);
+                AwsSignatureV4Generator.calculateAuthorizationHeaders(conf, bodyString, headers);
             }
 
-            return JsonUtil.loadJson(conf.getEndpoint(), conf.getHeaders(), bodyString, conf.getJsonPath(), true, List.of());
+            return JsonUtil.loadJson(conf.getEndpoint(), headers, bodyString, conf.getJsonPath(), true, List.of());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/extended/src/main/java/apoc/ml/bedrock/BedrockInvokeConfig.java
+++ b/extended/src/main/java/apoc/ml/bedrock/BedrockInvokeConfig.java
@@ -1,12 +1,18 @@
 package apoc.ml.bedrock;
 
+import apoc.util.Util;
+
 import java.util.Map;
 
 public class BedrockInvokeConfig extends BedrockConfig {
     public static final String MODEL = "model";
+    public static final String OPEN_AI_COMPATIBLE = "openAICompatible";
+
+    private final boolean openAICompatible;
 
     public BedrockInvokeConfig(Map<String, Object> config) {
         super(config);
+        this.openAICompatible = Util.toBoolean(config.get(OPEN_AI_COMPATIBLE));
     }
 
     @Override
@@ -20,5 +26,9 @@ public class BedrockInvokeConfig extends BedrockConfig {
     @Override
     String getDefaultMethod() {
         return "POST";
+    }
+
+    public boolean isOpenAICompatible() {
+        return openAICompatible;
     }
 }

--- a/extended/src/test/java/apoc/ml/bedrock/BedrockIT.java
+++ b/extended/src/test/java/apoc/ml/bedrock/BedrockIT.java
@@ -1,11 +1,13 @@
 package apoc.ml.bedrock;
 
 import apoc.util.TestUtil;
+import apoc.util.collection.Iterators;
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -20,6 +22,7 @@ import static apoc.ml.bedrock.BedrockConfig.METHOD_KEY;
 import static apoc.ml.bedrock.BedrockConfig.SECRET_KEY;
 import static apoc.ml.bedrock.BedrockGetModelsConfig.*;
 import static apoc.ml.bedrock.BedrockInvokeConfig.MODEL;
+import static apoc.ml.bedrock.BedrockInvokeConfig.OPEN_AI_COMPATIBLE;
 import static apoc.ml.bedrock.BedrockTestUtil.*;
 import static apoc.ml.bedrock.BedrockUtil.*;
 import static apoc.util.TestUtil.testCall;
@@ -46,8 +49,8 @@ public class BedrockIT {
         
         keyId = System.getenv(keyIdEnv);
         secretKey = System.getenv(secretKeyEnv);
-        assumeNotNull(keyIdEnv + "environment not configured", keyId);
-        assumeNotNull(secretKeyEnv + " environment configured", secretKey);
+        assumeNotNull(keyIdEnv + " environment not configured", keyId);
+        assumeNotNull(secretKeyEnv + "  environment configured", secretKey);
         
         TestUtil.registerProcedure(db, Bedrock.class);
     }
@@ -120,7 +123,7 @@ public class BedrockIT {
     @Test
     public void testCustomWithAnthropicClaude() {
         testCall(db, BEDROCK_CUSTOM_PROC,
-                Map.of("body", ANTHROPIC_CLAUDE_BODY,
+                Map.of("body", ANTHROPIC_CLAUDE_CUSTOM_BODY,
                         "conf", Map.of(MODEL, "anthropic.claude-v1")
                 ),
         r -> {
@@ -198,15 +201,34 @@ public class BedrockIT {
     }
 
     @Test
-    public void testChatCompletion() {
+    public void testChatCompletionWithOpenAICompatibleTrue() {
+        testResult(db, """
+                        CALL apoc.ml.bedrock.chat([
+                            {role:"system", content:"Only answer with a single word"}
+                            ,{role:"user", content:"What planet do humans live on?"}
+                        ], $conf)""",
+                Map.of("conf", Map.of(OPEN_AI_COMPATIBLE, true)),
+                this::chatCompletionAssertions);
+    }
+
+    @Test
+    public void testChatCompletionWithOpenAICompatibleFalse() {
+        List<Map<String, String>> body = List.of(
+                Map.of("prompt", "\n\nHuman: Hello world\n\nAssistant:"),
+                Map.of("prompt", "\n\nHuman: Ciao mondo\n\nAssistant:")
+        );
         testResult(db, "CALL apoc.ml.bedrock.chat($body)",
-                Map.of("body", List.of(ANTHROPIC_CLAUDE_BODY, ANTHROPIC_CLAUDE_BODY)),
-                r -> {
-            r.<Map<String,Object>>columnAs("value").forEachRemaining(row -> {
-                        assertNotNull(row.get("completion"));
-                        assertNotNull(row.get("stop_reason"));
-                    });
-                });
+                Map.of("body", body),
+                this::chatCompletionAssertions);
+    }
+
+    private void chatCompletionAssertions(Result r) {
+        List<Map<String, Object>> values = Iterators.asList(r.columnAs("value"));
+        assertEquals(2, values.size());
+        values.forEach(row -> {
+            assertNotNull(row.get("completion"));
+            assertNotNull(row.get("stop_reason"));
+        });
     }
 
     @Test

--- a/extended/src/test/java/apoc/ml/bedrock/BedrockTestUtil.java
+++ b/extended/src/test/java/apoc/ml/bedrock/BedrockTestUtil.java
@@ -18,7 +18,8 @@ public class BedrockTestUtil {
             "temperature", 0,
             "topP", 1.0
     );
-    public static final Map<String, Object> ANTHROPIC_CLAUDE_BODY = Map.of(
+            
+    public static final Map<String, Object> ANTHROPIC_CLAUDE_CUSTOM_BODY = Map.of(
             "prompt", "\n\nHuman: Hello world\n\nAssistant:",
             "max_tokens_to_sample", 300,
             "temperature", 0.5,


### PR DESCRIPTION
- Michael ha chiesto queste modifiche:
```
hmm can we provide a default for max_tokens_to_sample if it's left off?


for the prompts I was wondering if we could auto-generate them (as an option)
so that you could use the same [{role:"system", ...},{role:"user"},{role:"assistant"}] like in the other APIs
```


- Cambiato `List<Map<String, String>> messages` in `List<Map<String, Object>> messages` perché `max_tokens_to_sample` è un intero. 
NB: Nonostante prima fosse un Map<String, String>, era possibile passare una mappa string oggetti (p.e. `{prompt: '.....',max_tokens_to_sample: 300}`, Neo4j non dava errori per qualche motivo.


- Inoltre, cambiato `calculateAuthorizationHeaders` in modo da accettare `headers = new HashMap<>(conf.getHeaders())` invece di `conf.getHeaders()`,
perché altrimenti nel caso di `testChatCompletionWithOpenAICompatibleTrue`, calcolerebbe l'Authorization la prima volta (ovvero con `{role:"system", content:"Only answer with a single word"}`), ma lo salterebbe la seconda volta (ovvero con `{role:"user", content:"What planet do humans live on?"}`) [tramite questo controllo](https://github.com/vga91/neo4j-apoc-procedures/compare/dev...vga91:neo4j-apoc-procedures:bedrock-body-request-consistent-with-openai?expand=1#diff-082ceffb302653e7b751c52da90e1c0c61831828f977c216e0b404fb4b91dc52R39), ma questo darebbe un 403 in quanto la signature non va bene per quel body