### PR TITLE
Issue 3945: The apoc.bolt.* procedures fail together with the apoc.path.subgraphAll one

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.17.0-enterprise-debian',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.16.0-enterprise',
                 'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.17.0-debian',
                 'coreDir': 'apoc-core/core',
                 'testDockerBundle': false
@@ -131,7 +131,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.17.0"
+    neo4jVersion = "5.16.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/extended/src/main/java/apoc/bolt/BoltConnection.java
+++ b/extended/src/main/java/apoc/bolt/BoltConnection.java
@@ -25,7 +25,9 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.RelationshipType;
 
 import java.net.URISyntaxException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -60,7 +62,7 @@ public class BoltConnection {
                 SummaryCounters counters = statementResult.consume().counters();
                 return Stream.of(new RowResult(toMap(counters)));
             } else
-                return getRowResultStream(config.isVirtual(), session, params, statement);
+                return getRowResultStream(session, params, statement);
         });
     }
 
@@ -89,7 +91,7 @@ public class BoltConnection {
                     } else {
                         response.addAll(
                                 statementResult.stream()
-                                        .map(record -> buildRowResult(record, nodesCache, config.isVirtual()))
+                                        .map(record -> buildRowResult(record, nodesCache))
                                         .collect(Collectors.toList())
                         );
                     }
@@ -118,29 +120,43 @@ public class BoltConnection {
         return function.apply(transaction).onClose(transaction::commit).onClose(transaction::close);
     }
 
