### PR TITLE
Fixes 3798: apoc.cypher.runFile() - Unexpected behaviour with commented ;

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.18.0"
+    neo4jVersion = "5.17.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -182,7 +182,7 @@ public class CypherExtended {
     private void runDataStatementsInTx(Scanner scanner, BlockingQueue<RowResult> queue, Map<String, Object> params, boolean addStatistics, long timeout, boolean reportError, String fileName) {
         while (scanner.hasNext()) {
             String stmt = removeShellControlCommands(scanner.next());
-            if (stmt.trim().isEmpty()) continue;
+            if (isCommentOrEmpty(stmt)) continue;
             boolean schemaOperation;
             try {
                 schemaOperation = isSchemaOperation(stmt);
@@ -227,14 +227,14 @@ public class CypherExtended {
 
     private Scanner createScannerFor(Reader reader) {
         Scanner scanner = new Scanner(reader);
-        scanner.useDelimiter(";\r?\n");
+        scanner.useDelimiter(";\s*\r?\n");
         return scanner;
     }
 
     private void runSchemaStatementsInTx(Scanner scanner, BlockingQueue<RowResult> queue, Map<String, Object> params, boolean addStatistics, long timeout, boolean reportError, String fileName) {
         while (scanner.hasNext()) {
             String stmt = removeShellControlCommands(scanner.next());
-            if (stmt.trim().isEmpty()) continue;
+            if (isCommentOrEmpty(stmt)) continue;
             boolean schemaOperation;
             try {
                 schemaOperation = isSchemaOperation(stmt);
@@ -253,6 +253,11 @@ public class CypherExtended {
                 });
             }
         }
+    }
+
+    private static boolean isCommentOrEmpty(String stmt) {
+        String trimStatement = stmt.trim();
+        return trimStatement.isEmpty() || trimStatement.startsWith("//");
     }
 
     private final static Pattern shellControl = Pattern.compile("^:?\\b(begin|commit|rollback)\\b", Pattern.CASE_INSENSITIVE);

--- a/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.driver.types.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
@@ -149,6 +150,35 @@ public class CypherExtendedTest {
         testResult(db, "CALL apoc.cypher.runFile('create_delete.cypher')",
                 r -> {
                     assertCreateDeleteFile(r);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void testRunFileWithCommentsAndEmptyRows() throws Exception {
+        testResult(db, "CALL apoc.cypher.runFile('return.cypher', {statistics: false})",
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEquals(Map.of("\"Step 1\"", "Step 1"), row.get("result"));
+                    
+                    row = r.next();
+                    assertEquals(Map.of("row", "Step 3"), row.get("result"));
+                    
+                    row = r.next();
+                    assertEquals(Map.of("row", 6L), row.get("result"));
+                    
+                    row = r.next();
+                    assertEquals(Map.of("row", 7L), row.get("result"));
+                    
+                    row = r.next();
+                    assertEquals(Map.of("'8'", "8"), row.get("result"));
+                    
+                    row = r.next();
+                    assertEquals(Map.of("9", 9L), row.get("result"));
+                    
+                    row = r.next();
+                    assertEquals(Map.of("10", 10L), row.get("result"));
+                    
                     assertFalse(r.hasNext());
                 });
     }
@@ -615,6 +645,15 @@ public class CypherExtendedTest {
         try (Transaction tx = db.beginTx()) {
             assertEquals(expectedBefore + 4, count(tx.schema().getIndexes()));
         }
+    }
+
+    @Test
+    public void testRunSchemaFileWithCommentsAndEmptyRows() {
+        testResult(db, "CALL apoc.cypher.runSchemaFile('schemaWithCommentsAndEmptyRows.cypher')",
+                r -> {
+                    assertSchemaCypherFile(r);
+                    assertFalse(r.hasNext());
+                });
     }
 
     private void assertSchemaCypherFile(Result r) {

--- a/extended/src/test/resources/return.cypher
+++ b/extended/src/test/resources/return.cypher
@@ -1,0 +1,16 @@
+RETURN "Step 1"; 
+;
+// RETURN "Step 2" as row;
+ RETURN "Step 3" AS row;
+//    RETURN "Step 4" as row; 
+
+// RETURN "Step 5" as row;
+
+   RETURN 6 as row; 
+   // RETURN "Step 5" as row; // RETURN "Step 5" as row; 
+/*comment*/RETURN 7 /* comment*/ AS row;
+
+/*comment*/RETURN '8'/*comment*/;
+/*comment*/RETURN 9/*comment*/;
+;
+    /*comment*/RETURN 10/*comment*/

--- a/extended/src/test/resources/schemaWithCommentsAndEmptyRows.cypher
+++ b/extended/src/test/resources/schemaWithCommentsAndEmptyRows.cypher
@@ -1,0 +1,13 @@
+CREATE FULLTEXT INDEX CustomerIndex1 FOR (n:Customer1) ON EACH [n.name1];
+;
+    // RETURN "Step 2" as row;
+ CREATE FULLTEXT INDEX CustomerIndex21 FOR (n:Customer21) ON EACH [n.name12];
+  // RETURN "Step 4" as row;
+
+// RETURN "Step 5" as row; 
+
+  // RETURN "Step 5" as row; // RETURN "Step 5" as row; 
+  /*comment*/   CREATE FULLTEXT INDEX CustomerIndex231 FOR (n:Customer213) /* comment*/ ON EACH [n.name123];  
+;
+/*comment*/RETURN '8'/*comment*/;
+/*comment*/CREATE INDEX node_index_name FOR (n:Person) ON (n.surname);/*comment*/


### PR DESCRIPTION
Fixes `https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3798`

- fixed bug and added tests with comments and empty rows / spaces, for both schema and non-schema files

### Other changes

- added white spaces to `scanner.useDelimiter(...);`,
as it should work even if there is a semicolon with whitespace at the end of the line, i.e. `;  `