### PR TITLE
Issue 3858

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -151,9 +151,9 @@ CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $a
 |===
 
 
-=== OpenML API
+=== OpenLM API
 
-We can also call the Completion API of HuggingFace and Cohere, similar to the https://github.com/r2d4/openlm[OpenML] library, as below.
+We can also call the Completion API of HuggingFace and Cohere, similar to the https://github.com/r2d4/openlm[OpenLM] library, as below.
 
 For the https://huggingface.co/[HuggingFace API], we have to define the config `apiType: 'HUGGINGFACE'`, since we have to transform the body request.
 Unlike the default behavior, under-the-hood the `/completions` suffix is not added to the URL.
@@ -232,14 +232,14 @@ CALL apoc.ml.openai.embedding(['Some Text'], $anyScaleApiKey,
 Or via https://localai.io/[LocalAI APIs] (note that the apiKey is `null` by default):
 [source,cypher]
 ----
-CALL apoc.ml.openai.embedding(['Some Text'], null, 
+CALL apoc.ml.openai.embedding(['Some Text'], "ignored", 
 {endpoint: 'http://localhost:8080/v1', model: 'text-embedding-ada-002'})
 ----
 
-Or also, by using https://github.com/fardjad/node-llmatic[LLMatic Library] (note that the apiKey is `null` by default):
+Or also, by using https://github.com/fardjad/node-llmatic[LLMatic Library]:
 [source,cypher]
 ----
-CALL apoc.ml.openai.embedding(['Some Text'], null, 
+CALL apoc.ml.openai.embedding(['Some Text'], "ignored", 
 {endpoint: 'http://localhost:3000/v1', model: 'thenlper/gte-large'})
 ----
 

--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -6,7 +6,7 @@
 ====
 You need to acquire an https://platform.openai.com/account/api-keys[OpenAI API key^] to use these procedures. Using them will incur costs on your OpenAI account. You can set the api key globally by defining the `apoc.openai.key` configuration in `apoc.conf`
 
-But we can also use these procedures to call OpenAI-compatible APIs, which will therefore have their own API key (or even without API Key). 
+But you can also use these procedures to call OpenAI-compatible APIs, which will therefore have their own API key (or even without API Key). 
 See the paragraph <<openai_compatible_provider>> below.
 ====
 
@@ -153,9 +153,9 @@ CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $a
 
 === OpenML API
 
-we can also call the Completion API of HuggingFace and Cohere, similar to the https://github.com/r2d4/openlm[OpenML] library, as below.
+We can also call the Completion API of HuggingFace and Cohere, similar to the https://github.com/r2d4/openlm[OpenML] library, as below.
 
-For the https://huggingface.co/models[HuggingFace API], we have to define the config `apiType: 'HUGGINGFACE'`, since we have to transform the body request.
+For the https://huggingface.co/[HuggingFace API], we have to define the config `apiType: 'HUGGINGFACE'`, since we have to transform the body request.
 Unlike the default behavior, under-the-hood the `/completions` suffix is not added to the URL.
 
 For example:
@@ -229,14 +229,14 @@ CALL apoc.ml.openai.embedding(['Some Text'], $anyScaleApiKey,
 ----
 
 
-The https://localai.io/[LocalAI API] (note that the apiKey is `null` by default):
+Or via https://localai.io/[LocalAI APIs] (note that the apiKey is `null` by default):
 [source,cypher]
 ----
 CALL apoc.ml.openai.embedding(['Some Text'], null, 
 {endpoint: 'http://localhost:8080/v1', model: 'text-embedding-ada-002'})
 ----
 
-The https://github.com/fardjad/node-llmatic[LLMatic] (note that the apiKey is `null` by default):
+Or also, by using https://github.com/fardjad/node-llmatic[LLMatic Library] (note that the apiKey is `null` by default):
 [source,cypher]
 ----
 CALL apoc.ml.openai.embedding(['Some Text'], null, 

--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -2,17 +2,21 @@
 = OpenAI API Access
 :description: This section describes procedures that can be used to access the OpenAI API.
 
-NOTE: You need to acquire an https://platform.openai.com/account/api-keys[OpenAI API key^] to use these procedures. Using them will incur costs on your OpenAI account. You can set the api key globally by defining the `apoc.openai.key` configuration in `apoc.conf`
+[NOTE]
+====
+You need to acquire an https://platform.openai.com/account/api-keys[OpenAI API key^] to use these procedures. Using them will incur costs on your OpenAI account. You can set the api key globally by defining the `apoc.openai.key` configuration in `apoc.conf`
 
-
+But we can also use these procedures to call OpenAI-compatible APIs, which will therefore have their own API key (or even without API Key). 
+See the paragraph <<openai_compatible_provider>> below.
+====
 
 All the following procedures can have the following APOC config, i.e. in `apoc.conf` or via docker env variable
 .Apoc configuration
 |===
 |key | description | default
-| apoc.ml.openai.type | "AZURE" or "OPENAI", indicates whether the API is Azure or not | "OPENAI" 
+| apoc.ml.openai.type | "AZURE", "HUGGINGFACE", "OPENAI", indicates whether the API is Azure, HuggingFace or another one | "OPENAI" 
 | apoc.ml.openai.url | the OpenAI endpoint base url | https://api.openai.com/v1 
-    (or empty string if `apoc.ml.openai.type=AZURE`)
+    (or empty string if `apoc.ml.openai.type=<AZURE OR HUGGINGFACE>`)
 | apoc.ml.azure.api.version | in case of `apoc.ml.openai.type=AZURE`, indicates the `api-version` to be passed after the `?api-version=` url
 |===
 
@@ -27,6 +31,10 @@ If present, they take precedence over the analogous APOC configs.
 | apiType | analogous to `apoc.ml.openai.type` APOC config
 | endpoint | analogous to `apoc.ml.openai.url` APOC config
 | apiVersion | analogous to `apoc.ml.azure.api.version` APOC config
+| path | To customize the url portion added to the base url (defined by the `endpoint` config).
+    By default, is `/embeddings`, `/completions` and `/chat/completions` for respectively the `apoc.ml.openai.embedding`, `apoc.ml.openai.completion` and `apoc.ml.openai.chat` procedures.
+| jsonPath | To customize https://github.com/json-path/JsonPath[JSONPath] of the response. 
+    The default is `$` for the `apoc.ml.openai.chat` and `apoc.ml.openai.completion` procedures, and `$.data` for the `apoc.ml.openai.embedding` procedure.
 |===
 
 
@@ -142,6 +150,29 @@ CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $a
 | value | result entry from OpenAI (containing)
 |===
 
+
+=== OpenML API
+
+we can also call the Completion API of HuggingFace and Cohere, similar to the https://github.com/r2d4/openlm[OpenML] library, as below.
+
+For the https://huggingface.co/models[HuggingFace API], we have to define the config `apiType: 'HUGGINGFACE'`, since we have to transform the body request.
+Unlike the default behavior, under-the-hood the `/completions` suffix is not added to the URL.
+
+For example:
+[source,cypher]
+----
+CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $huggingFaceApiKey, 
+{endpoint: 'https://api-inference.huggingface.co/models/gpt2', apiType: 'HUGGINGFACE', model: 'gpt2'})
+----
+
+Or also, by using the https://docs.cohere.com/docs[Cohere API], where we have to define `path: '''` not to add the `/completions` suffix to the URL:
+[source,cypher]
+----
+CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $cohereApiKey, 
+{endpoint: 'https://api.cohere.ai/v1/generate', path: '', model: 'command'})
+----
+
+
 == Chat Completion API
 
 This procedure `apoc.ml.openai.chat` takes a list of maps of chat exchanges between assistant and user (with optional system message), and will return the next message in the flow.
@@ -182,6 +213,35 @@ choices=[{finish_reason="stop", index=0, message={role="assistant", content="Ear
 |name | description
 | value | result entry from OpenAI (containing created, id, model, object, usage(tokens), choices(message, index, finish_reason))
 |===
+
+
+[[openai_compatible_provider]]
+== OpenAI-compatible provider
+
+We can also use these procedures to call OpenAI-compatible APIs,
+by defining the `endpoint` config, and possibly the `model`, `path` and `jsonPath` configs.
+
+For example, we can call the https://app.endpoints.anyscale.com/[Anyscale Endpoints]:
+[source,cypher]
+----
+CALL apoc.ml.openai.embedding(['Some Text'], $anyScaleApiKey, 
+{endpoint: 'https://api.endpoints.anyscale.com/v1', model: 'thenlper/gte-large'})
+----
+
+
+The https://localai.io/[LocalAI API] (note that the apiKey is `null` by default):
+[source,cypher]
+----
+CALL apoc.ml.openai.embedding(['Some Text'], null, 
+{endpoint: 'http://localhost:8080/v1', model: 'text-embedding-ada-002'})
+----
+
+The https://github.com/fardjad/node-llmatic[LLMatic] (note that the apiKey is `null` by default):
+[source,cypher]
+----
+CALL apoc.ml.openai.embedding(['Some Text'], null, 
+{endpoint: 'http://localhost:3000/v1', model: 'thenlper/gte-large'})
+----
 
 
 == Query with natural language

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -50,7 +50,10 @@ public class OpenAI {
         }
     }
 
-    static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
+    // TODO - path, jsonPath,
+//    static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
+    
+    static Stream<Object> executeRequest(/*OpenAIRequestHandler apiType, */String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
         String apiTypeString = (String) configuration.getOrDefault(API_TYPE_CONF_KEY,
                 apocConfig.getString(APOC_ML_OPENAI_TYPE, OpenAIRequestHandler.Type.OPENAI.name())
         );
@@ -60,8 +63,6 @@ public class OpenAI {
         
         apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
         checkApiKey(apiKey, endpoint);
-
-
         
         final Map<String, Object> headers = new HashMap<>();
         headers.put("Content-Type", "application/json");
@@ -70,10 +71,12 @@ public class OpenAI {
         var config = new HashMap<>(configuration);
         // we remove these keys from config, since the json payload is calculated starting from the config map
         Stream.of(ENDPOINT_CONF_KEY, API_TYPE_CONF_KEY, API_VERSION_CONF_KEY, APIKEY_CONF_KEY).forEach(config::remove);
-        config.putIfAbsent("model", model);
+        
+        apiType.addBodyEntries(key, inputs, model, config);
+//        config.putIfAbsent("model", model);
         
         // TODO - DELETE
-        config.put("inputs", "non so");
+//        config.put("inputs", "non so");
         
 //        config.putAll(inputs
 //        config.put(key, inputs);
@@ -84,7 +87,17 @@ public class OpenAI {
         // eg: https://my-resource.openai.azure.com/openai/deployments/apoc-embeddings-model
         // therefore is better to join the not-empty path pieces
         var url = apiType.getFullUrl(path, configuration, apocConfig);
-        return JsonUtil.loadJson(url, headers, payload, "$[0]", true, List.of(), urlAccessChecker);
+        return JsonUtil.loadJson(url, headers, payload, apiType.adaptJsonPath(jsonPath), true, List.of(), urlAccessChecker);
+//        return JsonUtil.loadJson(url, headers, payload, "$[0]", true, List.of(), urlAccessChecker);
+    }
+
+    private OpenAIRequestHandler getOpenAIRequestHandler(Map<String, Object> configuration) {
+        String apiTypeString = (String) configuration.getOrDefault(API_TYPE_CONF_KEY,
+                apocConfig.getString(APOC_ML_OPENAI_TYPE, OpenAIRequestHandler.Type.OPENAI.name())
+        );
+        OpenAIRequestHandler apiType = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH))
+                .get();
+        return apiType;
     }
 
     private static void checkApiKey(String apiKey, String endpoint) {
@@ -115,6 +128,7 @@ public class OpenAI {
       "model": "text-embedding-ada-002",
       "usage": { "prompt_tokens": 8, "total_tokens": 8 } }
     */
+//        OpenAIRequestHandler apiType = getOpenAIRequestHandler(configuration);
         Stream<Object> resultStream = executeRequest(apiKey, configuration, "embeddings", "text-embedding-ada-002", "input", texts, "$.data", apocConfig, urlAccessChecker);
         return resultStream
                 .flatMap(v -> ((List<Map<String, Object>>) v).stream())
@@ -123,7 +137,6 @@ public class OpenAI {
                     return new EmbeddingResult(index, texts.get(index.intValue()), (List<Double>) m.get("embedding"));
                 });
     }
-
 
     @Procedure("apoc.ml.openai.completion")
     @Description("apoc.ml.openai.completion(prompt, api_key, configuration) - prompts the completion API")
@@ -136,6 +149,7 @@ public class OpenAI {
       "usage": { "prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12 }
     }
     */
+//        OpenAIRequestHandler apiType = getOpenAIRequestHandler(configuration);
         return executeRequest(apiKey, configuration, "completions", "gpt-3.5-turbo-instruct", "prompt", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
     }
@@ -143,6 +157,7 @@ public class OpenAI {
     @Procedure("apoc.ml.openai.chat")
     @Description("apoc.ml.openai.chat(messages, api_key, configuration]) - prompts the completion API")
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("api_key") String apiKey, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+//        OpenAIRequestHandler apiType = getOpenAIRequestHandler(configuration);
         return executeRequest(apiKey, configuration, "chat/completions", "gpt-3.5-turbo", "messages", messages, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
         // https://platform.openai.com/docs/api-reference/chat/create

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -61,12 +61,11 @@ public class OpenAI {
                 .get();
 
         String endpoint = apiType.getEndpoint(configuration, apocConfig);
+        apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
+        checkApiKey(apiKey, endpoint);
         
         jsonPath = (String) configuration.getOrDefault(JSON_PATH_CONF_KEY, jsonPath);
         path = (String) configuration.getOrDefault(PATH_CONF_KEY, path);
-        
-        apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
-        checkApiKey(apiKey, endpoint);
         
         final Map<String, Object> headers = new HashMap<>();
         headers.put("Content-Type", "application/json");

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -31,6 +31,7 @@ public class OpenAI {
     public static final String API_VERSION_CONF_KEY = "apiVersion";
     public static final String JSON_PATH_CONF_KEY = "jsonPath";
     public static final String PATH_CONF_KEY = "path";
+    public static final String MODEL_CONF_KEY = "model";
 
     @Context
     public ApocConfig apocConfig;
@@ -61,6 +62,7 @@ public class OpenAI {
         );
         OpenAIRequestHandler apiType = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH))
                 .get();
+
         String endpoint = apiType.getEndpoint(configuration, apocConfig);
         
         // TODO - aggiungere config per jsonPath
@@ -144,6 +146,7 @@ public class OpenAI {
                     return new EmbeddingResult(index, texts.get(index.intValue()), (List<Double>) m.get("embedding"));
                 });
     }
+
 
     @Procedure("apoc.ml.openai.completion")
     @Description("apoc.ml.openai.completion(prompt, api_key, configuration) - prompts the completion API")

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -54,16 +54,32 @@ public class OpenAI {
     }
 
     static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
+        apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
+        if (apiKey == null || apiKey.isBlank())
+            throw new IllegalArgumentException("API Key must not be empty");
+
         String apiTypeString = (String) configuration.getOrDefault(API_TYPE_CONF_KEY,
                 apocConfig.getString(APOC_ML_OPENAI_TYPE, OpenAIRequestHandler.Type.OPENAI.name())
         );
-        OpenAIRequestHandler apiType = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH))
-                .get();
-
-        String endpoint = apiType.getEndpoint(configuration, apocConfig);
-        apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
-        checkApiKey(apiKey, endpoint);
+        OpenAIRequestHandler.Type type = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH));
         
+        var config = new HashMap<>(configuration);
+        // we remove these keys from config, since the json payload is calculated starting from the config map
+        Stream.of(ENDPOINT_CONF_KEY, API_TYPE_CONF_KEY, API_VERSION_CONF_KEY, APIKEY_CONF_KEY).forEach(config::remove);
+        
+        switch (type) {
+            case HUGGINGFACE -> {
+                config.putIfAbsent("inputs", inputs);
+                jsonPath = "$[0]";
+            }
+            default -> {
+                config.putIfAbsent(MODEL_CONF_KEY, model);
+                config.put(key, inputs);
+            }
+        }
+        
+        OpenAIRequestHandler apiType = type.get();
+
         jsonPath = (String) configuration.getOrDefault(JSON_PATH_CONF_KEY, jsonPath);
         path = (String) configuration.getOrDefault(PATH_CONF_KEY, path);
         
@@ -71,29 +87,13 @@ public class OpenAI {
         headers.put("Content-Type", "application/json");
         apiType.addApiKey(headers, apiKey);
 
-        var config = new HashMap<>(configuration);
-        // we remove these keys from config, since the json payload is calculated starting from the config map
-        Stream.of(ENDPOINT_CONF_KEY, API_TYPE_CONF_KEY, API_VERSION_CONF_KEY, APIKEY_CONF_KEY).forEach(config::remove);
-        
-        apiType.addBodyEntries(key, inputs, model, config);
-
         String payload = JsonUtil.OBJECT_MAPPER.writeValueAsString(config);
         
         // new URL(endpoint), path) can produce a wrong path, since endpoint can have for example embedding,
         // eg: https://my-resource.openai.azure.com/openai/deployments/apoc-embeddings-model
         // therefore is better to join the not-empty path pieces
         var url = apiType.getFullUrl(path, configuration, apocConfig);
-        return JsonUtil.loadJson(url, headers, payload, apiType.getJsonPath(jsonPath), true, List.of(), urlAccessChecker);
-    }
-
-    private static void checkApiKey(String apiKey, String endpoint) {
-        // with localhost URLs, the API Key is not always mandatory
-        if (isLocalAddress(endpoint)) {
-            return;
-        }
-        if (apiKey == null || apiKey.isBlank()) {
-            throw new IllegalArgumentException("API Key must not be empty");
-        }
+        return JsonUtil.loadJson(url, headers, payload, jsonPath, true, List.of(), urlAccessChecker);
     }
 
     @Procedure("apoc.ml.openai.embedding")

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -53,10 +53,7 @@ public class OpenAI {
         }
     }
 
-    // TODO - path, jsonPath,
-//    static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
-    
-    static Stream<Object> executeRequest(/*OpenAIRequestHandler apiType, */String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
+    static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
         String apiTypeString = (String) configuration.getOrDefault(API_TYPE_CONF_KEY,
                 apocConfig.getString(APOC_ML_OPENAI_TYPE, OpenAIRequestHandler.Type.OPENAI.name())
         );
@@ -65,8 +62,6 @@ public class OpenAI {
 
         String endpoint = apiType.getEndpoint(configuration, apocConfig);
         
-        // TODO - aggiungere config per jsonPath
-        // TODO - aggiungere config per path
         jsonPath = (String) configuration.getOrDefault(JSON_PATH_CONF_KEY, jsonPath);
         path = (String) configuration.getOrDefault(PATH_CONF_KEY, path);
         
@@ -82,13 +77,6 @@ public class OpenAI {
         Stream.of(ENDPOINT_CONF_KEY, API_TYPE_CONF_KEY, API_VERSION_CONF_KEY, APIKEY_CONF_KEY).forEach(config::remove);
         
         apiType.addBodyEntries(key, inputs, model, config);
-//        config.putIfAbsent("model", model);
-        
-        // TODO - DELETE
-//        config.put("inputs", "non so");
-        
-//        config.putAll(inputs
-//        config.put(key, inputs);
 
         String payload = JsonUtil.OBJECT_MAPPER.writeValueAsString(config);
         
@@ -96,17 +84,7 @@ public class OpenAI {
         // eg: https://my-resource.openai.azure.com/openai/deployments/apoc-embeddings-model
         // therefore is better to join the not-empty path pieces
         var url = apiType.getFullUrl(path, configuration, apocConfig);
-        return JsonUtil.loadJson(url, headers, payload, apiType.adaptJsonPath(jsonPath), true, List.of(), urlAccessChecker);
-//        return JsonUtil.loadJson(url, headers, payload, "$[0]", true, List.of(), urlAccessChecker);
-    }
-
-    private OpenAIRequestHandler getOpenAIRequestHandler(Map<String, Object> configuration) {
-        String apiTypeString = (String) configuration.getOrDefault(API_TYPE_CONF_KEY,
-                apocConfig.getString(APOC_ML_OPENAI_TYPE, OpenAIRequestHandler.Type.OPENAI.name())
-        );
-        OpenAIRequestHandler apiType = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH))
-                .get();
-        return apiType;
+        return JsonUtil.loadJson(url, headers, payload, apiType.getJsonPath(jsonPath), true, List.of(), urlAccessChecker);
     }
 
     private static void checkApiKey(String apiKey, String endpoint) {
@@ -114,11 +92,9 @@ public class OpenAI {
         if (isLocalAddress(endpoint)) {
             return;
         }
-//        if (apiType.equals(OpenAIRequestHandler.Type.LOCALAI.get())) {
-//            return;
-//        }
-        if (apiKey == null || apiKey.isBlank())
+        if (apiKey == null || apiKey.isBlank()) {
             throw new IllegalArgumentException("API Key must not be empty");
+        }
     }
 
     @Procedure("apoc.ml.openai.embedding")
@@ -137,7 +113,6 @@ public class OpenAI {
       "model": "text-embedding-ada-002",
       "usage": { "prompt_tokens": 8, "total_tokens": 8 } }
     */
-//        OpenAIRequestHandler apiType = getOpenAIRequestHandler(configuration);
         Stream<Object> resultStream = executeRequest(apiKey, configuration, "embeddings", "text-embedding-ada-002", "input", texts, "$.data", apocConfig, urlAccessChecker);
         return resultStream
                 .flatMap(v -> ((List<Map<String, Object>>) v).stream())
@@ -159,7 +134,6 @@ public class OpenAI {
       "usage": { "prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12 }
     }
     */
-//        OpenAIRequestHandler apiType = getOpenAIRequestHandler(configuration);
         return executeRequest(apiKey, configuration, "completions", "gpt-3.5-turbo-instruct", "prompt", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
     }
@@ -167,7 +141,6 @@ public class OpenAI {
     @Procedure("apoc.ml.openai.chat")
     @Description("apoc.ml.openai.chat(messages, api_key, configuration]) - prompts the completion API")
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("api_key") String apiKey, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-//        OpenAIRequestHandler apiType = getOpenAIRequestHandler(configuration);
         return executeRequest(apiKey, configuration, "chat/completions", "gpt-3.5-turbo", "messages", messages, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
         // https://platform.openai.com/docs/api-reference/chat/create

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -29,7 +29,9 @@ public class OpenAI {
     public static final String APIKEY_CONF_KEY = "apiKey";
     public static final String ENDPOINT_CONF_KEY = "endpoint";
     public static final String API_VERSION_CONF_KEY = "apiVersion";
-    
+    public static final String JSON_PATH_CONF_KEY = "jsonPath";
+    public static final String PATH_CONF_KEY = "path";
+
     @Context
     public ApocConfig apocConfig;
 
@@ -60,6 +62,11 @@ public class OpenAI {
         OpenAIRequestHandler apiType = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH))
                 .get();
         String endpoint = apiType.getEndpoint(configuration, apocConfig);
+        
+        // TODO - aggiungere config per jsonPath
+        // TODO - aggiungere config per path
+        jsonPath = (String) configuration.getOrDefault(JSON_PATH_CONF_KEY, jsonPath);
+        path = (String) configuration.getOrDefault(PATH_CONF_KEY, path);
         
         apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
         checkApiKey(apiKey, endpoint);

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import static apoc.ExtendedApocConfig.APOC_ML_OPENAI_TYPE;
 import static apoc.ExtendedApocConfig.APOC_OPENAI_KEY;
+import static apoc.util.ExtendedUtil.isLocalAddress;
 
 
 @Extended
@@ -50,17 +51,17 @@ public class OpenAI {
     }
 
     static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
-        apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
-        if (apiKey == null || apiKey.isBlank())
-            throw new IllegalArgumentException("API Key must not be empty");
-
         String apiTypeString = (String) configuration.getOrDefault(API_TYPE_CONF_KEY,
                 apocConfig.getString(APOC_ML_OPENAI_TYPE, OpenAIRequestHandler.Type.OPENAI.name())
         );
         OpenAIRequestHandler apiType = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH))
                 .get();
-
         String endpoint = apiType.getEndpoint(configuration, apocConfig);
+        
+        apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
+        checkApiKey(apiKey, endpoint);
+
+
         
         final Map<String, Object> headers = new HashMap<>();
         headers.put("Content-Type", "application/json");
@@ -70,7 +71,12 @@ public class OpenAI {
         // we remove these keys from config, since the json payload is calculated starting from the config map
         Stream.of(ENDPOINT_CONF_KEY, API_TYPE_CONF_KEY, API_VERSION_CONF_KEY, APIKEY_CONF_KEY).forEach(config::remove);
         config.putIfAbsent("model", model);
-        config.put(key, inputs);
+        
+        // TODO - DELETE
+        config.put("inputs", "non so");
+        
+//        config.putAll(inputs
+//        config.put(key, inputs);
 
         String payload = JsonUtil.OBJECT_MAPPER.writeValueAsString(config);
         
@@ -78,7 +84,19 @@ public class OpenAI {
         // eg: https://my-resource.openai.azure.com/openai/deployments/apoc-embeddings-model
         // therefore is better to join the not-empty path pieces
         var url = apiType.getFullUrl(path, configuration, apocConfig);
-        return JsonUtil.loadJson(url, headers, payload, jsonPath, true, List.of(), urlAccessChecker);
+        return JsonUtil.loadJson(url, headers, payload, "$[0]", true, List.of(), urlAccessChecker);
+    }
+
+    private static void checkApiKey(String apiKey, String endpoint) {
+        // with localhost URLs, the API Key is not always mandatory
+        if (isLocalAddress(endpoint)) {
+            return;
+        }
+//        if (apiType.equals(OpenAIRequestHandler.Type.LOCALAI.get())) {
+//            return;
+//        }
+        if (apiKey == null || apiKey.isBlank())
+            throw new IllegalArgumentException("API Key must not be empty");
     }
 
     @Procedure("apoc.ml.openai.embedding")

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -33,14 +33,24 @@ abstract class OpenAIRequestHandler {
     }
 
     public String getFullUrl(String method, Map<String, Object> procConfig, ApocConfig apocConfig) {
-        return Stream.of(getEndpoint(procConfig, apocConfig), /*method, */getApiVersion(procConfig, apocConfig))
+        return Stream.of(getEndpoint(procConfig, apocConfig), method, getApiVersion(procConfig, apocConfig))
                 .filter(StringUtils::isNotBlank)
                 .collect(Collectors.joining("/"));
+    }
+    
+    public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
+        config.putIfAbsent("model", model);
+        config.put(key, inputs);
+    }
+    
+    public String adaptJsonPath(String jsonPath) {
+        return jsonPath;
     }
 
     enum Type {
         AZURE(new Azure(null)),
         LOCALAI(new OpenAi(null)),
+        HUGGING_FACE(new HuggingFace()),
         OPENAI(new OpenAi("https://api.openai.com/v1"));
 
         private final OpenAIRequestHandler handler;
@@ -53,6 +63,22 @@ abstract class OpenAIRequestHandler {
         }
     }
 
+    private static class HuggingFace extends OpenAi {
+        public HuggingFace() {
+            super(null);
+        }
+
+        @Override
+        public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
+//            config.put("inputs", "non so");
+        }
+
+        @Override
+        public String adaptJsonPath(String jsonPath) {
+            return "$[0]";
+        }
+    }
+    
 //    static class LocalAi extends OpenAi {
 //
 //        public LocalAi() {

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -67,7 +67,7 @@ abstract class OpenAIRequestHandler {
         }
     }
     
-    private static class HuggingFace extends OpenLM {
+    private static class HuggingFace extends OpenAi {
         public HuggingFace() {
             super(null);
         }
@@ -84,12 +84,6 @@ abstract class OpenAIRequestHandler {
         @Override
         public String getJsonPath(String jsonPath) {
             return "$[0]";
-        }
-    }
-
-    private static class OpenLM extends OpenAi {
-        public OpenLM(String defaultUrl) {
-            super(defaultUrl);
         }
 
         @Override

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -33,13 +33,15 @@ abstract class OpenAIRequestHandler {
     }
 
     public String getFullUrl(String method, Map<String, Object> procConfig, ApocConfig apocConfig) {
-        return Stream.of(getEndpoint(procConfig, apocConfig), method, getApiVersion(procConfig, apocConfig))
+        return Stream.of(getEndpoint(procConfig, apocConfig), /*method, */getApiVersion(procConfig, apocConfig))
                 .filter(StringUtils::isNotBlank)
                 .collect(Collectors.joining("/"));
     }
 
     enum Type {
-        AZURE(new Azure(null)), OPENAI(new OpenAi("https://api.openai.com/v1"));
+        AZURE(new Azure(null)),
+        LOCALAI(new OpenAi(null)),
+        OPENAI(new OpenAi("https://api.openai.com/v1"));
 
         private final OpenAIRequestHandler handler;
         Type(OpenAIRequestHandler handler) {
@@ -50,6 +52,13 @@ abstract class OpenAIRequestHandler {
             return handler;
         }
     }
+
+//    static class LocalAi extends OpenAi {
+//
+//        public LocalAi() {
+//            super(n);
+//        }
+//    }
 
     static class Azure extends OpenAIRequestHandler {
 

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -34,22 +34,9 @@ abstract class OpenAIRequestHandler {
     }
 
     public String getFullUrl(String method, Map<String, Object> procConfig, ApocConfig apocConfig) {
-        return Stream.of(getEndpoint(procConfig, apocConfig), getMethod(method), getApiVersion(procConfig, apocConfig))
+        return Stream.of(getEndpoint(procConfig, apocConfig), method, getApiVersion(procConfig, apocConfig))
                 .filter(StringUtils::isNotBlank)
                 .collect(Collectors.joining("/"));
-    }
-    
-    public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
-        config.putIfAbsent("model", model);
-        config.put(key, inputs);
-    }
-    
-    public String getMethod(String method) {
-        return method;
-    }
-    
-    public String getJsonPath(String jsonPath) {
-        return jsonPath;
     }
 
     enum Type {
@@ -70,25 +57,6 @@ abstract class OpenAIRequestHandler {
     private static class HuggingFace extends OpenAi {
         public HuggingFace() {
             super(null);
-        }
-
-        @Override
-        public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
-            config.putIfAbsent("inputs", inputs);
-        }
-
-        /**
-         * Otherwise the {@link OpenAI#executeRequest(String, Map, String, String, String, Object, String, ApocConfig, URLAccessChecker)}
-         * returns a List, and therefore a ClassCastException, since a map should return 
-         */
-        @Override
-        public String getJsonPath(String jsonPath) {
-            return "$[0]";
-        }
-
-        @Override
-        public String getMethod(String method) {
-            return "";
         }
     }
 

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -3,6 +3,7 @@ package apoc.ml;
 
 import apoc.ApocConfig;
 import org.apache.commons.lang3.StringUtils;
+import org.neo4j.graphdb.security.URLAccessChecker;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,7 +34,7 @@ abstract class OpenAIRequestHandler {
     }
 
     public String getFullUrl(String method, Map<String, Object> procConfig, ApocConfig apocConfig) {
-        return Stream.of(getEndpoint(procConfig, apocConfig), adaptMethod(method), getApiVersion(procConfig, apocConfig))
+        return Stream.of(getEndpoint(procConfig, apocConfig), getMethod(method), getApiVersion(procConfig, apocConfig))
                 .filter(StringUtils::isNotBlank)
                 .collect(Collectors.joining("/"));
     }
@@ -43,18 +44,16 @@ abstract class OpenAIRequestHandler {
         config.put(key, inputs);
     }
     
-    public String adaptJsonPath(String jsonPath) {
-        return jsonPath;
+    public String getMethod(String method) {
+        return method;
     }
     
-    public String adaptMethod(String method) {
-        return method;
+    public String getJsonPath(String jsonPath) {
+        return jsonPath;
     }
 
     enum Type {
         AZURE(new Azure(null)),
-        LOCALAI(new OpenAi(null)),
-        COHERE(new Cohere()),
         HUGGINGFACE(new HuggingFace()),
         OPENAI(new OpenAi("https://api.openai.com/v1"));
 
@@ -67,32 +66,24 @@ abstract class OpenAIRequestHandler {
             return handler;
         }
     }
-
-    private static class Cohere extends OpenLM {
-        public Cohere() {
-            super(null);
-            // todo
-//            super("defaultUrl TODO");
-        }
-
-//        @Override
-//        public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
-////            config.put("inputs", "non so"); TODO
-//        }
-    }
     
     private static class HuggingFace extends OpenLM {
         public HuggingFace() {
             super(null);
-//            super("https://api-inference.huggingface.co/models");
         }
 
         @Override
         public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
-//            Object inputsValue = config.remove("inputs");
             config.putIfAbsent("inputs", inputs);
+        }
 
-//            config.put("inputs", "non so");
+        /**
+         * Otherwise the {@link OpenAI#executeRequest(String, Map, String, String, String, Object, String, ApocConfig, URLAccessChecker)}
+         * returns a List, and therefore a ClassCastException, since a map should return 
+         */
+        @Override
+        public String getJsonPath(String jsonPath) {
+            return "$[0]";
         }
     }
 
@@ -100,25 +91,12 @@ abstract class OpenAIRequestHandler {
         public OpenLM(String defaultUrl) {
             super(defaultUrl);
         }
-        
 
         @Override
-        public String adaptJsonPath(String jsonPath) {
-            return "$[0]";
-        }
-
-        @Override
-        public String adaptMethod(String method) {
+        public String getMethod(String method) {
             return "";
         }
     }
-    
-//    static class LocalAi extends OpenAi {
-//
-//        public LocalAi() {
-//            super(n);
-//        }
-//    }
 
     static class Azure extends OpenAIRequestHandler {
 

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -33,7 +33,7 @@ abstract class OpenAIRequestHandler {
     }
 
     public String getFullUrl(String method, Map<String, Object> procConfig, ApocConfig apocConfig) {
-        return Stream.of(getEndpoint(procConfig, apocConfig), method, getApiVersion(procConfig, apocConfig))
+        return Stream.of(getEndpoint(procConfig, apocConfig), adaptMethod(method), getApiVersion(procConfig, apocConfig))
                 .filter(StringUtils::isNotBlank)
                 .collect(Collectors.joining("/"));
     }
@@ -46,11 +46,16 @@ abstract class OpenAIRequestHandler {
     public String adaptJsonPath(String jsonPath) {
         return jsonPath;
     }
+    
+    public String adaptMethod(String method) {
+        return method;
+    }
 
     enum Type {
         AZURE(new Azure(null)),
         LOCALAI(new OpenAi(null)),
-        HUGGING_FACE(new HuggingFace()),
+        COHERE(new Cohere()),
+        HUGGINGFACE(new HuggingFace()),
         OPENAI(new OpenAi("https://api.openai.com/v1"));
 
         private final OpenAIRequestHandler handler;
@@ -63,19 +68,47 @@ abstract class OpenAIRequestHandler {
         }
     }
 
-    private static class HuggingFace extends OpenAi {
-        public HuggingFace() {
-            super(null);
+    private static class Cohere extends OpenLM {
+        public Cohere() {
+            // todo
+            super("defaultUrl TODO");
         }
 
         @Override
         public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
+//            config.put("inputs", "non so"); TODO
+        }
+    }
+    
+    private static class HuggingFace extends OpenLM {
+        public HuggingFace() {
+            super(null);
+//            super("https://api-inference.huggingface.co/models");
+        }
+
+        @Override
+        public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
+//            Object inputsValue = config.remove("inputs");
+            config.putIfAbsent("inputs", inputs);
+
 //            config.put("inputs", "non so");
         }
+    }
+
+    private static class OpenLM extends OpenAi {
+        public OpenLM(String defaultUrl) {
+            super(defaultUrl);
+        }
+        
 
         @Override
         public String adaptJsonPath(String jsonPath) {
             return "$[0]";
+        }
+
+        @Override
+        public String adaptMethod(String method) {
+            return "";
         }
     }
     

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -70,14 +70,15 @@ abstract class OpenAIRequestHandler {
 
     private static class Cohere extends OpenLM {
         public Cohere() {
+            super(null);
             // todo
-            super("defaultUrl TODO");
+//            super("defaultUrl TODO");
         }
 
-        @Override
-        public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
-//            config.put("inputs", "non so"); TODO
-        }
+//        @Override
+//        public void addBodyEntries(String key, Object inputs, String model, Map<String, Object> config) {
+////            config.put("inputs", "non so"); TODO
+//        }
     }
     
     private static class HuggingFace extends OpenLM {

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -7,6 +7,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
@@ -50,7 +51,9 @@ public class ExtendedUtil
 
     public static boolean isLocalAddress(String url) {
         try {
-            InetAddress address = InetAddress.getByName(url);
+            String host = URI.create(url).getHost();
+                    
+            InetAddress address = InetAddress.getByName(host);
             return address.isAnyLocalAddress()
                    || address.isLoopbackAddress()
                    || NetworkInterface.getByInetAddress(address) != null;

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -4,6 +4,10 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.formatProperties
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatToString;
 
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 import java.util.Map;
@@ -42,5 +46,17 @@ public class ExtendedUtil
     public static String toCypherMap( Map<String, Object> map) {
         final StringBuilder builder = formatProperties(map);
         return "{" + formatToString(builder) + "}";
+    }
+
+    public static boolean isLocalAddress(String url) {
+        try {
+            InetAddress address = InetAddress.getByName(url);
+            return address.isAnyLocalAddress()
+                   || address.isLoopbackAddress()
+                   || NetworkInterface.getByInetAddress(address) != null;
+        } catch (UnknownHostException | SocketException e) {
+            // ignored
+        }
+        return false;
     }
 }

--- a/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
@@ -16,6 +16,7 @@ import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
 import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenAIAnyScaleIT {
 
@@ -46,21 +47,47 @@ public class OpenAIAnyScaleIT {
 
     @Test
     public void completion() {
+        String modelId = "Meta-Llama/Llama-Guard-7b";
         testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
-                getParams("Meta-Llama/Llama-Guard-7b"),
-                (row) -> assertCompletion(row, "text-davinci-003"));
+                getParams(modelId),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+                    var finishReason = (String)((List<Map>) result.get("choices")).get(0).get("finish_reason");
+                    assertTrue(finishReason.matches("stop|length"));
+                    String text = (String) ((List<Map>) result.get("choices")).get(0).get("text");
+                    assertTrue(text != null && !text.isBlank());
+
+                    assertEquals(modelId, result.get("model"));
+                });
     }
 
     @Test
     public void chatCompletion() {
+        String modelId = "meta-llama/Llama-2-70b-chat-hf";
         testCall(db, """
             CALL apoc.ml.openai.chat([
             {role:"system", content:"Only answer with a single word"},
             {role:"user", content:"What planet do humans live on?"}
             ],  $apiKey, $conf)
             """, 
-                getParams("meta-llama/Llama-2-70b-chat-hf"),
-                (row) -> assertChatCompletion(row, "gpt-3.5-turbo"));
+                getParams(modelId),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+
+                    Map message = ((List<Map<String,Map>>) result.get("choices")).get(0).get("message");
+                    assertEquals("assistant", message.get("role"));
+                    String text = (String) message.get("content");
+                    assertTrue(text != null && !text.isBlank());
+
+                    assertTrue(result.containsKey("usage"));
+                    assertTrue(((Map) result.get("usage")).get("prompt_tokens") instanceof Number);
+
+                    assertTrue(result.get("model").toString().startsWith(modelId));
+                });
     }
 
     private Map<String, Object> getParams(String model) {

--- a/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
-import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
-import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,7 +35,7 @@ public class OpenAIAnyScaleIT {
 
     @Test
     public void getEmbedding() {
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+        testCall(db, EMBEDDING_QUERY,
                 getParams("thenlper/gte-large"),
                 row -> {
                     assertEquals(0L, row.get("index"));
@@ -48,7 +48,7 @@ public class OpenAIAnyScaleIT {
     @Test
     public void completion() {
         String modelId = "Meta-Llama/Llama-Guard-7b";
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+        testCall(db, COMPLETION_QUERY,
                 getParams(modelId),
                 (row) -> {
                     var result = (Map<String,Object>) row.get("value");
@@ -66,12 +66,7 @@ public class OpenAIAnyScaleIT {
     @Test
     public void chatCompletion() {
         String modelId = "meta-llama/Llama-2-70b-chat-hf";
-        testCall(db, """
-            CALL apoc.ml.openai.chat([
-            {role:"system", content:"Only answer with a single word"},
-            {role:"user", content:"What planet do humans live on?"}
-            ],  $apiKey, $conf)
-            """, 
+        testCall(db, CHAT_COMPLETION_QUERY, 
                 getParams(modelId),
                 (row) -> {
                     var result = (Map<String,Object>) row.get("value");
@@ -93,7 +88,7 @@ public class OpenAIAnyScaleIT {
     private Map<String, Object> getParams(String model) {
         return Map.of("apiKey", openaiKey,
                 "conf", Map.of(ENDPOINT_CONF_KEY, "https://api.endpoints.anyscale.com/v1",
-                        "model", model
+                        MODEL_CONF_KEY, model
                 )
         );
     }

--- a/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
@@ -1,0 +1,73 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
+import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenAIAnyScaleIT {
+
+    private String openaiKey;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        openaiKey = System.getenv("OPENAI_KEY");
+        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+                getParams("thenlper/gte-large"),
+                row -> {
+                    assertEquals(0L, row.get("index"));
+                    assertEquals("Some Text", row.get("text"));
+                    var embedding = (List<Double>) row.get("embedding");
+                    assertEquals(1024, embedding.size());
+                });
+    }
+
+    @Test
+    public void completion() {
+        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+                getParams("Meta-Llama/Llama-Guard-7b"),
+                (row) -> assertCompletion(row, "text-davinci-003"));
+    }
+
+    @Test
+    public void chatCompletion() {
+        testCall(db, """
+            CALL apoc.ml.openai.chat([
+            {role:"system", content:"Only answer with a single word"},
+            {role:"user", content:"What planet do humans live on?"}
+            ],  $apiKey, $conf)
+            """, 
+                getParams("meta-llama/Llama-2-70b-chat-hf"),
+                (row) -> assertChatCompletion(row, "gpt-3.5-turbo"));
+    }
+
+    private Map<String, Object> getParams(String model) {
+        return Map.of("apiKey", openaiKey,
+                "conf", Map.of(ENDPOINT_CONF_KEY, "https://api.endpoints.anyscale.com/v1",
+                        "model", model
+                )
+        );
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
@@ -27,8 +27,8 @@ public class OpenAIAnyScaleIT {
 
     @Before
     public void setUp() throws Exception {
-        openaiKey = System.getenv("OPENAI_KEY");
-        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
+        openaiKey = System.getenv("OPENAI_ANYSCALE_KEY");
+        Assume.assumeNotNull("No OPENAI_ANYSCALE_KEY environment configured", openaiKey);
         TestUtil.registerProcedure(db, OpenAI.class);
     }
 

--- a/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
@@ -14,6 +14,9 @@ import java.util.stream.Stream;
 import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
 import static apoc.ml.OpenAI.API_VERSION_CONF_KEY;
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.CHAT_COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.EMBEDDING_QUERY;
 import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
 import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
@@ -56,7 +59,7 @@ public class OpenAIAzureIT {
 
     @Test
     public void embedding() {
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+        testCall(db, EMBEDDING_QUERY,
                 getParams(OPENAI_EMBEDDING_URL),
                 OpenAITestResultUtils::assertEmbeddings);
     }
@@ -65,19 +68,14 @@ public class OpenAIAzureIT {
     @Test
     @Ignore("It returns wrong answers sometimes")
     public void completion() {
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+        testCall(db, COMPLETION_QUERY,
                 getParams(OPENAI_CHAT_URL),
                 (row) -> assertCompletion(row, "gpt-35-turbo"));
     }
 
     @Test
     public void chatCompletion() {
-        testCall(db, """
-            CALL apoc.ml.openai.chat([
-            {role:"system", content:"Only answer with a single word"},
-            {role:"user", content:"What planet do humans live on?"}
-            ], $apiKey, $conf)
-            """, getParams(OPENAI_COMPLETION_URL),
+        testCall(db, CHAT_COMPLETION_QUERY, getParams(OPENAI_COMPLETION_URL),
                 (row) -> assertChatCompletion(row, "gpt-35-turbo"));
     }
 

--- a/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
@@ -37,11 +37,11 @@ public class OpenAIAzureIT {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        OPENAI_KEY = System.getenv("OPENAI_KEY");
+        OPENAI_KEY = System.getenv("OPENAI_AZURE_KEY");
         // Azure OpenAI base URLs
-        OPENAI_EMBEDDING_URL = System.getenv("OPENAI_EMBEDDING_URL");
-        OPENAI_CHAT_URL = System.getenv("OPENAI_CHAT_URL");
-        OPENAI_COMPLETION_URL = System.getenv("OPENAI_COMPLETION_URL");
+        OPENAI_EMBEDDING_URL = System.getenv("OPENAI_AZURE_EMBEDDING_URL");
+        OPENAI_CHAT_URL = System.getenv("OPENAI_AZURE_CHAT_URL");
+        OPENAI_COMPLETION_URL = System.getenv("OPENAI_AZURE_COMPLETION_URL");
 
         // Azure OpenAI query url (`<baseURL>/<type>/?api-version=<OPENAI_AZURE_API_VERSION>`)
         OPENAI_AZURE_API_VERSION = System.getenv("OPENAI_AZURE_API_VERSION");

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -10,9 +10,9 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Map;
 
-import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
-import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.emptyMap;
 
 public class OpenAIIT {
 
@@ -33,25 +33,20 @@ public class OpenAIIT {
 
     @Test
     public void getEmbedding() {
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey)", Map.of("apiKey",openaiKey),
+        testCall(db, EMBEDDING_QUERY, Map.of("apiKey",openaiKey, "conf", emptyMap()),
                 OpenAITestResultUtils::assertEmbeddings);
     }
 
     @Test
     public void completion() {
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey)",
-                Map.of("apiKey", openaiKey),
+        testCall(db, COMPLETION_QUERY,
+                Map.of("apiKey", openaiKey, "conf", emptyMap()),
                 (row) -> assertCompletion(row, "gpt-3.5-turbo-instruct"));
     }
 
     @Test
     public void chatCompletion() {
-        testCall(db, """
-CALL apoc.ml.openai.chat([
-{role:"system", content:"Only answer with a single word"},
-{role:"user", content:"What planet do humans live on?"}
-],  $apiKey)
-""", Map.of("apiKey",openaiKey),
+        testCall(db, CHAT_COMPLETION_QUERY, Map.of("apiKey",openaiKey, "conf", emptyMap()),
                 (row) -> assertChatCompletion(row, "gpt-3.5-turbo"));
 
         /*

--- a/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
@@ -123,7 +123,7 @@ public class OpenAILLMaticIT {
     }
 
     private Map<String, Object> getParams(String model) {
-        return Util.map(APIKEY_CONF_KEY, null,
+        return Util.map(APIKEY_CONF_KEY, "ignored",
                 "conf", Map.of(
                         ENDPOINT_CONF_KEY, localAIUrl,
                         MODEL_CONF_KEY, model

--- a/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
@@ -1,6 +1,7 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
+import apoc.util.Util;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -15,27 +16,26 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocConfig.apocConfig;
-import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
+import static apoc.ml.OpenAI.APIKEY_CONF_KEY;
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
-import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
-import static apoc.ml.OpenAITestResultUtils.assertCompletion;
-import static apoc.util.TestUtil.testCall;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/*
-To start the test, follow the instructions in this video: https://www.youtube.com/watch?v=V_baaAZMY44
 
-The APIs, especially the `/completions` one, are extremely unstable (i.e. we could get many SocketTimeoutExceptions),
-even via e.g. Insomnia,
-so it's better to change the `nTokPredict` value, placed in `llmatic.config.json`, to a low value, like `128`,
-before executing `npx llmatic start`
 
+/**
+ * To start the test, follow the instructions in this video: https://www.youtube.com/watch?v=V_baaAZMY44.
+ *
+ * NB: The APIs, especially the `/completions` one, are extremely unstable (i.e. we could get many SocketTimeoutExceptions), also via e.g. Insomnia or PostMan,
+ * even with `apoc.http.timeout.*` config increased.
+ * So it's better to change the `nTokPredict` value, placed in `llmatic.config.json`, to a low value, like `128`,
+ * before executing `npx llmatic start`
  */
-public class OpenAILMMaticIT {
+public class OpenAILLMaticIT {
     public static final String MODEL_ID = "meta-llama/Llama-2-70b-chat-hf";
-
     private String localAIUrl;
 
     @Rule
@@ -49,15 +49,13 @@ public class OpenAILMMaticIT {
         
         localAIUrl = System.getenv("LLM_MATIC_URL");
         Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
-//        openaiKey = System.getenv("OPENAI_KEY");
-//        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
         TestUtil.registerProcedure(db, OpenAI.class);
         
     }
 
     @Test
     public void getEmbedding() {
-        assertEventually(() -> db.executeTransactionally("CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+        assertEventually(() -> db.executeTransactionally(EMBEDDING_QUERY,
                 getParams("thenlper/gte-large"),
                 r -> {
                     Map<String, Object> row = r.next();
@@ -73,7 +71,7 @@ public class OpenAILMMaticIT {
 
     @Test
     public void completion() {
-        assertEventually(() -> db.executeTransactionally("CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+        assertEventually(() -> db.executeTransactionally(COMPLETION_QUERY,
                 getParams(MODEL_ID),
                 (r) -> {
                     Map<String, Object> row = r.next();
@@ -92,12 +90,7 @@ public class OpenAILMMaticIT {
 
     @Test
     public void chatCompletion() {
-        assertEventually(() -> db.executeTransactionally("""
-            CALL apoc.ml.openai.chat([
-            {role:"system", content:"Only answer with a single word"},
-            {role:"user", content:"What planet do humans live on?"}
-            ],  $apiKey, $conf)
-            """, 
+        assertEventually(() -> db.executeTransactionally(CHAT_COMPLETION_QUERY, 
                 getParams(MODEL_ID),
                 (r) -> {
                     Map<String, Object> row = r.next();
@@ -123,18 +116,16 @@ public class OpenAILMMaticIT {
             try {
                 return booleanCallable.call();
             } catch (RuntimeException e) {
-                System.out.println("e = " + e);
                 return false;
             }
         }, val -> val, 60, TimeUnit.SECONDS);
     }
 
     private Map<String, Object> getParams(String model) {
-        return Map.of("apiKey", "openaiKey",
+        return Util.map(APIKEY_CONF_KEY, null,
                 "conf", Map.of(
                         ENDPOINT_CONF_KEY, localAIUrl,
-//                        ENDPOINT_CONF_KEY, "https://api.endpoints.anyscale.com/v1",
-                        "model", model
+                        MODEL_CONF_KEY, model
                 )
         );
     }

--- a/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
@@ -27,12 +27,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
- * To start the test, follow the instructions in this video: https://www.youtube.com/watch?v=V_baaAZMY44.
+ * To start the tests, follow the instructions in this video: https://www.youtube.com/watch?v=V_baaAZMY44.
  *
  * NB: The APIs, especially the `/completions` one, are extremely unstable (i.e. we could get many SocketTimeoutExceptions), also via e.g. Insomnia or PostMan,
- * even with `apoc.http.timeout.*` config increased.
+ * even with `assertEventually` and `apoc.http.timeout.*` configs increased.
  * So it's better to change the `nTokPredict` value, placed in `llmatic.config.json`, to a low value, like `128`,
- * before executing `npx llmatic start`
+ * before executing `npx llmatic start`.
+ * 
+ * Finally, set the env var `LLM_MATIC_URL=http://localhost:3000/v1`
  */
 public class OpenAILLMaticIT {
     public static final String MODEL_ID = "meta-llama/Llama-2-70b-chat-hf";
@@ -48,9 +50,8 @@ public class OpenAILLMaticIT {
         apocConfig().setProperty("apoc.http.timeout.read", 30_000);
         
         localAIUrl = System.getenv("LLM_MATIC_URL");
-        Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
+        Assume.assumeNotNull("No LLM_MATIC_URL environment configured", localAIUrl);
         TestUtil.registerProcedure(db, OpenAI.class);
-        
     }
 
     @Test

--- a/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
@@ -29,7 +29,8 @@ To start the test, follow the instructions in this video: https://www.youtube.co
 
 The APIs, especially the `/completions` one, are extremely unstable (i.e. we could get many SocketTimeoutExceptions),
 even via e.g. Insomnia,
-so it's better to change the `nTokPredict` value, placed in `llmatic.config.json`, to a low value, like `128`
+so it's better to change the `nTokPredict` value, placed in `llmatic.config.json`, to a low value, like `128`,
+before executing `npx llmatic start`
 
  */
 public class OpenAILMMaticIT {

--- a/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.List;
 import java.util.Map;
 
 import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
@@ -15,14 +16,13 @@ import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
 import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OpenAILMMaticIT {
 
     /*
     Follow the instructions TODO
     */
-    
-    private String openaiKey;
 
     private String localAIUrl;
 
@@ -32,7 +32,7 @@ public class OpenAILMMaticIT {
 
     @Before
     public void setUp() throws Exception {
-        localAIUrl = System.getenv("LOCAL_AI_URL");
+        localAIUrl = System.getenv("LLM_MATIC_URL");
         Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
 //        openaiKey = System.getenv("OPENAI_KEY");
 //        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
@@ -43,7 +43,12 @@ public class OpenAILMMaticIT {
     public void getEmbedding() {
         testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
                 getParams("thenlper/gte-large"),
-                OpenAITestResultUtils::assertEmbeddings);
+                row -> {
+                    assertEquals(0L, row.get("index"));
+                    assertEquals("Some Text", row.get("text"));
+                    var embedding = (List<Double>) row.get("embedding");
+                    assertEquals(5120, embedding.size());
+                });
     }
 
     @Test

--- a/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
@@ -1,0 +1,77 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Map;
+
+import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
+import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.util.TestUtil.testCall;
+
+public class OpenAILMMaticIT {
+
+    /*
+    Follow the instructions TODO
+    */
+    
+    private String openaiKey;
+
+    private String localAIUrl;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        localAIUrl = System.getenv("LOCAL_AI_URL");
+        Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
+//        openaiKey = System.getenv("OPENAI_KEY");
+//        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+                getParams("thenlper/gte-large"),
+                OpenAITestResultUtils::assertEmbeddings);
+    }
+
+    @Test
+    public void completion() {
+        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+                getParams("Meta-Llama/Llama-Guard-7b"),
+                (row) -> assertCompletion(row, "text-davinci-003"));
+    }
+
+    @Test
+    public void chatCompletion() {
+        testCall(db, """
+            CALL apoc.ml.openai.chat([
+            {role:"system", content:"Only answer with a single word"},
+            {role:"user", content:"What planet do humans live on?"}
+            ],  $apiKey, $conf)
+            """, 
+                getParams("meta-llama/Llama-2-70b-chat-hf"),
+                (row) -> assertChatCompletion(row, "gpt-3.5-turbo"));
+    }
+
+    private Map<String, Object> getParams(String model) {
+        return Map.of("apiKey", "openaiKey",
+                "conf", Map.of(
+                        ENDPOINT_CONF_KEY, localAIUrl,
+//                        ENDPOINT_CONF_KEY, "https://api.endpoints.anyscale.com/v1",
+                        "model", model
+                )
+        );
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILMMaticIT.java
@@ -5,24 +5,35 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.test.assertion.Assert;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
+import static apoc.ApocConfig.apocConfig;
 import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
 import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/*
+To start the test, follow the instructions in this video: https://www.youtube.com/watch?v=V_baaAZMY44
+
+The APIs, especially the `/completions` one, are extremely unstable (i.e. we could get many SocketTimeoutExceptions),
+even via e.g. Insomnia,
+so it's better to change the `nTokPredict` value, placed in `llmatic.config.json`, to a low value, like `128`
+
+ */
 public class OpenAILMMaticIT {
-
-    /*
-    Follow the instructions TODO
-    */
+    public static final String MODEL_ID = "meta-llama/Llama-2-70b-chat-hf";
 
     private String localAIUrl;
 
@@ -32,42 +43,89 @@ public class OpenAILMMaticIT {
 
     @Before
     public void setUp() throws Exception {
+        apocConfig().setProperty("apoc.http.timeout.connect", 30_000);
+        apocConfig().setProperty("apoc.http.timeout.read", 30_000);
+        
         localAIUrl = System.getenv("LLM_MATIC_URL");
         Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
 //        openaiKey = System.getenv("OPENAI_KEY");
 //        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
         TestUtil.registerProcedure(db, OpenAI.class);
+        
     }
 
     @Test
     public void getEmbedding() {
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+        assertEventually(() -> db.executeTransactionally("CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
                 getParams("thenlper/gte-large"),
-                row -> {
+                r -> {
+                    Map<String, Object> row = r.next();
                     assertEquals(0L, row.get("index"));
                     assertEquals("Some Text", row.get("text"));
                     var embedding = (List<Double>) row.get("embedding");
                     assertEquals(5120, embedding.size());
-                });
+                    assertFalse(r.hasNext());
+                    return true;
+                }
+        ));
     }
 
     @Test
     public void completion() {
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
-                getParams("Meta-Llama/Llama-Guard-7b"),
-                (row) -> assertCompletion(row, "text-davinci-003"));
+        assertEventually(() -> db.executeTransactionally("CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+                getParams(MODEL_ID),
+                (r) -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+                    var finishReason = (String)((List<Map>) result.get("choices")).get(0).get("finish_reason");
+                    assertTrue(finishReason.matches("stop|length"));
+                    assertEquals(MODEL_ID, result.get("model"));
+                    
+                    assertFalse(r.hasNext());
+                    return true;
+                }
+        ));
     }
 
     @Test
     public void chatCompletion() {
-        testCall(db, """
+        assertEventually(() -> db.executeTransactionally("""
             CALL apoc.ml.openai.chat([
             {role:"system", content:"Only answer with a single word"},
             {role:"user", content:"What planet do humans live on?"}
             ],  $apiKey, $conf)
             """, 
-                getParams("meta-llama/Llama-2-70b-chat-hf"),
-                (row) -> assertChatCompletion(row, "gpt-3.5-turbo"));
+                getParams(MODEL_ID),
+                (r) -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+
+                    Map message = ((List<Map<String,Map>>) result.get("choices")).get(0).get("message");
+                    assertEquals("assistant", message.get("role"));
+                    String text = (String) message.get("content");
+                    assertTrue(text != null && !text.isBlank());
+                    assertTrue(result.get("model").toString().startsWith(MODEL_ID));
+                    
+                    assertFalse(r.hasNext());
+                    return true;
+                }
+        ));
+    }
+
+
+    private void assertEventually(Callable<Boolean> booleanCallable) {
+        Assert.assertEventually(() -> {
+            try {
+                return booleanCallable.call();
+            } catch (RuntimeException e) {
+                System.out.println("e = " + e);
+                return false;
+            }
+        }, val -> val, 60, TimeUnit.SECONDS);
     }
 
     private Map<String, Object> getParams(String model) {

--- a/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 /**
- * To start the test, follow the instructions provided here: https://localai.io/basics/build/
+ * To start the tests, follow the instructions provided here: https://localai.io/basics/build/
  * Then, download the embedding model, as explained here: https://localai.io/models/#embeddings-bert 
  * Finally, set the env var `LOCAL_AI_URL=http://localhost:<portNumber>/v1`, default is `LOCAL_AI_URL=http://localhost:8080/v1`
  */

--- a/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
@@ -1,6 +1,7 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
+import apoc.util.Util;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -12,23 +13,19 @@ import java.util.List;
 import java.util.Map;
 
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
-import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
-import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+
+/**
+ * To start the test, follow the instructions provided here: https://localai.io/basics/build/
+ * Then, download the embedding model, as explained here: https://localai.io/models/#embeddings-bert 
+ * Finally, set the env var `LOCAL_AI_URL=http://localhost:<portNumber>/v1`, default is `LOCAL_AI_URL=http://localhost:8080/v1`
+ */
 public class OpenAILocalAIIT {
 
-//    private String openaiKey;
-    
-    
-    /*
-    Follow the instructions provided here: https://localai.io/basics/build/
-    Plus download the embedding model, as explained here: https://localai.io/models/#embeddings-bert 
-    
-    Finally, set the env var `LOCAL_AI_URL=http://localhost:<portNumber>/v1` 
-     */
-    /* http://localhost:8080/v1 */
     private String localAIUrl;
 
     @Rule
@@ -39,14 +36,12 @@ public class OpenAILocalAIIT {
     public void setUp() throws Exception {
         localAIUrl = System.getenv("LOCAL_AI_URL");
         Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
-//        openaiKey = System.getenv("OPENAI_KEY");
-//        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
         TestUtil.registerProcedure(db, OpenAI.class);
     }
 
     @Test
     public void getEmbedding() {
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], null, $conf)",
+        testCall(db, EMBEDDING_QUERY,
                 getParams("text-embedding-ada-002"),
                 row -> {
                     assertEquals(0L, row.get("index"));
@@ -58,30 +53,22 @@ public class OpenAILocalAIIT {
 
     @Test
     public void completion() {
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', null, $conf)",
+        testCall(db, COMPLETION_QUERY,
                 getParams("ggml-gpt4all-j"),
                 (row) -> assertCompletion(row, "ggml-gpt4all-j"));
     }
 
     @Test
     public void chatCompletion() {
-        testCall(db, """
-            CALL apoc.ml.openai.chat([
-            {role:"system", content:"Only answer with a single word"},
-            {role:"user", content:"What planet do humans live on?"}
-            ],  null, $conf)
-            """, 
+        testCall(db, CHAT_COMPLETION_QUERY, 
                 getParams("ggml-gpt4all-j"),
                 (row) -> assertChatCompletion(row, "ggml-gpt4all-j"));
     }
 
     private Map<String, Object> getParams(String model) {
-        // todo - openai key?
-        return Map.of(// "apiKey", "openaiKey",
-                "conf", Map.of(//API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.ANY_SCALE.name(),
-                        ENDPOINT_CONF_KEY, localAIUrl,
-                        "model", model
-                )
+        return Util.map("apiKey", null,
+                "conf", Map.of(ENDPOINT_CONF_KEY, localAIUrl,
+                        MODEL_CONF_KEY, model)
         );
     }
 }

--- a/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
@@ -1,0 +1,87 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
+import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenAILocalAIIT {
+
+//    private String openaiKey;
+    
+    
+    /*
+    Follow the instructions provided here: https://localai.io/basics/build/
+    Plus download the embedding model, as explained here: https://localai.io/models/#embeddings-bert 
+    
+    Finally, set the env var `LOCAL_AI_URL=http://localhost:<portNumber>/v1` 
+     */
+    /* http://localhost:8080/v1 */
+    private String localAIUrl;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        localAIUrl = System.getenv("LOCAL_AI_URL");
+        Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
+//        openaiKey = System.getenv("OPENAI_KEY");
+//        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], null, $conf)",
+                getParams("text-embedding-ada-002"),
+                row -> {
+                    assertEquals(0L, row.get("index"));
+                    assertEquals("Some Text", row.get("text"));
+                    var embedding = (List<Double>) row.get("embedding");
+                    assertEquals(384, embedding.size());
+                });
+    }
+
+    @Test
+    public void completion() {
+        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', null, $conf)",
+                getParams("ggml-gpt4all-j"),
+                (row) -> assertCompletion(row, "ggml-gpt4all-j"));
+    }
+
+    @Test
+    public void chatCompletion() {
+        testCall(db, """
+            CALL apoc.ml.openai.chat([
+            {role:"system", content:"Only answer with a single word"},
+            {role:"user", content:"What planet do humans live on?"}
+            ],  null, $conf)
+            """, 
+                getParams("ggml-gpt4all-j"),
+                (row) -> assertChatCompletion(row, "ggml-gpt4all-j"));
+    }
+
+    private Map<String, Object> getParams(String model) {
+        // todo - openai key?
+        return Map.of(// "apiKey", "openaiKey",
+                "conf", Map.of(//API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.ANY_SCALE.name(),
+                        ENDPOINT_CONF_KEY, localAIUrl,
+                        "model", model
+                )
+        );
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
@@ -66,7 +66,7 @@ public class OpenAILocalAIIT {
     }
 
     private Map<String, Object> getParams(String model) {
-        return Util.map("apiKey", null,
+        return Util.map("apiKey", "x",
                 "conf", Map.of(ENDPOINT_CONF_KEY, localAIUrl,
                         MODEL_CONF_KEY, model)
         );

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -10,11 +10,15 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Map;
 
+import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
 import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
 
+/**
+ * OpenLM allows
+ */
 public class OpenAIOpenLMIT {
 
     private String openaiKey;
@@ -32,6 +36,9 @@ public class OpenAIOpenLMIT {
 
     @Test
     public void getEmbedding() {
+        // https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2
+        
+        // TODO?? -- JsonUtil.loadJson(url, headers, payload, "$", true, List.of(), urlAccessChecker)??
         testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
                 getParams("thenlper/gte-large"),
                 OpenAITestResultUtils::assertEmbeddings);
@@ -60,6 +67,7 @@ public class OpenAIOpenLMIT {
     private Map<String, Object> getParams(String model) {
         return Map.of("apiKey", openaiKey,
                 "conf", Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/gpt2",
+                        API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGING_FACE.name(),
                         "model", model
                 )
         );

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -16,14 +16,18 @@ import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
 import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 import static apoc.ml.OpenAI.PATH_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * OpenLM allows
+ * OpenLM-like tests for Cohere and HuggingFace, see here: https://github.com/r2d4/openlm
  * 
- * It works only for `\completion` API
+ * NB: It works only for `Completion` API, as described in the GitHub README.md
+ * ```
+ *      OpenLM currently supports the Completion endpoint, but over time will support more standardized endpoints that make sense.
+ * ```
  */
 public class OpenAIOpenLMIT {
     
@@ -33,20 +37,12 @@ public class OpenAIOpenLMIT {
 
     @Before
     public void setUp() throws Exception {
-
         TestUtil.registerProcedure(db, OpenAI.class);
     }
 
-//    @Test
-//    public void getEmbedding() {
-//        // https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2
-//        
-//        // TODO?? -- JsonUtil.loadJson(url, headers, payload, "$", true, List.of(), urlAccessChecker)??
-//        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
-//                getParams("thenlper/gte-large"),
-//                OpenAITestResultUtils::assertEmbeddings);
-//    }
-
+    /**
+     * Request converter similar to: https://github.com/r2d4/openlm/blob/main/openlm/llm/huggingface.py
+     */
     @Test
     public void completionWithHuggingFace() {
         String huggingFaceApiKey = System.getenv("HF_API_TOKEN");
@@ -54,13 +50,11 @@ public class OpenAIOpenLMIT {
         
         String modelId = "gpt2";
         Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/" + modelId,
-                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name()
-                ,
-                "model", modelId
+                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name(),
+                MODEL_CONF_KEY, modelId
         );
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+        testCall(db, COMPLETION_QUERY,
                 Map.of("conf", conf, "apiKey", huggingFaceApiKey),
-//                getParams("Meta-Llama/Llama-Guard-7b"),
                 (row) -> {
                     var result = (Map<String,Object>) row.get("value");
                     String generatedText = (String) result.get("generated_text");
@@ -69,6 +63,9 @@ public class OpenAIOpenLMIT {
                 });
     }
 
+    /**
+     * Request converter similar to: https://github.com/r2d4/openlm/blob/main/openlm/llm/cohere.py
+     */
     @Test
     public void completionWithCohere() {
         String cohereApiKey = System.getenv("COHERE_API_TOKEN");
@@ -77,12 +74,10 @@ public class OpenAIOpenLMIT {
         String modelId = "command";
         Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api.cohere.ai/v1/generate",
                 PATH_CONF_KEY, "",
-//                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.COHERE.name(),
-                // API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.COHERE.name()
                 MODEL_CONF_KEY, modelId
         );
         
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+        testCall(db, COMPLETION_QUERY,
                 Map.of("conf", conf, "apiKey", cohereApiKey),
                 (row) -> {
                     var result = (Map<String,Object>) row.get("value");
@@ -96,27 +91,5 @@ public class OpenAIOpenLMIT {
                     assertTrue(result.get("id") instanceof String);
                     assertTrue(result.get("prompt") instanceof String);
                 });
-    }
-
-//    @Test
-//    public void chatCompletion() {
-//        testCall(db, """
-//                        CALL apoc.ml.openai.chat([
-//                                    {
-//                                    	inputs: "non so"
-//                                    }
-//                        ],  $apiKey, $conf)
-//                        """, 
-//                getParams("meta-llama/Llama-2-70b-chat-hf"),
-//                (row) -> assertChatCompletion(row, "gpt2"));
-//    }
-
-    private Map<String, Object> getParams(String model) {
-        return Map.of(//"apiKey", openaiKey,
-                "conf", Map.of(//ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/gpt2",
-                        API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name(),
-                        "model", model
-                )
-        );
     }
 }

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -8,13 +8,16 @@ import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
-import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
-import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAI.PATH_CONF_KEY;
 import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -23,17 +26,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * It works only for `\completion` API
  */
 public class OpenAIOpenLMIT {
-
-    private String openaiKey;
-
+    
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
 
     @Before
     public void setUp() throws Exception {
-        openaiKey = System.getenv("HF_API_TOKEN");
-        Assume.assumeNotNull("No HF_API_TOKEN environment configured", openaiKey);
+
         TestUtil.registerProcedure(db, OpenAI.class);
     }
 
@@ -48,7 +48,10 @@ public class OpenAIOpenLMIT {
 //    }
 
     @Test
-    public void completion() {
+    public void completionWithHuggingFace() {
+        String huggingFaceApiKey = System.getenv("HF_API_TOKEN");
+        Assume.assumeNotNull("No HF_API_TOKEN environment configured", huggingFaceApiKey);
+        
         String modelId = "gpt2";
         Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/" + modelId,
                 API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name()
@@ -56,13 +59,42 @@ public class OpenAIOpenLMIT {
                 "model", modelId
         );
         testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
-                Map.of("conf", conf, "apiKey", openaiKey),
+                Map.of("conf", conf, "apiKey", huggingFaceApiKey),
 //                getParams("Meta-Llama/Llama-Guard-7b"),
                 (row) -> {
                     var result = (Map<String,Object>) row.get("value");
                     String generatedText = (String) result.get("generated_text");
                     assertTrue(generatedText.toLowerCase().contains("blue"),
                             "Actual generatedText is " + generatedText);
+                });
+    }
+
+    @Test
+    public void completionWithCohere() {
+        String cohereApiKey = System.getenv("COHERE_API_TOKEN");
+        Assume.assumeNotNull("No COHERE_API_TOKEN environment configured", cohereApiKey);
+        
+        String modelId = "command";
+        Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api.cohere.ai/v1/generate",
+                PATH_CONF_KEY, "",
+//                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.COHERE.name(),
+                // API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.COHERE.name()
+                MODEL_CONF_KEY, modelId
+        );
+        
+        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+                Map.of("conf", conf, "apiKey", cohereApiKey),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    Map meta = (Map) result.get("meta");
+                    assertEquals(Set.of("warnings", "billed_units", "api_version"), meta.keySet());
+
+                    List<Map> generations = (List<Map>) result.get("generations");
+                    assertEquals(1, generations.size());
+                    assertEquals(Set.of("finish_reason", "id", "text"), generations.get(0).keySet());
+                    
+                    assertTrue(result.get("id") instanceof String);
+                    assertTrue(result.get("prompt") instanceof String);
                 });
     }
 

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -24,10 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * OpenLM-like tests for Cohere and HuggingFace, see here: https://github.com/r2d4/openlm
  * 
- * NB: It works only for `Completion` API, as described in the GitHub README.md
- * ```
- *      OpenLM currently supports the Completion endpoint, but over time will support more standardized endpoints that make sense.
- * ```
+ * NB: It works only for `Completion` API, as described in the README.md:
+ * https://github.com/r2d4/openlm/blob/main/README.md?plain=1#L36
  */
 public class OpenAIOpenLMIT {
     

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -15,9 +15,12 @@ import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
 import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * OpenLM allows
+ * 
+ * It works only for `\completion` API
  */
 public class OpenAIOpenLMIT {
 
@@ -29,45 +32,57 @@ public class OpenAIOpenLMIT {
 
     @Before
     public void setUp() throws Exception {
-        openaiKey = System.getenv("OPENAI_KEY");
-        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
+        openaiKey = System.getenv("HF_API_TOKEN");
+        Assume.assumeNotNull("No HF_API_TOKEN environment configured", openaiKey);
         TestUtil.registerProcedure(db, OpenAI.class);
     }
 
-    @Test
-    public void getEmbedding() {
-        // https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2
-        
-        // TODO?? -- JsonUtil.loadJson(url, headers, payload, "$", true, List.of(), urlAccessChecker)??
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
-                getParams("thenlper/gte-large"),
-                OpenAITestResultUtils::assertEmbeddings);
-    }
+//    @Test
+//    public void getEmbedding() {
+//        // https://api-inference.huggingface.co/pipeline/feature-extraction/sentence-transformers/all-MiniLM-L6-v2
+//        
+//        // TODO?? -- JsonUtil.loadJson(url, headers, payload, "$", true, List.of(), urlAccessChecker)??
+//        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+//                getParams("thenlper/gte-large"),
+//                OpenAITestResultUtils::assertEmbeddings);
+//    }
 
     @Test
     public void completion() {
+        String modelId = "gpt2";
+        Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/" + modelId,
+                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name()
+                ,
+                "model", modelId
+        );
         testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
-                getParams("Meta-Llama/Llama-Guard-7b"),
-                (row) -> assertCompletion(row, "gpt2"));
+                Map.of("conf", conf, "apiKey", openaiKey),
+//                getParams("Meta-Llama/Llama-Guard-7b"),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    String generatedText = (String) result.get("generated_text");
+                    assertTrue(generatedText.toLowerCase().contains("blue"),
+                            "Actual generatedText is " + generatedText);
+                });
     }
 
-    @Test
-    public void chatCompletion() {
-        testCall(db, """
-                        CALL apoc.ml.openai.chat([
-                                    {
-                                    	inputs: "non so"
-                                    }
-                        ],  $apiKey, $conf)
-                        """, 
-                getParams("meta-llama/Llama-2-70b-chat-hf"),
-                (row) -> assertChatCompletion(row, "gpt2"));
-    }
+//    @Test
+//    public void chatCompletion() {
+//        testCall(db, """
+//                        CALL apoc.ml.openai.chat([
+//                                    {
+//                                    	inputs: "non so"
+//                                    }
+//                        ],  $apiKey, $conf)
+//                        """, 
+//                getParams("meta-llama/Llama-2-70b-chat-hf"),
+//                (row) -> assertChatCompletion(row, "gpt2"));
+//    }
 
     private Map<String, Object> getParams(String model) {
-        return Map.of("apiKey", openaiKey,
-                "conf", Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/gpt2",
-                        API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGING_FACE.name(),
+        return Map.of(//"apiKey", openaiKey,
+                "conf", Map.of(//ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/gpt2",
+                        API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name(),
                         "model", model
                 )
         );

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -49,6 +49,7 @@ public class OpenAIOpenLMIT {
         String modelId = "gpt2";
         Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/" + modelId,
                 API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name(),
+                PATH_CONF_KEY, "",
                 MODEL_CONF_KEY, modelId
         );
         testCall(db, COMPLETION_QUERY,

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -1,0 +1,67 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Map;
+
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
+import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.util.TestUtil.testCall;
+
+public class OpenAIOpenLMIT {
+
+    private String openaiKey;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        openaiKey = System.getenv("OPENAI_KEY");
+        Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+                getParams("thenlper/gte-large"),
+                OpenAITestResultUtils::assertEmbeddings);
+    }
+
+    @Test
+    public void completion() {
+        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+                getParams("Meta-Llama/Llama-Guard-7b"),
+                (row) -> assertCompletion(row, "gpt2"));
+    }
+
+    @Test
+    public void chatCompletion() {
+        testCall(db, """
+                        CALL apoc.ml.openai.chat([
+                                    {
+                                    	inputs: "non so"
+                                    }
+                        ],  $apiKey, $conf)
+                        """, 
+                getParams("meta-llama/Llama-2-70b-chat-hf"),
+                (row) -> assertChatCompletion(row, "gpt2"));
+    }
+
+    private Map<String, Object> getParams(String model) {
+        return Map.of("apiKey", openaiKey,
+                "conf", Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/gpt2",
+                        "model", model
+                )
+        );
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAITest.java
+++ b/extended/src/test/java/apoc/ml/OpenAITest.java
@@ -33,7 +33,7 @@ public class OpenAITest {
         // openaiKey = System.getenv("OPENAI_KEY");
         // Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
         var path = Paths.get(getUrlFileName("embeddings").toURI()).getParent().toUri();
-        System.setProperty(APOC_ML_OPENAI_URL, path.toString());
+        apocConfig().setProperty(APOC_ML_OPENAI_URL, path.toString());
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, OpenAI.class);
     }

--- a/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
+++ b/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
@@ -7,6 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenAITestResultUtils {
+    public static final String EMBEDDING_QUERY = "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)";
+    public static final String CHAT_COMPLETION_QUERY = """
+            CALL apoc.ml.openai.chat([
+            {role:"system", content:"Only answer with a single word"},
+            {role:"user", content:"What planet do humans live on?"}
+            ], $apiKey, $conf)
+            """;
+    public static final String COMPLETION_QUERY = "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)";
+    
     public static void assertEmbeddings(Map<String, Object> row) {
         assertEquals(0L, row.get("index"));
         assertEquals("Some Text", row.get("text"));


### PR DESCRIPTION
- Aggiunte configurazioni `path` per manipolare il suffisso dell'url (che di default è `/embeddings`, `/completions` e `/chat/completions`)
e `jsonPath` (per manipolare eventualmente il jsonPath restituito con api che non tornano una mappa, ma ad esempio una lista).
- Migliorato controllo per l'apiKey, che viene saltato se richiamo una api con url in locale (tramite `ExtendedUtil.isLocalAddress`), in quanto non è sempre necessario, come con [Local AI](https://localai.io/) e LLMatic](https://github.com/fardjad/node-llmatic)

- Aggiunti test per https://app.endpoints.anyscale.com/
- Aggiunti test per Local AI
- Aggiunti test per LLMatic (con degli assertEventually in quanto sono molto lenti e vanno spesso in SocketTimeout)
- Aggiunti test per simulare il comportamento di https://github.com/r2d4/openlm, che manipola API in modo che abbiano un formato compatibile con OpenAI. Fatti test con Cohere e HuggingFace. Come per la libreria, fatti test solo per le Completions API 
  - Per HuggingFace è stato aggiunto un OpenAIRequestHandler.Type, per trasformare l'input in un formato coerente con le Api HuggingFace (ossia `{"inputs": ["text...."]}`) e per non aggiungere `/completions` al base url
  - Per Cohere, aggiunta nota sulla documentazione per spiegare di esplicitare `path: ''`, altrimenti aggiunge `/completions` all'url, cosa non prevista dalle api cohere