-    private RowResult buildRowResult(Record record, Map<Long,Object> nodesCache, boolean virtual) {
-        return new RowResult(record.asMap(value -> {
-            Object entity = value.asObject();
-            if (entity instanceof Node) return toNode(entity, virtual, nodesCache);
-            if (entity instanceof Relationship) return toRelationship(entity, virtual, nodesCache);
-            if (entity instanceof Path) return toPath(entity, virtual, nodesCache);
-            return entity;
-        }));
+    private RowResult buildRowResult(Record record, Map<Long, Object> nodesCache) {
+        return new RowResult(record.asMap(value -> convertRecursive(value, nodesCache)));
     }
 
-    private Stream<RowResult> getRowResultStream(boolean virtual, Session session, Map<String, Object> params, String statement) {
+    private Object convertRecursive(Object entity, Map<Long, Object> nodesCache) {
+        if (entity instanceof Value) return convertRecursive(((Value) entity).asObject(), nodesCache);
+        if (entity instanceof Node) return toNode(entity, nodesCache);
+        if (entity instanceof Relationship) return toRelationship(entity, nodesCache);
+        if (entity instanceof Path) return toPath(entity, nodesCache);
+        if (entity instanceof Collection) return toCollection((Collection) entity, nodesCache);
+        if (entity instanceof Map) return toMap((Map<String, Object>) entity, nodesCache);
+        return entity;
+    }
+
+    private Object toMap(Map<String, Object> entity, Map<Long, Object> nodeCache) {
+        return entity.entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleEntry(entry.getKey(), convertRecursive(entry.getValue(), nodeCache)))
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+    }
+
+    private Object toCollection(Collection entity, Map<Long, Object> nodeCache) {
+        return entity.stream().map(elem -> convertRecursive(elem, nodeCache)).collect(Collectors.toList());
+    }
+
+    private Stream<RowResult> getRowResultStream(Session session, Map<String, Object> params, String statement) {
         Map<Long, Object> nodesCache = new HashMap<>();
 
         return withTransaction(session, tx -> {
             ClosedAwareDelegatingIterator<Record> iterator = new ClosedAwareDelegatingIterator(tx.run(statement, params));
-            return Iterators.stream(iterator).map(record -> buildRowResult(record, nodesCache, virtual));
+            return Iterators.stream(iterator).map(record -> buildRowResult(record, nodesCache));
         });
     }
 
-    private Object toNode(Object value, boolean virtual, Map<Long, Object> nodesCache) {
+    private Object toNode(Object value, Map<Long, Object> nodesCache) {
         Value internalValue = ((InternalEntity) value).asValue();
         Node node = internalValue.asNode();
-        if (virtual) {
+        if (config.isVirtual()) {
             List<Label> labels = new ArrayList<>();
             node.labels().forEach(l -> labels.add(Label.label(l)));
             VirtualNode virtualNode = new VirtualNode(node.id(), labels.toArray(new Label[0]), node.asMap());
@@ -150,10 +166,10 @@ public class BoltConnection {
             return Util.map("entityType", internalValue.type().name(), "labels", node.labels(), "id", node.id(), "properties", node.asMap());
     }
 
-    private Object toRelationship(Object value, boolean virtual, Map<Long, Object> nodesCache) {
+    private Object toRelationship(Object value, Map<Long, Object> nodesCache) {
         Value internalValue = ((InternalEntity) value).asValue();
         Relationship relationship = internalValue.asRelationship();
-        if (virtual) {
+        if (config.isVirtual()) {
             VirtualNode start = (VirtualNode) nodesCache.getOrDefault(relationship.startNodeId(), new VirtualNode(relationship.startNodeId()));
             VirtualNode end = (VirtualNode) nodesCache.getOrDefault(relationship.endNodeId(), new VirtualNode(relationship.endNodeId()));
             VirtualRelationship virtualRelationship = new VirtualRelationship(relationship.id(), start, end, RelationshipType.withName(relationship.type()), relationship.asMap());
@@ -162,13 +178,13 @@ public class BoltConnection {
             return Util.map("entityType", internalValue.type().name(), "type", relationship.type(), "id", relationship.id(), "start", relationship.startNodeId(), "end", relationship.endNodeId(), "properties", relationship.asMap());
     }
 
-    private Object toPath(Object value, boolean virtual, Map<Long, Object> nodesCache) {
+    private Object toPath(Object value, Map<Long, Object> nodesCache) {
         List<Object> entityList = new LinkedList<>();
         Value internalValue = ((InternalPath) value).asValue();
         internalValue.asPath().forEach(p -> {
-            entityList.add(toNode(p.start(), virtual, nodesCache));
-            entityList.add(toRelationship(p.relationship(), virtual, nodesCache));
-            entityList.add(toNode(p.end(), virtual, nodesCache));
+            entityList.add(toNode(p.start(), nodesCache));
+            entityList.add(toRelationship(p.relationship(), nodesCache));
+            entityList.add(toNode(p.end(), nodesCache));
         });
         return entityList;
     }

--- a/extended/src/main/java/apoc/bolt/BoltConnection.java
+++ b/extended/src/main/java/apoc/bolt/BoltConnection.java
@@ -137,7 +137,7 @@ public class BoltConnection {
     private Object toMap(Map<String, Object> entity, Map<Long, Object> nodeCache) {
         return entity.entrySet().stream()
                 .map(entry -> new AbstractMap.SimpleEntry(entry.getKey(), convertRecursive(entry.getValue(), nodeCache)))
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
     }
 
     private Object toCollection(Collection entity, Map<Long, Object> nodeCache) {

--- a/extended/src/test/java/apoc/bolt/BoltTest.java
+++ b/extended/src/test/java/apoc/bolt/BoltTest.java
@@ -15,6 +15,8 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.driver.Session;
+import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -50,6 +52,7 @@ public class BoltTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -57,6 +60,7 @@ public class BoltTest {
         neo4jContainer.start();
         TestUtil.registerProcedure(db, Bolt.class, ExportCypher.class, Cypher.class, PathExplorer.class, GraphRefactoring.class);
         BOLT_URL = getBoltUrl().replaceAll("'", "");
+        session = neo4jContainer.getSession();
     }
 
     @AfterClass
@@ -67,15 +71,16 @@ public class BoltTest {
     @After
     public void after() {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
+        session.executeWrite(tx -> tx.run("MATCH (n:BoltStart), (m:Other) DETACH DELETE n, m").consume());
     }
 
     @Test
     public void testBoltLoadWithSubgraphAllQuery() {
-        neo4jContainer.getSession().executeWrite(tx -> tx.run("CREATE (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})").consume());
+        session.executeWrite(tx -> tx.run("CREATE (rootA:BoltStart {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})").consume());
 
         // procedure with config virtual: false
         String boltQuery = """
-            MATCH (rootA:Person {foobar: 'foobar'})
+            MATCH (rootA:BoltStart {foobar: 'foobar'})
             WITH rootA
             CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
             YIELD nodes, relationships
@@ -108,13 +113,13 @@ public class BoltTest {
                 });
         
         // check that `apoc.refactor.cloneSubgraph` after `apoc.bolt.load` creates entities correctly 
-        TestUtil.testCallCount(db, "MATCH (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1}) RETURN *",1);
+        TestUtil.testCallCount(db, "MATCH (rootA:BoltStart {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1}) RETURN *",1);
     }
     
     @Test
     public void testBoltExecuteWithSubgraphAllQuery() {
         String boltQuery = """
-            MERGE (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})
+            MERGE (rootA:BoltStart {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})
             WITH rootA
             CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
             YIELD nodes, relationships
@@ -142,13 +147,11 @@ public class BoltTest {
         String localStatement = "RETURN 'foobar' AS foobar";
         
         String remoteStatement = """
-            MERGE (rootA:Person {foobar: foobar})-[:VIEWED]->(:Other {id: 1})
+            MERGE (rootA:BoltStart {foobar: foobar})-[:VIEWED]->(:Other {id: 1})
             WITH rootA
             CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
             YIELD nodes, relationships
             RETURN nodes, relationships, rootA""";
-        
-        String boltUrl = BOLT_URL;
         
         String query = """
                    CALL apoc.bolt.load.fromLocal($boltUrl, $localStatement, $remoteStatement, {virtual: $virtual, readOnly: false}) YIELD row
@@ -157,12 +160,12 @@ public class BoltTest {
         
         // procedure with config virtual: true
         TestUtil.testCall(db, query,
-                Map.of("boltUrl", boltUrl, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", true),
+                Map.of("boltUrl", BOLT_URL, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", true),
                 this::virtualTrueEntitiesAssertions);
         
         // procedure with config virtual: false
         TestUtil.testCall(db, query,
-                Map.of("boltUrl", boltUrl, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", false),
+                Map.of("boltUrl", BOLT_URL, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", false),
                 this::virtualFalseEntitiesAssertions);
     }
 
@@ -181,7 +184,7 @@ public class BoltTest {
         assertEquals(RelationshipType.withName("VIEWED"), rel.getType());
 
         Node rootA = (Node) row.get("rootA");
-        assertEquals(List.of(Label.label("Person")), rootA.getLabels());
+        assertEquals(List.of(Label.label("BoltStart")), rootA.getLabels());
         assertEquals(Map.of("foobar", "foobar"), rootA.getAllProperties());
     }
 
@@ -200,13 +203,90 @@ public class BoltTest {
         assertEquals("VIEWED", rel.get("type"));
 
         Map rootA = (Map) row.get("rootA");
-        assertEquals(List.of("Person"), rootA.get("labels"));
+        assertEquals(List.of("BoltStart"), rootA.get("labels"));
         assertEquals(Map.of("foobar", "foobar"), rootA.get("properties"));
     }
 
     private void graphRefactorAssertions(Map<String, Object> r) {
         assertNull(r.get("error"));
         assertTrue(r.get("input") instanceof Long);
+    }
+
+    @Test
+    public void testBoltLoadReturningMapAndList() {
+        session.executeWrite(tx -> tx.run("CREATE (rootA:BoltStart {foobar: 'foobar'})-[:VIEWED {id: 2}]->(:Other {id: 1})").consume());
+        
+        // procedure with config virtual: false
+        String boltQuery = """
+            MATCH (start:BoltStart {foobar: 'foobar'})-[rel:VIEWED]->(end:Other)
+            WITH start, rel, end, [start, end, rel] as list
+            RETURN  start, rel, end, {keyOne: start, keyTwo: {innerKey: list}} as map, list""";
+
+        String boltLoadQuery = """
+                CALL apoc.bolt.load($boltUrl, $boltQuery, {}, {virtual: $virtual})
+                YIELD row
+                RETURN row""";
+
+        TestUtil.testCall(db, boltLoadQuery,
+                Map.of("boltUrl", BOLT_URL, "boltQuery", boltQuery, "virtual", true),
+                this::virtualTrueWithMapAndListAssertions);
+
+        TestUtil.testCall(db, boltLoadQuery,
+                Map.of("boltUrl", BOLT_URL, "boltQuery", boltQuery, "virtual", false),
+                this::virtualFalseWithMapAndListAssertions);
+    }
+
+    private void virtualFalseWithMapAndListAssertions(Map<String, Object> r) {
+        Map<String, Object> row = (Map<String, Object>) r.get("row");
+
+        Map start = (Map) row.get("start");
+        assertEquals("NODE", start.get("entityType")); 
+        Map end = (Map) row.get("end");
+        assertEquals("NODE", end.get("entityType"));
+        Map rel = (Map) row.get("rel");
+        assertEquals("RELATIONSHIP", rel.get("entityType"));
+
+        List<Map> list = (List<Map>) row.get("list");
+        assertEquals(3, list.size());
+
+        assertEquals(start, list.get(0));
+        assertEquals(end, list.get(1));
+        assertEquals(rel, list.get(2));
+        
+        Map map = (Map) row.get("map");
+        assertEquals(start, map.get("keyOne"));
+
+        Map mapKeyTwo = (Map) map.get("keyTwo");
+        assertEquals(list, mapKeyTwo.get("innerKey"));
+    }
+
+    private void virtualTrueWithMapAndListAssertions(Map<String, Object> r) {
+        Map<String, Object> row = (Map<String, Object>) r.get("row");
+
+        Node start = (Node) row.get("start");
+        assertEquals(List.of(Label.label("BoltStart")), start.getLabels());
+        assertEquals(Map.of("foobar", "foobar"), start.getAllProperties());
+        
+        Node end = (Node) row.get("end");
+        assertEquals(List.of(Label.label("Other")), end.getLabels());
+        assertEquals(Map.of("id", 1L), end.getAllProperties());
+        
+        Relationship rel = (Relationship) row.get("rel");
+        assertEquals(RelationshipType.withName("VIEWED"), rel.getType());
+        assertEquals(Map.of("id", 2L), rel.getAllProperties());
+
+        List<Entity> list = (List<Entity>) row.get("list");
+        assertEquals(3, list.size());
+
+        assertEquals(start, list.get(0));
+        assertEquals(end, list.get(1));
+        assertEquals(rel, list.get(2));
+        
+        Map map = (Map) row.get("map");
+        assertEquals(start, map.get("keyOne"));
+
+        Map mapKeyTwo = (Map) map.get("keyTwo");
+        assertEquals(list, mapKeyTwo.get("innerKey"));
     }
 
     @Test

--- a/extended/src/test/java/apoc/bolt/BoltTest.java
+++ b/extended/src/test/java/apoc/bolt/BoltTest.java
@@ -2,11 +2,14 @@ package apoc.bolt;
 
 import apoc.cypher.Cypher;
 import apoc.export.cypher.ExportCypher;
+import apoc.path.PathExplorer;
+import apoc.refactor.GraphRefactoring;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.ApocPackage;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -15,6 +18,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -27,7 +31,9 @@ import java.util.Map;
 
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.driver.Values.isoDuration;
 import static org.neo4j.driver.Values.point;
@@ -45,9 +51,9 @@ public class BoltTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        neo4jContainer = createEnterpriseDB(List.of(ApocPackage.EXTENDED), true).withInitScript("init_neo4j_bolt.cypher");
+        neo4jContainer = createEnterpriseDB(List.of(ApocPackage.EXTENDED, ApocPackage.CORE), true).withInitScript("init_neo4j_bolt.cypher");
         neo4jContainer.start();
-        TestUtil.registerProcedure(db, Bolt.class, ExportCypher.class, Cypher.class);
+        TestUtil.registerProcedure(db, Bolt.class, ExportCypher.class, Cypher.class, PathExplorer.class, GraphRefactoring.class);
     }
 
     @AfterClass
@@ -55,6 +61,147 @@ public class BoltTest {
         neo4jContainer.close();
     }
     
+    @After
+    public void after() {
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+    }
+
+    @Test
+    public void test() {
+        neo4jContainer.getSession().executeWrite(tx -> tx.run("CREATE (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})").consume());
+
+        String boltQuery = """
+            MATCH (rootA:Person {foobar: 'foobar'})
+            WITH rootA
+            CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
+            YIELD nodes, relationships
+            RETURN nodes, relationships, rootA""";
+        String boltUrl = getBoltUrl().replaceAll("'", "");
+        
+        String query = """
+                CALL apoc.bolt.load($boltUrl, $boltQuery, {}, {virtual: $virtual})
+                YIELD row
+                RETURN row""";
+
+        TestUtil.testCall(db, query,
+                Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", false),
+                this::virtualFalseEntitiesAssertions);
+
+
+        String query1 = """
+                CALL apoc.bolt.load($boltUrl, $boltQuery, {}, {virtual: $virtual}) YIELD row
+                WITH row
+                WITH row.nodes AS nodes, row.relationships AS relationships, row.rootA AS rootA
+                CALL apoc.refactor.cloneSubgraph(nodes, relationships)
+                YIELD input, output, error
+                RETURN input, output, error;""";
+        TestUtil.testResult(db, query1,
+                Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", true),
+                r -> {
+                    graphRefactorAssertions(r.next());
+                    graphRefactorAssertions(r.next());
+                    assertFalse(r.hasNext());
+                });
+
+        TestUtil.testCallCount(db, "MATCH (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1}) RETURN *",1);
+    }
+    
+    @Test
+    public void test2() {
+
+        String boltQuery = """
+            MERGE (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})
+            WITH rootA
+            CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
+            YIELD nodes, relationships
+            RETURN nodes, relationships, rootA""";
+        String boltUrl = getBoltUrl().replaceAll("'", "");
+        
+        String query = """
+                   CALL apoc.bolt.execute($boltUrl, $boltQuery, {}, {virtual: $virtual}) YIELD row
+                   WITH row
+                   RETURN row""";
+        
+        TestUtil.testCall(db, query,
+                Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", true),
+                this::virtualTrueEntitiesAssertions);
+
+
+        TestUtil.testCall(db, query,
+                Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", false),
+                this::virtualFalseEntitiesAssertions);
+    }
+    
+    @Test
+    public void test3() {
+        String localStatement = "RETURN 'foobar' AS foobar";
+        
+        String remoteStatement = """
+            MERGE (rootA:Person {foobar: foobar})-[:VIEWED]->(:Other {id: 1})
+            WITH rootA
+            CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
+            YIELD nodes, relationships
+            RETURN nodes, relationships, rootA""";
+        
+        String boltUrl = getBoltUrl().replaceAll("'", "");
+        
+        String query = """
+                   CALL apoc.bolt.load.fromLocal($boltUrl, $localStatement, $remoteStatement, {virtual: $virtual, readOnly: false}) YIELD row
+                   WITH row
+                   RETURN row""";
+        
+        TestUtil.testCall(db, query,
+                Map.of("boltUrl", boltUrl, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", true),
+                this::virtualTrueEntitiesAssertions);
+
+        TestUtil.testCall(db, query,
+                Map.of("boltUrl", boltUrl, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", false),
+                this::virtualFalseEntitiesAssertions);
+    }
+
+    private void virtualTrueEntitiesAssertions(Map<String, Object> r) {
+        Map<String, Object> row = (Map<String, Object>) r.get("row");
+        List<Node> nodes = (List<Node>) row.get("nodes");
+        assertEquals(2, nodes.size());
+        List<Long> ids = nodes.stream().map(i -> i.getId()).toList();
+
+        List<Relationship> relationships = (List<Relationship>) row.get("relationships");
+        assertEquals(1, relationships.size());
+
+        Relationship rel = relationships.get(0);
+        assertTrue(ids.contains(rel.getStartNodeId()));
+        assertTrue(ids.contains(rel.getEndNodeId()));
+        assertEquals(RelationshipType.withName("VIEWED"), rel.getType());
+
+        Node rootA = (Node) row.get("rootA");
+        assertEquals(List.of(Label.label("Person")), rootA.getLabels());
+        assertEquals(Map.of("foobar", "foobar"), rootA.getAllProperties());
+    }
+
+    private void virtualFalseEntitiesAssertions(Map<String, Object> r) {
+        Map<String, Object> row = (Map<String, Object>) r.get("row");
+        List<Map> nodes = (List<Map>) row.get("nodes");
+        assertEquals(2, nodes.size());
+        List<Long> ids = nodes.stream().map(i -> (Long) i.get("id")).toList();
+
+        List<Map> relationships = (List<Map>) row.get("relationships");
+        assertEquals(1, relationships.size());
+
+        Map rel = relationships.get(0);
+        assertTrue(ids.contains((Long) rel.get("start")));
+        assertTrue(ids.contains((Long) rel.get("end")));
+        assertEquals("VIEWED", rel.get("type"));
+
+        Map rootA = (Map) row.get("rootA");
+        assertEquals(List.of("Person"), rootA.get("labels"));
+        assertEquals(Map.of("foobar", "foobar"), rootA.get("properties"));
+    }
+
+    private void graphRefactorAssertions(Map<String, Object> r) {
+        assertNull(r.get("error"));
+        assertTrue(r.get("input") instanceof Long);
+    }
+
     @Test
     public void testNeo4jBolt() {
         final String uriDbBefore4 = System.getenv("URI_DB_BEFORE_4");

--- a/extended/src/test/java/apoc/bolt/BoltTest.java
+++ b/extended/src/test/java/apoc/bolt/BoltTest.java
@@ -44,6 +44,8 @@ import static org.neo4j.driver.Values.point;
  */
 public class BoltTest {
 
+    public static String BOLT_URL;
+    
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
@@ -54,6 +56,7 @@ public class BoltTest {
         neo4jContainer = createEnterpriseDB(List.of(ApocPackage.EXTENDED, ApocPackage.CORE), true).withInitScript("init_neo4j_bolt.cypher");
         neo4jContainer.start();
         TestUtil.registerProcedure(db, Bolt.class, ExportCypher.class, Cypher.class, PathExplorer.class, GraphRefactoring.class);
+        BOLT_URL = getBoltUrl().replaceAll("'", "");
     }
 
     @AfterClass
@@ -67,73 +70,75 @@ public class BoltTest {
     }
 
     @Test
-    public void test() {
+    public void testBoltLoadWithSubgraphAllQuery() {
         neo4jContainer.getSession().executeWrite(tx -> tx.run("CREATE (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})").consume());
 
+        // procedure with config virtual: false
         String boltQuery = """
             MATCH (rootA:Person {foobar: 'foobar'})
             WITH rootA
             CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
             YIELD nodes, relationships
             RETURN nodes, relationships, rootA""";
-        String boltUrl = getBoltUrl().replaceAll("'", "");
         
-        String query = """
-                CALL apoc.bolt.load($boltUrl, $boltQuery, {}, {virtual: $virtual})
+        String boltLoadQueryVirtualFalse = """
+                CALL apoc.bolt.load($boltUrl, $boltQuery, {}, {virtual: false})
                 YIELD row
                 RETURN row""";
 
-        TestUtil.testCall(db, query,
-                Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", false),
+        TestUtil.testCall(db, boltLoadQueryVirtualFalse,
+                Map.of("boltUrl", BOLT_URL, "boltQuery", boltQuery, "virtual", false),
                 this::virtualFalseEntitiesAssertions);
 
-
-        String query1 = """
-                CALL apoc.bolt.load($boltUrl, $boltQuery, {}, {virtual: $virtual}) YIELD row
+        // procedure with config virtual: true
+        String boltLoadQueryVirtualTrue = """
+                CALL apoc.bolt.load($boltUrl, $boltQuery, {}, {virtual: true}) YIELD row
                 WITH row
                 WITH row.nodes AS nodes, row.relationships AS relationships, row.rootA AS rootA
                 CALL apoc.refactor.cloneSubgraph(nodes, relationships)
                 YIELD input, output, error
                 RETURN input, output, error;""";
-        TestUtil.testResult(db, query1,
-                Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", true),
+        
+        TestUtil.testResult(db, boltLoadQueryVirtualTrue,
+                Map.of("boltUrl", BOLT_URL, "boltQuery", boltQuery, "virtual", true),
                 r -> {
                     graphRefactorAssertions(r.next());
                     graphRefactorAssertions(r.next());
                     assertFalse(r.hasNext());
                 });
-
+        
+        // check that `apoc.refactor.cloneSubgraph` after `apoc.bolt.load` creates entities correctly 
         TestUtil.testCallCount(db, "MATCH (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1}) RETURN *",1);
     }
     
     @Test
-    public void test2() {
-
+    public void testBoltExecuteWithSubgraphAllQuery() {
         String boltQuery = """
             MERGE (rootA:Person {foobar: 'foobar'})-[:VIEWED]->(:Other {id: 1})
             WITH rootA
             CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'VIEWED>'})
             YIELD nodes, relationships
             RETURN nodes, relationships, rootA""";
-        String boltUrl = getBoltUrl().replaceAll("'", "");
+        String boltUrl = BOLT_URL;
         
         String query = """
                    CALL apoc.bolt.execute($boltUrl, $boltQuery, {}, {virtual: $virtual}) YIELD row
                    WITH row
                    RETURN row""";
-        
+
+        // procedure with config virtual: true
         TestUtil.testCall(db, query,
                 Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", true),
                 this::virtualTrueEntitiesAssertions);
-
-
+        
+        // procedure with config virtual: false
         TestUtil.testCall(db, query,
                 Map.of("boltUrl", boltUrl, "boltQuery", boltQuery, "virtual", false),
                 this::virtualFalseEntitiesAssertions);
     }
     
     @Test
-    public void test3() {
+    public void testBoltFromLocalWithSubgraphAllQuery() {
         String localStatement = "RETURN 'foobar' AS foobar";
         
         String remoteStatement = """
@@ -143,17 +148,19 @@ public class BoltTest {
             YIELD nodes, relationships
             RETURN nodes, relationships, rootA""";
         
-        String boltUrl = getBoltUrl().replaceAll("'", "");
+        String boltUrl = BOLT_URL;
         
         String query = """
                    CALL apoc.bolt.load.fromLocal($boltUrl, $localStatement, $remoteStatement, {virtual: $virtual, readOnly: false}) YIELD row
                    WITH row
                    RETURN row""";
         
+        // procedure with config virtual: true
         TestUtil.testCall(db, query,
                 Map.of("boltUrl", boltUrl, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", true),
                 this::virtualTrueEntitiesAssertions);
-
+        
+        // procedure with config virtual: false
         TestUtil.testCall(db, query,
                 Map.of("boltUrl", boltUrl, "localStatement", localStatement, "remoteStatement", remoteStatement, "virtual", false),
                 this::virtualFalseEntitiesAssertions);
@@ -553,7 +560,7 @@ public class BoltTest {
         String localStatement = "RETURN 'foobar' AS foobar";
         String remoteStatement = "CREATE (n: TestLoadFromLocalNode { m: foobar })";
         final Map<String, Object> map = Util.map(
-                "url", getBoltUrl().replaceAll("'", ""),
+                "url", BOLT_URL,
                 "localStatement", localStatement,
                 "remoteStatement", remoteStatement,
                 "config", Util.map("readOnly", false));
@@ -567,7 +574,7 @@ public class BoltTest {
     public void testLoadFromLocalStream() {
         String localStatement = "RETURN \"CREATE (n: TestLoadFromLocalStream)\" AS statement";
         final Map<String, Object> map = Util.map(
-                "url", getBoltUrl().replaceAll("'", ""),
+                "url", BOLT_URL,
                 "localStatement", localStatement,
                 "remoteStatement", null,
                 "config", Util.map("readOnly", false, "streamStatements", true));
@@ -577,7 +584,7 @@ public class BoltTest {
         assertEquals(1L, remoteCount);
     }
 
-    private String getBoltUrl() {
+    private static String getBoltUrl() {
         return String.format("'bolt://neo4j:%s@%s:%s'",
                 TestContainerUtil.password,
                 neo4jContainer.getContainerIpAddress(),

--- a/extended/src/test/java/apoc/coll/CollExtendedTest.java
+++ b/extended/src/test/java/apoc/coll/CollExtendedTest.java
@@ -1,5 +1,7 @@
 package apoc.coll;
 
+import apoc.bolt.Bolt;
+import apoc.path.PathExplorer;
 import apoc.util.TestUtil;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -25,8 +27,9 @@ public class CollExtendedTest {
     
     @BeforeClass
     public static void setUp() throws Exception {
-        TestUtil.registerProcedure(db, CollExtended.class);
+        TestUtil.registerProcedure(db, CollExtended.class, Bolt.class, PathExplorer.class);
     }
+
 
     @Test
     public void testAvgDuration() {

--- a/extended/src/test/java/apoc/coll/CollExtendedTest.java
+++ b/extended/src/test/java/apoc/coll/CollExtendedTest.java
@@ -1,7 +1,5 @@
 package apoc.coll;
 
-import apoc.bolt.Bolt;
-import apoc.path.PathExplorer;
 import apoc.util.TestUtil;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -27,9 +25,8 @@ public class CollExtendedTest {
     
     @BeforeClass
     public static void setUp() throws Exception {
-        TestUtil.registerProcedure(db, CollExtended.class, Bolt.class, PathExplorer.class);
+        TestUtil.registerProcedure(db, CollExtended.class);
     }
-
 
     @Test
     public void testAvgDuration() {


### PR DESCRIPTION
NB: 
to execute tests locally, change `5.18.0"` to `5.16.0"` in `apoc-core/build.gradle` (which is ignored by git)

---



Issue 3945: `https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3945`

- Fixes issue case, by adding `convertRecursive` to handle maps and collections (https://github.com/vga91/neo4j-apoc-procedures/pull/424/files#diff-c0b63ee9409cc47b02b4dac7a4386af00b6ccef90d10fa251f564af5abb14937R137)
- Tested `apoc.bolt.load` returning map and list
- Tested with other apoc.bolt.* procedures
- Verified that you can use, 
subsequent to the `apoc.bolt.load` procedure, the `apoc.refactor.cloneSubgraph` as requested [by the user on slack here](https://neo4j.slack.com/archives/C136J23GE/p1707239672283549), i.e.:
```
Hello,
I have a question.
Do you have anything like apoc.refactor.cloneSubgraph but that can clone a subgraph from a db to another one?
Thanks.

...

And when calling apoc.refactor.cloneSubgraph I get
MERGE (rootB:CVE {id:'CVE-ROOT'})
WITH rootB
call apoc.bolt.load("bolt://neo4j:admin1234@localhost:7688","
    MATCH  (rootA:CVE{id:'CVE-2010-3544'})
    CALL apoc.path.subgraphAll(rootA, {relationshipFilter:'IS_APPLICABLE_IN>'})
    YIELD nodes, relationships
    RETURN nodes, relationships,rootA
", {id:'CVE-2010-3548', databaseName:'neo4j'}) YIELD row
WITH row, rootB
WITH row.nodes AS nodes, row.relationships AS relationships ,row.rootA AS rootA, rootB
CALL apoc.refactor.cloneSubgraph(
    nodes,
    [rel in relationships WHERE type(rel) = 'IS_APPLICABLE_IN'],
    { standinNodes:[[rootA, rootB]] })
YIELD input, output, error
RETURN input, output, error;

```

- refactorings: 
  - leverage `config.isVirtual()` instead of `virtual` as a parameter in BoltConnection.java
  - added a `public static String BOLT_URL;` in `BoltTest.java`

