### PR TITLE
Fixes 3970: Add support for Mistral AI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.18.0"
+    neo4jVersion = "5.17.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/extended/src/test/java/apoc/ml/OpenAIMistralApiIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIMistralApiIT.java
@@ -1,0 +1,83 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Map;
+
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.CHAT_COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.EMBEDDING_QUERY;
+import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
+import static apoc.ml.OpenAITestResultUtils.assertEmbeddings;
+import static apoc.util.TestUtil.testCall;
+
+/**
+ * Tests with Mistral API: https://docs.mistral.ai/platform/endpoints/ 
+ */
+public class OpenAIMistralApiIT {
+
+    private String mistralApiKey;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+    @Before
+    public void setUp() throws Exception {
+        mistralApiKey = System.getenv("MISTRAL_API_KEY");
+        Assume.assumeNotNull("No MISTRAL_API_KEY environment configured", mistralApiKey);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void chatCompletionWithMistralLarge() {
+        chatCompletionTestCommon("mistral-large-latest");
+    }
+
+    @Test
+    public void chatCompletionWithMistralMedium() {
+        chatCompletionTestCommon("mistral-medium-latest");
+    }
+
+    @Test
+    public void chatCompletionWithMistralSmall() {
+        chatCompletionTestCommon("mistral-small-latest");
+    }
+
+    @Test
+    public void chatCompletionWithMistral8x7B() {
+        chatCompletionTestCommon("open-mixtral-8x7b");
+    }
+
+    @Test
+    public void chatCompletionWithMistral7B() {
+        chatCompletionTestCommon("open-mistral-7b");
+    }
+
+    @Test
+    public void chatCompletionWithMistralEmbed() {
+        String model = "mistral-embed";
+        testCall(db, EMBEDDING_QUERY,
+                getParams(model),
+                r -> assertEmbeddings(r, 1024));
+    }
+
+    private void chatCompletionTestCommon(String model) {
+        testCall(db, CHAT_COMPLETION_QUERY,
+                getParams(model),
+                (row) -> assertChatCompletion(row, model));
+    }
+
+    private Map<String, Object> getParams(String model) {
+        Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api.mistral.ai/v1",
+                MODEL_CONF_KEY, model);
+
+        return Map.of("apiKey", mistralApiKey, "conf", conf);
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
+++ b/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
@@ -15,12 +15,16 @@ public class OpenAITestResultUtils {
             ], $apiKey, $conf)
             """;
     public static final String COMPLETION_QUERY = "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)";
-    
+
     public static void assertEmbeddings(Map<String, Object> row) {
+        assertEmbeddings(row, 1536);
+    }
+
+    public static void assertEmbeddings(Map<String, Object> row, int embeddingSize) {
         assertEquals(0L, row.get("index"));
         assertEquals("Some Text", row.get("text"));
         var embedding = (List<Double>) row.get("embedding");
-        assertEquals(1536, embedding.size());
+        assertEquals(embeddingSize, embedding.size());
     }
 
     public static void assertCompletion(Map<String, Object> row, String expectedModel) {


### PR DESCRIPTION
Fixes 3970

The procedures are completely compatible with OpenAI, 
both the endpoint final parts (i.e. `/chat/completions` and `/embeddings`) and the headers,
so the integration test has just been created.