### PR TITLE
test submodules ignore only in dev

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -46,7 +46,7 @@ shadowJar {
 // to init the submodule in case of new submodule or refresh it if exists, every time we compile 
 task gitSubmoduleLoad {
     def execute = ["bash", "-c", "git submodule status apoc-core | grep -q \"^-\" && rm -r apoc-core && git submodule update --init apoc-core || git submodule update --remote apoc-core; " +
-            "git update-index --assume-unchanged apoc-core"]
+            "git config --file .gitmodules --get submodule.apoc-core.branch | grep -wq 'dev' && git update-index --assume-unchanged apoc-core || git update-index --assume-unchanged apoc-core"]
             .execute()
     execute.waitForProcessOutput(System.out, System.err)
 }


### PR DESCRIPTION
With this change, in 5.x the `apoc-core` submodule stuff is pushed every time we compile.
If the branch is dev, the apoc-core is ignored, like current behavior.

See https://github.com/vga91/neo4j-apoc-procedures/pull/407 5.x analog.