### PR TITLE
Issue 1948: multi char separator in apoc.load.csv

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.18.0"
+    neo4jVersion = "5.16.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation project(':common')
     implementation group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.15.3'
-    implementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
+    implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.10.0'
     implementation group: 'us.fatehi', name: 'schemacrawler', version: '15.04.01'
 
     // These will be dependencies not packaged with the .jar
@@ -147,7 +147,7 @@ dependencies {
     testImplementation group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.9.0'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
     testImplementation group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', withoutServers
-
+    testImplementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/extended/src/main/java/apoc/load/LoadCsv.java
+++ b/extended/src/main/java/apoc/load/LoadCsv.java
@@ -6,10 +6,6 @@ import apoc.load.util.LoadCsvConfig;
 import apoc.util.ExtendedUtil;
 import apoc.util.FileUtils;
 import apoc.util.Util;
-import com.opencsv.CSVParserBuilder;
-import com.opencsv.CSVReader;
-import com.opencsv.CSVReaderBuilder;
-import com.opencsv.exceptions.CsvValidationException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
@@ -27,6 +23,9 @@ import apoc.load.util.Results;
 import static apoc.util.ExtendedFileUtils.closeReaderSafely;
 import static apoc.util.Util.cleanUrl;
 import static java.util.Collections.emptyList;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
 
 @Extended
 public class LoadCsv {
@@ -57,7 +56,7 @@ public class LoadCsv {
             }
             reader = FileUtils.readerFor(urlOrBinary, httpHeaders, payload, config.getCompressionAlgo(), urlAccessChecker);
             return streamCsv(url, config, reader);
-        } catch (IOException | CsvValidationException e) {
+        } catch (IOException e) {
             closeReaderSafely(reader);
             if(!config.isFailOnError())
                 return Stream.of(new CSVResult(new String[0], new String[0], 0, true, Collections.emptyMap(), emptyList(), EnumSet.noneOf(Results.class)));
@@ -66,29 +65,27 @@ public class LoadCsv {
         }
     }
 
-    public Stream<CSVResult> streamCsv(@Name("url") String url, LoadCsvConfig config, CountingReader reader) throws IOException, CsvValidationException {
+    public Stream<CSVResult> streamCsv(@Name("url") String url, LoadCsvConfig config, CountingReader reader) throws IOException {
 
-        CSVReader csv = new CSVReaderBuilder(reader)
-                .withCSVParser(new CSVParserBuilder()
-                        .withEscapeChar(config.getEscapeChar())
-                        .withQuoteChar(config.getQuoteChar())
-                        .withIgnoreQuotations( config.isIgnoreQuotations() )
-                        .withSeparator(config.getSeparator())
-                        .build())
+        CSVFormat csvFormat = CSVFormat.DEFAULT.builder()
+                .setEscape(config.getEscapeChar())
+                .setQuote(config.isIgnoreQuotations() ? '\0' : config.getQuoteChar())
+                .setDelimiter(config.getSeparator())
                 .build();
 
-        String[] header = getHeader(csv, config);
+        Iterator<CSVRecord> csvIterator = csvFormat.parse(reader).iterator();
+
+        String[] header = getHeader(csvIterator, config);
         boolean checkIgnore = !config.getIgnore().isEmpty() || config.getMappings().values().stream().anyMatch(m -> m.ignore);
-        return StreamSupport.stream(new CSVSpliterator(csv, header, url, config.getSkip(), config.getLimit(),
-                checkIgnore, config.getMappings(), config.getNullValues(), config.getResults(), config.getIgnoreErrors()), false)
-                .onClose(() -> closeReaderSafely(reader));
+        return StreamSupport.stream(new CSVSpliterator(csvIterator, header, url, config.getSkip(), config.getLimit(),
+                checkIgnore, config.getMappings(), config.getNullValues(), config.getResults(), config.getIgnoreErrors(), config.isIgnoreQuotations(), config.getQuoteChar()), false);
     }
 
     private static final Mapping EMPTY = new Mapping("", Collections.emptyMap(), LoadCsvConfig.DEFAULT_ARRAY_SEP, false);
 
-    private String[] getHeader(CSVReader csv, LoadCsvConfig config) throws IOException, CsvValidationException {
+    private String[] getHeader(Iterator<CSVRecord> csv, LoadCsvConfig config) throws IOException {
         if (!config.isHasHeader()) return null;
-        String[] headers = csv.readNext();
+        String[] headers = csv.next().values();
         List<String> ignore = config.getIgnore();
         if (ignore.isEmpty()) return headers;
 
@@ -103,7 +100,7 @@ public class LoadCsv {
     }
 
     private static class CSVSpliterator extends Spliterators.AbstractSpliterator<CSVResult> {
-        private final CSVReader csv;
+        private final Iterator<CSVRecord> csv;
         private final String[] header;
         private final String url;
         private final long limit;
@@ -112,9 +109,11 @@ public class LoadCsv {
         private final List<String> nullValues;
         private final EnumSet<Results> results;
         private final boolean ignoreErrors;
+        private final boolean ignoreQuotations;
+        private final String quoteChar;
         long lineNo;
 
-        public CSVSpliterator(CSVReader csv, String[] header, String url, long skip, long limit, boolean ignore, Map<String, Mapping> mapping, List<String> nullValues, EnumSet<Results> results, boolean ignoreErrors) throws IOException, CsvValidationException {
+        public CSVSpliterator(Iterator<CSVRecord> csv, String[] header, String url, long skip, long limit, boolean ignore, Map<String, Mapping> mapping, List<String> nullValues, EnumSet<Results> results, boolean ignoreErrors, boolean ignoreQuotations, char quoteChar) throws IOException {
             super(Long.MAX_VALUE, Spliterator.ORDERED);
             this.csv = csv;
             this.header = header;
@@ -126,25 +125,35 @@ public class LoadCsv {
             this.ignoreErrors = ignoreErrors;
             this.limit = ExtendedUtil.isSumOutOfRange(skip, limit) ? Long.MAX_VALUE : (skip + limit);
             lineNo = skip;
+            this.ignoreQuotations = ignoreQuotations;
+            this.quoteChar = String.valueOf(quoteChar);
             while (skip-- > 0) {
-                csv.readNext();
+                csv.next();
             }
         }
 
         @Override
         public boolean tryAdvance(Consumer<? super CSVResult> action) {
             try {
-                String[] row = csv.readNext();
-                if (row != null && lineNo < limit) {
+                if (csv.hasNext() && lineNo < limit) {
+                    String[] row = csv.next().values();
+                    removeQuotes(row, ignoreQuotations, quoteChar);
                     action.accept(new CSVResult(header, row, lineNo, ignore,mapping, nullValues,results));
                     lineNo++;
                     return true;
                 }
                 return false;
-            } catch (IOException | CsvValidationException e) {
-                throw new RuntimeException("Error reading CSV from " + (url == null ? "binary" : " URL " + cleanUrl(url)) + " at " + lineNo, e);
             } catch (ArrayIndexOutOfBoundsException e) {
                 throw new RuntimeException("Error reading CSV from " + (url == null ? "binary" : " URL " + cleanUrl(url)) + " at " + lineNo + ". Please check whether you included a delimiter before a column separator or forgot a column separator.");
+            }
+        }
+
+        private void removeQuotes(String[] row, boolean ignoreQuotations, String quoteChar) {
+            if (!ignoreQuotations) {
+                return;
+            }
+            for (int i = 0; i < row.length; i++) {
+                row[i] = row[i].replace(quoteChar, "");
             }
         }
     }

--- a/extended/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/extended/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -13,13 +13,13 @@ import static java.util.Collections.emptyList;
 public class LoadCsvConfig extends CompressionConfig {
 
     public static final char DEFAULT_ARRAY_SEP = ';';
-    public static final char DEFAULT_SEP = ',';
+    public static final String DEFAULT_SEP = ",";
     public static final char DEFAULT_QUOTE_CHAR = '"';
     // this is the same value as ICSVParser.DEFAULT_ESCAPE_CHARACTER
     public static final char DEFAULT_ESCAPE_CHAR = '\\';
 
     private final boolean ignoreErrors;
-    private char separator;
+    private String separator;
     private char arraySep;
     private char quoteChar;
     private char escapeChar;
@@ -43,7 +43,7 @@ public class LoadCsvConfig extends CompressionConfig {
             config = Collections.emptyMap();
         }
         ignoreErrors = Util.toBoolean(config.getOrDefault("ignoreErrors", false));
-        separator = parseCharFromConfig(config, "sep", DEFAULT_SEP);
+        separator = parseStringFromConfig(config, "sep", DEFAULT_SEP);
         arraySep = parseCharFromConfig(config, "arraySep", DEFAULT_ARRAY_SEP);
         quoteChar = parseCharFromConfig(config,"quoteChar", DEFAULT_QUOTE_CHAR);
         escapeChar = parseCharFromConfig(config,"escapeChar", DEFAULT_ESCAPE_CHAR);
@@ -66,6 +66,18 @@ public class LoadCsvConfig extends CompressionConfig {
         mappings = createMapping(mapping, arraySep, ignore);
     }
 
+    private static String parseStringFromConfig(Map<String, Object> config, String key, String defaultValue) {
+        String separator = (String) config.getOrDefault(key, defaultValue);
+        if ("TAB".equals(separator)) {
+            return "\t";
+        }
+        if ("NONE".equals(separator)) {
+            return "\0";
+        }
+        return separator;
+    }
+
+
     private Map<String, Mapping> createMapping(Map<String, Map<String, Object>> mapping, char arraySep, List<String> ignore) {
         if (mapping.isEmpty()) return Collections.emptyMap();
         HashMap<String, Mapping> result = new HashMap<>(mapping.size());
@@ -76,7 +88,7 @@ public class LoadCsvConfig extends CompressionConfig {
         return result;
     }
 
-    public char getSeparator() {
+    public String getSeparator() {
         return separator;
     }
 

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -115,6 +115,16 @@ public class LoadCsvTest {
                     assertFalse(r.hasNext());
                 });
     }
+    
+    @Test
+    public void testLoadCsvWithMultiCharSeparator(){
+        String url = "testMultiCharSep.csv";
+        Map<String, Object> conf = map("results", List.of("map","list","stringMap","strings"),
+                "sep", "SEP");
+        testResult(db, "CALL apoc.load.csv($url, $conf)", 
+                map("url",url, "conf", conf),
+                this::commonAssertionsLoadCsv);
+    }
 
 
     private void commonAssertionsLoadCsv(Result r) {
@@ -216,13 +226,6 @@ RETURN m.col_1,m.col_2,m.col_3
         final List<String> results = List.of("map", "list", "stringMap", "strings");
         testResult(db, "CALL apoc.load.csv($url, $config)",
                 map("url", url.toString(), "config", map("results", results)),
-                (r) -> {
-                    assertRow(r, 0L,"name", "Naruto", "surname","Uzumaki");
-                    assertRow(r, 1L,"name", "Minato", "surname","Namikaze");
-                    assertFalse(r.hasNext());
-                });
-        testResult(db, "CALL apoc.load.csv($url,$config)",
-                map("url", url.toString(), "config", map("results", results, "escapeChar", "NONE")),
                 (r) -> {
                     assertRow(r, 0L,"name", "Narut\\o", "surname","Uzu\\maki");
                     assertRow(r, 1L,"name", "Minat\\o", "surname","Nami\\kaze");

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -134,6 +134,24 @@ public class LoadCsvTest {
         assertFalse(r.hasNext());
     }
 
+    @Test
+    public void testLoadCsvWithNoneSeparator() {
+        String url = "test.csv";
+        testResult(db, "CALL apoc.load.csv($url, {sep:'NONE'})", map("url",url), // 'file:test.csv'
+                r -> {
+                    Object actualList = r.next().get("list");
+                    assertEquals(List.of("Selma,8"), actualList);
+                    
+                    actualList = r.next().get("list");
+                    assertEquals(List.of("Rana,11"), actualList);
+                    
+                    actualList = r.next().get("list");
+                    assertEquals(List.of("Selina,18"), actualList);
+                    
+                    assertFalse(r.hasNext());
+                });
+    }
+
     /*
     WITH 'file:///test.csv' AS url
 CALL apoc.load.csv(url,) YIELD map AS m

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -85,6 +85,37 @@ public class LoadCsvTest {
                         "conf", map(COMPRESSION, CompressionAlgo.DEFLATE.name(), "results", List.of("map", "list", "stringMap", "strings"))),
                 this::commonAssertionsLoadCsv);
     }
+    
+    @Test
+    public void testLoadCsvWithQuote() {
+        String url = "testQuote.csv";
+        testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url",url), // 'file:test.csv'
+                r -> {
+                    assertRow(r, 0L, "name", "Selma", "age", "8");
+                    assertRow(r, 1L, "name", "Rana", "age", "11");
+                    assertRow(r, 2L, "name", "Seli,na", "age", "18");
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void testLoadCsvWithQuoteAndIgnoreQuotations() {
+        String url = "testQuote.csv";
+        testResult(db, "CALL apoc.load.csv($url,{ignoreQuotations: true, results:['list']})", map("url",url), // 'file:test.csv'
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEquals(List.of("Selma","8"), row.get("list"));
+
+                    row = r.next();
+                    assertEquals(List.of("Rana","11"), row.get("list"));
+                    
+                    row = r.next();
+                    assertEquals(List.of("Seli", "na", "18"), row.get("list"));
+                    
+                    assertFalse(r.hasNext());
+                });
+    }
+
 
     private void commonAssertionsLoadCsv(Result r) {
         assertRow(r, 0L, "name", "Selma", "age", "8");

--- a/extended/src/test/resources/testMultiCharSep.csv
+++ b/extended/src/test/resources/testMultiCharSep.csv
@@ -1,0 +1,4 @@
+nameSEPage
+SelmaSEP8
+RanaSEP11
+SelinaSEP18

--- a/extended/src/test/resources/testQuote.csv
+++ b/extended/src/test/resources/testQuote.csv
@@ -1,0 +1,4 @@
+name,age
+"Selma","8"
+"Rana","11"
+"Seli,na","18"

--- a/extended/src/test/resources/testWithSingleQuote.csv
+++ b/extended/src/test/resources/testWithSingleQuote.csv
@@ -1,0 +1,4 @@
+name,age
+"Se,lma",8
+"Ran,a",11
+"Sel,ina",18


### PR DESCRIPTION
## Changes

- Increased test coverage: https://github.com/vga91/neo4j-apoc-procedures/pull/429/commits/93baf522d1306c3c3d6fc2376fee324e89030bec

- Changed to [apache commons csv](https://commons.apache.org/proper/commons-csv/) which supports multi char separators.

Remove quote is used to replace the behavior of withIgnoreQuotations, which removed quotes but if there was a separator character in the middle, it didn't escape it (test: `testLoadCsvWithQuoteAndIgnoreQuotations`)


NB: The only difference in the test cases, is `testLoadCsvEscape`, which however I think was a wrong behavior of `opencsv` which deleted the escape characters even if they had no escape function.


Changed opencsv in gradle to `testImplementation`, since is used [here](https://github.com/vga91/neo4j-apoc-procedures/blob/dev/extended/src/test/java/apoc/custom/SignatureTest.java#L74).
Maybe we can leverage apache commons also in that test.


---

## Alternatives

- Alternatively, there is a fork of [opencsv](https://mvnrepository.com/artifact/org.openrefine.dependencies/opencsv-multichar), but even though it is supposed to be a fork it has some different behaviors and it has not been supported for a long time



- Otherwise, a workaround is the following one, which anyway works only if all characters in the separator are the same, ignoring empty results:

```
.multichar.csv
----
Fo;;Bar;;Baz
One;;Two;;Three
Four;;1;;Five
----


Procedure
----
CALL apoc.load.csv("file.csv", {ignore:[""], 
  mapping: {Foo: {array: true, arraySep: "|"}},
  results: ["map","list", "stringMap", "strings"]})
YIELD lineNo, list, map RETURN *
----

.Result
---
| lineNo | list | map
| 0      | [["One"], "Two", "Three"]     | {"Bar": "Two", "Baz": "Three", "Foo": ["One"]}
| 1      | [["Is", "Splitted"], "1", ""] | {"Bar": "1", "Baz": "", "Foo": ["Is", "Splitted"]}
---
```
