### PR TITLE
Fixes 3751: Failed to invoke procedure apoc.cypher.mapParallel2: Caused by:RuntimeException: Error polling, timeout

### DIFF
--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -250,7 +250,6 @@ public class CypherExtended {
             while (result.hasNext()) {
                 terminationGuard.check();
                 Map<String, Object> res = EntityUtil.anyRebind(tx, result.next());
-//                Map<String, Object> res = tx == null ? result.next() : EntityUtil.anyRebind(tx, result.next());
                 queue.put(new RowResult(row++, res));
             }
             if (addStatistics) {
@@ -373,16 +372,16 @@ public class CypherExtended {
     public Stream<MapResult> mapParallel2(@Name("fragment") String fragment, @Name("params") Map<String, Object> params, @Name("list") List<Object> data, @Name("partitions") long partitions,@Name(value = "timeout",defaultValue = "10") long timeout) {
         final String statement = withParamsAndIterator(fragment, params.keySet(), "_");
         tx.execute("EXPLAIN " + statement).close();
-        BlockingQueue<RowResult> queue = new ArrayBlockingQueue<>(100000);
+        int queueCapacity = 100000;
+        BlockingQueue<RowResult> queue = new ArrayBlockingQueue<>(queueCapacity);
+        ArrayBlockingQueue<Transaction> transactions = new ArrayBlockingQueue<>(queueCapacity);
         Stream<List<Object>> parallelPartitions = Util.partitionSubList(data, (int)(partitions <= 0 ? PARTITIONS : partitions), null);
         Util.inFuture(pools, () -> {
             long total = parallelPartitions
                 .map((List<Object> partition) -> {
                     Transaction transaction = db.beginTx();
-                    Result result = transaction.execute(statement, parallelParams(params, "_", partition));
-                    try 
-//                                () 
-                    {
+                    transactions.add(transaction);
+                    try (Result result = transaction.execute(statement, parallelParams(params, "_", partition))) {
                         return consumeResult(result, queue, false, transaction);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
@@ -392,8 +391,9 @@ public class CypherExtended {
             return total;
         });
         
-        
-        return StreamSupport.stream(new QueueBasedSpliterator<>(queue, RowResult.TOMBSTONE, terminationGuard, (int)timeout),true).map((rowResult) -> new MapResult(rowResult.result));
+        return StreamSupport.stream(new QueueBasedSpliterator<>(queue, RowResult.TOMBSTONE, terminationGuard, (int)timeout),true)
+                .map(rowResult -> new MapResult(rowResult.result))
+                .onClose(() -> transactions.forEach(Transaction::close));
     }
 
     public Map<String, Object> parallelParams(@Name("params") Map<String, Object> params, String key, List<Object> partition) {

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -178,7 +178,7 @@ public class CypherExtended {
                 if (isPeriodicOperation(stmt)) {
                     Util.inThread(pools , () -> {
                         try {
-                            return db.executeTransactionally(stmt, params, result -> consumeResult(result, queue, addStatistics, timeout));
+                            return db.executeTransactionally(stmt, params, result -> consumeResult(result, queue, addStatistics, tx));
                         } catch (Exception e) {
                             collectError(queue, reportError, e, fileName);
                             return null;
@@ -188,7 +188,7 @@ public class CypherExtended {
                 else {
                     Util.inTx(db, pools, threadTx -> {
                         try (Result result = threadTx.execute(stmt, params)) {
-                            return consumeResult(result, queue, addStatistics, timeout);
+                            return consumeResult(result, queue, addStatistics, tx);
                         } catch (Exception e) {
                             collectError(queue, reportError, e, fileName);
                             return null;
@@ -231,7 +231,7 @@ public class CypherExtended {
             if (schemaOperation) {
                 Util.inTx(db, pools, txInThread -> {
                     try (Result result = txInThread.execute(stmt, params)) {
-                        return consumeResult(result, queue, addStatistics, timeout);
+                        return consumeResult(result, queue, addStatistics, tx);
                     } catch (Exception e) {
                         collectError(queue, reportError, e, fileName);
                         return null;
@@ -243,13 +243,14 @@ public class CypherExtended {
 
     private final static Pattern shellControl = Pattern.compile("^:?\\b(begin|commit|rollback)\\b", Pattern.CASE_INSENSITIVE);
 
-    private Object consumeResult(Result result, BlockingQueue<RowResult> queue, boolean addStatistics, long timeout) {
+    private Object consumeResult(Result result, BlockingQueue<RowResult> queue, boolean addStatistics, Transaction tx) {
         try {
             long time = System.currentTimeMillis();
             int row = 0;
             while (result.hasNext()) {
                 terminationGuard.check();
                 Map<String, Object> res = EntityUtil.anyRebind(tx, result.next());
+//                Map<String, Object> res = tx == null ? result.next() : EntityUtil.anyRebind(tx, result.next());
                 queue.put(new RowResult(row++, res));
             }
             if (addStatistics) {
@@ -377,9 +378,12 @@ public class CypherExtended {
         Util.inFuture(pools, () -> {
             long total = parallelPartitions
                 .map((List<Object> partition) -> {
-                    try (Transaction transaction = db.beginTx();
-                         Result result = transaction.execute(statement, parallelParams(params, "_", partition))) {
-                        return consumeResult(result, queue, false, timeout);
+                    Transaction transaction = db.beginTx();
+                    Result result = transaction.execute(statement, parallelParams(params, "_", partition));
+                    try 
+//                                () 
+                    {
+                        return consumeResult(result, queue, false, transaction);
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }}
@@ -387,6 +391,8 @@ public class CypherExtended {
             queue.put(RowResult.TOMBSTONE);
             return total;
         });
+        
+        
         return StreamSupport.stream(new QueueBasedSpliterator<>(queue, RowResult.TOMBSTONE, terminationGuard, (int)timeout),true).map((rowResult) -> new MapResult(rowResult.result));
     }
 

--- a/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
@@ -243,6 +243,11 @@ public class CypherEnterpriseExtendedTest {
 
             session.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n"));
         }
+
+        // Check that `SHOW TRANSACTIONS` just returns itself 
+        String showTransactionsQuery = "SHOW TRANSACTIONS";
+        testCall(session, showTransactionsQuery,
+                r -> assertEquals(showTransactionsQuery, r.get("currentQuery")));
     }
 
     public void testRunProcedureWithSimpleReturnResults(String query, Map<String, Object> params) {

--- a/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
@@ -231,13 +231,18 @@ public class CypherEnterpriseExtendedTest {
 
     @Test
     public void testCypherMapParallel2WithResults() {
-        String query = """
-                MATCH (n:ReturnQuery) WITH COLLECT(n) AS list
-                CALL apoc.cypher.mapParallel2('MATCH (_)-[r:REL]->(o:Other) RETURN r, o', {}, list, 1)
-                YIELD value RETURN value""";
-        Map<String, Object> params = Map.of("file", SIMPLE_RETURN_QUERIES);
+        // this test could cause flaky errors, 
+        // so we need to run the query several times to make sure it always works
+        for (int i = 0; i < 30; i++) {
+            String query = """
+                    MATCH (n:ReturnQuery) WITH COLLECT(n) AS list
+                    CALL apoc.cypher.mapParallel2('MATCH (_)-[r:REL]->(o:Other) RETURN r, o', {}, list, 1)
+                    YIELD value RETURN value""";
+            Map<String, Object> params = Map.of("file", SIMPLE_RETURN_QUERIES);
+            testCypherMapParallelCommon(query, params);
 
-        testCypherMapParallelCommon(query, params);
+            session.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n"));
+        }
     }
 
     public void testRunProcedureWithSimpleReturnResults(String query, Map<String, Object> params) {

--- a/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -5,6 +5,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.Utils;
 import apoc.util.collection.Iterators;
+import org.apache.commons.io.FileUtils;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -19,6 +20,8 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -46,11 +49,11 @@ import static org.neo4j.driver.internal.util.Iterables.count;
  * @since 08.05.16
  */
 public class CypherExtendedTest {
-
+    public static final String IMPORT_DIR = "src/test/resources";
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.allow_file_urls, true)
-            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, new File("src/test/resources").toPath().toAbsolutePath());
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, new File(IMPORT_DIR).toPath().toAbsolutePath());
 
     @Rule
     public ExpectedException thrown= ExpectedException.none();
@@ -226,7 +229,76 @@ public class CypherExtendedTest {
                     "RETURN value.title limit 5",
                 r -> assertEquals(5, Iterators.count(r)));
     }
-    
+
+    @Test
+    public void testIssue3751MapParallel2() {
+        int expected = 500;
+        db.executeTransactionally("UNWIND range(1, $int) as id CREATE (:Polling {id: id})",
+                Map.of("int", expected));
+
+        // the error is flaky, so we need to run the query several times to replicate it
+        for (int i = 0; i < 30; i++) {
+            testCallCount(db, """
+                            MATCH (n:Polling) WITH collect({childD: n}) as params \s
+                            CALL apoc.cypher.mapParallel2(" WITH _.childD as childD RETURN childD", {}, params, 6, 10)\s
+                            YIELD value RETURN value""",
+                    Map.of(),
+                    expected);
+        }
+    }
+
+    @Test
+    public void testIssue3751RunFiles() {
+        int numEntities = 500;
+        db.executeTransactionally("UNWIND range(1, $int) as id CREATE (:Polling {id: id})",
+                Map.of("int", numEntities));
+
+        for (int i = 0; i < 30; i++) {
+            int numFiles = 30;
+            List<String> files = Collections.nCopies(numFiles, "parallel.cypher");
+
+            int expected = numEntities * numFiles;
+            testCallCount(db, "CALL apoc.cypher.runFiles($files, {statistics: false})",
+                    Map.of("files", files),
+                    expected);
+        }
+    }
+
+    @Test
+    public void testIssue3751RunSchemaFiles() throws IOException {
+        for (int i = 0; i < 15; i++) {
+            int numFiles = 10;
+            List<File> files = new ArrayList<>();
+
+            for (int fileIdx = 0; fileIdx < numFiles; fileIdx++) {
+                String id = i + "" + fileIdx;
+                File file = new File(IMPORT_DIR, "schema" + id);
+
+                String content = """
+                            CREATE INDEX index%1$s FOR (n:Person%1$s) ON (n.name%1$s);
+                            CREATE INDEX secondIndex%1$s FOR (n:Foo%1$s) ON (n.bar%1$s);
+                            CREATE INDEX thirdIndex%1$s FOR (n:Ajeje%1$s) ON (n.brazorf%1$s);
+                            """
+                        .formatted(id);
+                
+                FileUtils.writeStringToFile(file,
+                        content,
+                        StandardCharsets.UTF_8);
+                
+                files.add(file);
+            }
+
+            // 4 is the number of indexes
+            int expected = numFiles * 3;
+            List<String> fileNames = files.stream().map(File::getName).toList();
+            testCallCount(db, "CALL apoc.cypher.runSchemaFiles($files, {statistics: true})",
+                    Map.of("files", fileNames),
+                    expected);
+        
+            files.forEach(File::delete);
+        }
+        
+    }
     
     @Test
     public void testRunFileWithParameters() throws Exception {

--- a/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -245,7 +245,14 @@ public class CypherExtendedTest {
                     Map.of(),
                     expected);
         }
+
+        // Check that `SHOW TRANSACTIONS` just returns itself 
+        String showTransactionsQuery = "SHOW TRANSACTIONS";
+        testCall(db, showTransactionsQuery,
+                r -> assertEquals(showTransactionsQuery, r.get("currentQuery")));
     }
+
+
 
     @Test
     public void testIssue3751RunFiles() {

--- a/extended/src/test/resources/parallel.cypher
+++ b/extended/src/test/resources/parallel.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Polling) SET n.test = date() RETURN n;


### PR DESCRIPTION
Fixes 3751

- Added fix like `https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3810`
- Changed transaction handling from try-with-res to [`transactions.add(transaction);`](https://github.com/vga91/neo4j-apoc-procedures/pull/420/files#diff-0be321a488b8e1a039cef51ff786b8142a2eac4a76f7585ff6121e4fc588dfc9R383)
- Added `SHOW TRANSACTIONS` tests
- Tested the `https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3899` case as well