### PR TITLE
Fixes 3611: ML API procedures handle null values being passed in better

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.19.0"
+    neo4jVersion = "5.18.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/extended/src/main/java/apoc/ml/MLUtil.java
+++ b/extended/src/main/java/apoc/ml/MLUtil.java
@@ -1,0 +1,5 @@
+package apoc.ml;
+
+public class MLUtil {
+    public static final String ERROR_NULL_INPUT = "The input provided is null. Please specify a valid input";
+}

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -114,6 +114,10 @@ public class OpenAI {
       "model": "text-embedding-ada-002",
       "usage": { "prompt_tokens": 8, "total_tokens": 8 } }
     */
+        if (texts == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
+        
         Map<Boolean, List<String>> collect = texts.stream()
                 .collect(Collectors.groupingBy(Objects::nonNull));
 

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -16,6 +16,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.ExtendedApocConfig.APOC_ML_OPENAI_TYPE;
@@ -111,13 +113,26 @@ public class OpenAI {
       "model": "text-embedding-ada-002",
       "usage": { "prompt_tokens": 8, "total_tokens": 8 } }
     */
-        Stream<Object> resultStream = executeRequest(apiKey, configuration, "embeddings", "text-embedding-ada-002", "input", texts, "$.data", apocConfig, urlAccessChecker);
-        return resultStream
+        Map<Boolean, List<String>> collect = texts.stream()
+                .collect(Collectors.groupingBy(Objects::nonNull));
+
+        List<String> nonNullTexts = collect.get(true);
+
+        Stream<Object> resultStream = executeRequest(apiKey, configuration, "embeddings", "text-embedding-ada-002", "input", nonNullTexts, "$.data", apocConfig, urlAccessChecker);
+        Stream<EmbeddingResult> embeddingResultStream = resultStream
                 .flatMap(v -> ((List<Map<String, Object>>) v).stream())
                 .map(m -> {
                     Long index = (Long) m.get("index");
-                    return new EmbeddingResult(index, texts.get(index.intValue()), (List<Double>) m.get("embedding"));
+                    return new EmbeddingResult(index, nonNullTexts.get(index.intValue()), (List<Double>) m.get("embedding"));
                 });
+
+        List<String> nullTexts = collect.getOrDefault(false, List.of());
+        Stream<EmbeddingResult> nullResultStream = nullTexts.stream()
+                .map(i -> {
+                    // null text return index -1 to indicate that are not coming from `/embeddings` RestAPI
+                    return new EmbeddingResult(-1, i, List.of());
+                });
+        return Stream.concat(embeddingResultStream, nullResultStream);
     }
 
 
@@ -132,6 +147,9 @@ public class OpenAI {
       "usage": { "prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12 }
     }
     */
+        if (prompt == null) {
+            return Stream.of(new MapResult(null));
+        }
         return executeRequest(apiKey, configuration, "completions", "gpt-3.5-turbo-instruct", "prompt", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
     }
@@ -139,6 +157,9 @@ public class OpenAI {
     @Procedure("apoc.ml.openai.chat")
     @Description("apoc.ml.openai.chat(messages, api_key, configuration]) - prompts the completion API")
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("api_key") String apiKey, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        if (messages == null) {
+            return Stream.of(new MapResult(null));
+        }
         return executeRequest(apiKey, configuration, "chat/completions", "gpt-3.5-turbo", "messages", messages, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
         // https://platform.openai.com/docs/api-reference/chat/create

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import static apoc.ExtendedApocConfig.APOC_ML_OPENAI_TYPE;
 import static apoc.ExtendedApocConfig.APOC_OPENAI_KEY;
+import static apoc.ml.MLUtil.ERROR_NULL_INPUT;
 
 
 @Extended
@@ -148,7 +149,7 @@ public class OpenAI {
     }
     */
         if (prompt == null) {
-            return Stream.of(new MapResult(null));
+            throw new RuntimeException(ERROR_NULL_INPUT);
         }
         return executeRequest(apiKey, configuration, "completions", "gpt-3.5-turbo-instruct", "prompt", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
@@ -158,7 +159,7 @@ public class OpenAI {
     @Description("apoc.ml.openai.chat(messages, api_key, configuration]) - prompts the completion API")
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("api_key") String apiKey, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
         if (messages == null) {
-            return Stream.of(new MapResult(null));
+            throw new RuntimeException(ERROR_NULL_INPUT);
         }
         return executeRequest(apiKey, configuration, "chat/completions", "gpt-3.5-turbo", "messages", messages, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);

--- a/extended/src/main/java/apoc/ml/VertexAI.java
+++ b/extended/src/main/java/apoc/ml/VertexAI.java
@@ -20,7 +20,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 
@@ -94,16 +96,30 @@ public class VertexAI {
   ]
 }
     */
+
+        Map<Boolean, List<String>> collect = texts.stream()
+                .collect(Collectors.groupingBy(Objects::nonNull));
+
+        List<String> nonNullTexts = collect.get(true);
+        
         Object inputs = texts.stream().map(text -> Map.of("content", text)).toList();
         Stream<Object> resultStream = executeRequest(accessToken, project, configuration, "textembedding-gecko", inputs, List.of(), urlAccessChecker);
         AtomicInteger ai = new AtomicInteger();
-        return resultStream
+        Stream<EmbeddingResult> embeddingResultStream = resultStream
                 .flatMap(v -> ((List<Map<String, Object>>) v).stream())
                 .map(m -> {
-                    Map<String,Object> embeddings = (Map<String, Object>) ((Map)m).get("embeddings");
+                    Map<String, Object> embeddings = (Map<String, Object>) ((Map) m).get("embeddings");
                     int index = ai.getAndIncrement();
-                    return new EmbeddingResult(index, texts.get(index), (List<Double>) embeddings.get("values"));
+                    return new EmbeddingResult(index, nonNullTexts.get(index), (List<Double>) embeddings.get("values"));
                 });
+        
+        List<String> nullTexts = collect.getOrDefault(false, List.of());
+        Stream<EmbeddingResult> nullResultStream = nullTexts.stream()
+                .map(text -> {
+                    // null text return index -1 to indicate that are not coming from `/embeddings` RestAPI
+                    return new EmbeddingResult(-1, text, List.of());
+                });
+        return Stream.concat(embeddingResultStream, nullResultStream);
     }
 
 
@@ -153,6 +169,10 @@ docs https://cloud.google.com/vertex-ai/docs/generative-ai/text/test-text-prompt
   ]
 }
  */
+        if (prompt == null) {
+            return Stream.of(new MapResult(null));
+        }
+        
         Object input = List.of(Map.of("prompt",prompt));
         var parameterKeys = List.of("temperature", "topK", "topP", "maxOutputTokens");
         var resultStream = executeRequest(accessToken, project, configuration, "text-bison", input, parameterKeys, urlAccessChecker);
@@ -192,6 +212,9 @@ docs https://cloud.google.com/vertex-ai/docs/generative-ai/text/test-text-prompt
                                             @Name(value = "context",defaultValue = "") String context,
                                             @Name(value = "examples", defaultValue = "[]") List<Map<String, Map<String,String>>> examples
                                             ) throws Exception {
+        if (messages == null) {
+            return Stream.of(new MapResult(null));
+        }
         Object inputs = List.of(Map.of("context",context, "examples",examples, "messages", messages));
         var parameterKeys = List.of("temperature", "topK", "topP", "maxOutputTokens");
         return executeRequest(accessToken, project, configuration, "chat-bison", inputs, parameterKeys, urlAccessChecker)

--- a/extended/src/main/java/apoc/ml/VertexAI.java
+++ b/extended/src/main/java/apoc/ml/VertexAI.java
@@ -99,6 +99,10 @@ public class VertexAI {
 }
     */
 
+        if (texts == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
+        
         Map<Boolean, List<String>> collect = texts.stream()
                 .collect(Collectors.groupingBy(Objects::nonNull));
 

--- a/extended/src/main/java/apoc/ml/VertexAI.java
+++ b/extended/src/main/java/apoc/ml/VertexAI.java
@@ -25,6 +25,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static apoc.ml.MLUtil.ERROR_NULL_INPUT;
+
 
 @Extended
 public class VertexAI {
@@ -170,7 +172,7 @@ docs https://cloud.google.com/vertex-ai/docs/generative-ai/text/test-text-prompt
 }
  */
         if (prompt == null) {
-            return Stream.of(new MapResult(null));
+            throw new RuntimeException(ERROR_NULL_INPUT);
         }
         
         Object input = List.of(Map.of("prompt",prompt));
@@ -213,7 +215,7 @@ docs https://cloud.google.com/vertex-ai/docs/generative-ai/text/test-text-prompt
                                             @Name(value = "examples", defaultValue = "[]") List<Map<String, Map<String,String>>> examples
                                             ) throws Exception {
         if (messages == null) {
-            return Stream.of(new MapResult(null));
+            throw new RuntimeException(ERROR_NULL_INPUT);
         }
         Object inputs = List.of(Map.of("context",context, "examples",examples, "messages", messages));
         var parameterKeys = List.of("temperature", "topK", "topP", "maxOutputTokens");

--- a/extended/src/main/java/apoc/ml/Watson.java
+++ b/extended/src/main/java/apoc/ml/Watson.java
@@ -39,6 +39,9 @@ public class Watson {
     @Procedure("apoc.ml.watson.chat")
     @Description("apoc.ml.watson.chat(messages, accessToken, $configuration) - prompts the completion API")
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("accessToken") String accessToken, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        if (messages == null) {
+            return Stream.of(new MapResult(null));
+        }
         String prompt = messages.stream()
                 .map(message -> {
                     Object role = message.get("role");
@@ -56,6 +59,9 @@ public class Watson {
     @Procedure("apoc.ml.watson.completion")
     @Description("apoc.ml.watson.completion(prompt, accessToken, $configuration) - prompts the completion API")
     public Stream<MapResult> completion(@Name("prompt") String prompt, @Name("accessToken") String accessToken, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        if (prompt == null) {
+            return Stream.of(new MapResult(null));
+        }
         return executeRequest(prompt, accessToken, configuration);
     }
 

--- a/extended/src/main/java/apoc/ml/aws/Bedrock.java
+++ b/extended/src/main/java/apoc/ml/aws/Bedrock.java
@@ -114,7 +114,9 @@ public class Bedrock {
     @Description("apoc.ml.bedrock.embedding([texts], $configuration) - returns the embeddings for a given text")
     public Stream<Embedding> embedding(@Name(value = "texts") List<String> texts,
                                        @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
-        
+        if (texts == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, TITAN_EMBED_TEXT);
 
@@ -133,6 +135,9 @@ public class Bedrock {
     @Procedure("apoc.ml.bedrock.image")
     public Stream<Image> image(@Name(value = "body") Map<String, Object> body,
                                @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
+        if (body == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
         configuration.putIfAbsent(MODEL, STABILITY_STABLE_DIFFUSION_XL);
         configuration.putIfAbsent(JSON_PATH, "$.artifacts[0]");
         

--- a/extended/src/main/java/apoc/ml/aws/Bedrock.java
+++ b/extended/src/main/java/apoc/ml/aws/Bedrock.java
@@ -60,7 +60,9 @@ public class Bedrock {
     public Stream<MapResult> chatCompletion(
             @Name("messages") List<Map<String, Object>> messages,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
-
+        if (messages == null) {
+            return Stream.of(new MapResult(null));
+        }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, ANTHROPIC_CLAUDE_V2);
 
@@ -94,7 +96,9 @@ public class Bedrock {
     @Description("apoc.ml.bedrock.completion(prompt, $conf) - prompts the completion API")
     public Stream<MapResult> completion(@Name("prompt") String prompt,
                                        @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
-
+        if (prompt == null) {
+            return Stream.of(new MapResult(null));
+        }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, JURASSIC_2_ULTRA);
         
@@ -109,6 +113,7 @@ public class Bedrock {
     @Description("apoc.ml.bedrock.embedding([texts], $configuration) - returns the embeddings for a given text")
     public Stream<Embedding> embedding(@Name(value = "texts") List<String> texts,
                                        @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
+        
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, TITAN_EMBED_TEXT);
 

--- a/extended/src/main/java/apoc/ml/aws/Bedrock.java
+++ b/extended/src/main/java/apoc/ml/aws/Bedrock.java
@@ -17,6 +17,7 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.apache.commons.lang3.StringUtils;
 
+import static apoc.ml.MLUtil.ERROR_NULL_INPUT;
 import static apoc.ml.aws.AWSConfig.JSON_PATH;
 import static apoc.ml.aws.BedrockInvokeConfig.MODEL;
 import static apoc.util.JsonUtil.OBJECT_MAPPER;
@@ -61,7 +62,7 @@ public class Bedrock {
             @Name("messages") List<Map<String, Object>> messages,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
         if (messages == null) {
-            return Stream.of(new MapResult(null));
+            throw new RuntimeException(ERROR_NULL_INPUT);
         }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, ANTHROPIC_CLAUDE_V2);
@@ -97,7 +98,7 @@ public class Bedrock {
     public Stream<MapResult> completion(@Name("prompt") String prompt,
                                        @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
         if (prompt == null) {
-            return Stream.of(new MapResult(null));
+            throw new RuntimeException(ERROR_NULL_INPUT);
         }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, JURASSIC_2_ULTRA);

--- a/extended/src/test/java/apoc/ml/MLTestUtil.java
+++ b/extended/src/test/java/apoc/ml/MLTestUtil.java
@@ -1,0 +1,25 @@
+package apoc.ml;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+import java.util.Map;
+
+import static apoc.ml.MLUtil.ERROR_NULL_INPUT;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MLTestUtil {
+    public static void assertNullInputFails(GraphDatabaseService db, String query, Map<String, Object> params) {
+        try {
+            testCall(db, query, params,
+                    (row) -> fail("Should fail due to null input")
+            );
+        } catch (RuntimeException e) {
+            String message = e.getMessage();
+            assertTrue("Current error message is: " + message, 
+                    message.contains(ERROR_NULL_INPUT)
+            );
+        }
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -19,6 +19,7 @@ import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class OpenAIIT {
 
@@ -121,5 +122,22 @@ public class OpenAIIT {
   ]
 }
          */
+    }
+
+    @Test
+    public void completionNull() {
+        testCall(db, "CALL apoc.ml.openai.completion(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
+    }
+    
+    @Test
+    public void chatCompletionNull() {
+        testCall(db, 
+                "CALL apoc.ml.openai.chat(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -1,6 +1,7 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
+import apoc.util.collection.Iterators;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,12 +9,16 @@ import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
 import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
 
 public class OpenAIIT {
 
@@ -66,6 +71,19 @@ public class OpenAIIT {
                 "dimensions", 256);
         testCall(db, EMBEDDING_QUERY, Map.of("apiKey", openaiKey, "conf", conf),
                 r -> assertEmbeddings(r, 256));
+    }
+
+    @Test
+    public void getEmbeddingNull() {
+        testResult(db, "CALL apoc.ml.openai.embedding([null, 'Some Text', null, 'Other Text'], $apiKey, $conf)", Map.of("apiKey",openaiKey, "conf", emptyMap()),
+                r -> {
+                    Set<String> actual = Iterators.asSet(r.columnAs("text"));
+
+                    Set<String> expected = new HashSet<>() {{
+                        add(null); add(null); add("Some Text"); add("Other Text");
+                    }};
+                    assertEquals(expected, actual);
+                });
     }
 
     @Test

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -13,13 +13,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class OpenAIIT {
 
@@ -126,18 +126,15 @@ public class OpenAIIT {
 
     @Test
     public void completionNull() {
-        testCall(db, "CALL apoc.ml.openai.completion(null, $apiKey, $conf)",
-                Map.of("apiKey", openaiKey, "conf", emptyMap()),
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.openai.completion(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap())
         );
     }
     
     @Test
     public void chatCompletionNull() {
-        testCall(db, 
-                "CALL apoc.ml.openai.chat(null, $apiKey, $conf)",
-                Map.of("apiKey", openaiKey, "conf", emptyMap()),
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.openai.chat(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap())
         );
     }
 }

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -125,6 +125,13 @@ public class OpenAIIT {
     }
 
     @Test
+    public void embeddingsNull() {
+        assertNullInputFails(db, "CALL apoc.ml.openai.embedding(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap())
+        );
+    }
+
+    @Test
     public void completionNull() {
         assertNullInputFails(db, "CALL apoc.ml.openai.completion(null, $apiKey, $conf)",
                 Map.of("apiKey", openaiKey, "conf", emptyMap())

--- a/extended/src/test/java/apoc/ml/VertexAIIT.java
+++ b/extended/src/test/java/apoc/ml/VertexAIIT.java
@@ -230,6 +230,13 @@ public class VertexAIIT {
         assertTrue(stringRow.toLowerCase().contains(expected),
                 "Actual result is: " + stringRow);
     }
+
+    @Test
+    public void embeddingsNull() {
+        assertNullInputFails(db, "CALL apoc.ml.vertexai.embedding(null, $apiKey, $project)",
+                parameters
+        );
+    }
     
     @Test
     public void completionNull() {

--- a/extended/src/test/java/apoc/ml/VertexAIIT.java
+++ b/extended/src/test/java/apoc/ml/VertexAIIT.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.ml.VertexAIHandler.ENDPOINT_CONF_KEY;
 import static apoc.ml.VertexAIHandler.MODEL_CONF_KEY;
 import static apoc.ml.VertexAIHandler.PREDICT_RESOURCE;
@@ -232,18 +233,15 @@ public class VertexAIIT {
     
     @Test
     public void completionNull() {
-        testCall(db, "CALL apoc.ml.vertexai.completion(null, $apiKey, $project)",
-                parameters,
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.vertexai.completion(null, $apiKey, $project)",
+                parameters
         );
     }
 
     @Test
     public void chatCompletionNull() {
-        testCall(db,
-                "CALL apoc.ml.vertexai.chat(null, $apiKey, $project)",
-                parameters,
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.vertexai.chat(null, $apiKey, $project)",
+                parameters
         );
     }
 }

--- a/extended/src/test/java/apoc/ml/VertexAIIT.java
+++ b/extended/src/test/java/apoc/ml/VertexAIIT.java
@@ -1,6 +1,7 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
+import apoc.util.collection.Iterators;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assume;
 import org.junit.Before;
@@ -13,8 +14,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static apoc.ml.VertexAIHandler.ENDPOINT_CONF_KEY;
 import static apoc.ml.VertexAIHandler.MODEL_CONF_KEY;
@@ -22,6 +25,9 @@ import static apoc.ml.VertexAIHandler.PREDICT_RESOURCE;
 import static apoc.ml.VertexAIHandler.RESOURCE_CONF_KEY;
 import static apoc.ml.VertexAIHandler.STREAM_RESOURCE;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -64,6 +70,20 @@ public class VertexAIIT {
             assertEquals(768, embedding.size());
             assertEquals(true, embedding.stream().allMatch(d -> d instanceof Double));
         });
+    }
+
+    @Test
+    public void getEmbeddingNull() {
+        testResult(db, "CALL apoc.ml.vertexai.embedding([null, 'Some Text', null, 'Other Text'], $apiKey, $project)",
+                parameters,
+                r -> {
+                    Set<String> actual = Iterators.asSet(r.columnAs("text"));
+
+                    Set<String> expected = new HashSet<>() {{
+                        add(null); add(null); add("Some Text"); add("Other Text");
+                    }};
+                    assertEquals(expected, actual);
+                });
     }
 
     @Test
@@ -208,5 +228,22 @@ public class VertexAIIT {
         String stringRow = row.toString();
         assertTrue(stringRow.toLowerCase().contains(expected),
                 "Actual result is: " + stringRow);
+    }
+    
+    @Test
+    public void completionNull() {
+        testCall(db, "CALL apoc.ml.vertexai.completion(null, $apiKey, $project)",
+                parameters,
+                (row) -> assertNull(row.get("value"))
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        testCall(db,
+                "CALL apoc.ml.vertexai.chat(null, $apiKey, $project)",
+                parameters,
+                (row) -> assertNull(row.get("value"))
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/WatsonIT.java
+++ b/extended/src/test/java/apoc/ml/WatsonIT.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import static apoc.ExtendedApocConfig.APOC_ML_WATSON_URL;
 import static apoc.ExtendedApocConfig.APOC_ML_WATSON_PROJECT_ID;
 import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -129,5 +131,22 @@ public class WatsonIT {
         assertTrue(generatedText.toLowerCase().contains(text));
         assertEquals(inputTokenCount, result.get("input_token_count"));
         assertEquals(stopReason, result.get("stop_reason"));
+    }
+
+    @Test
+    public void completionNull() {
+        testCall(db, "CALL apoc.ml.watson.completion(null, $apiKey, $conf)",
+                Map.of("apiKey", accessToken, "conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        testCall(db,
+                "CALL apoc.ml.watson.chat(null, $apiKey, $conf)",
+                Map.of("apiKey", accessToken, "conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/WatsonIT.java
+++ b/extended/src/test/java/apoc/ml/WatsonIT.java
@@ -13,9 +13,9 @@ import java.util.Map;
 
 import static apoc.ExtendedApocConfig.APOC_ML_WATSON_URL;
 import static apoc.ExtendedApocConfig.APOC_ML_WATSON_PROJECT_ID;
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.util.TestUtil.testCall;
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -135,18 +135,15 @@ public class WatsonIT {
 
     @Test
     public void completionNull() {
-        testCall(db, "CALL apoc.ml.watson.completion(null, $apiKey, $conf)",
-                Map.of("apiKey", accessToken, "conf", emptyMap()),
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.watson.completion(null, $apiKey, $conf)",
+                Map.of("apiKey", accessToken, "conf", emptyMap())
         );
     }
 
     @Test
     public void chatCompletionNull() {
-        testCall(db,
-                "CALL apoc.ml.watson.chat(null, $apiKey, $conf)",
-                Map.of("apiKey", accessToken, "conf", emptyMap()),
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.watson.chat(null, $apiKey, $conf)",
+                Map.of("apiKey", accessToken, "conf", emptyMap())
         );
     }
 }

--- a/extended/src/test/java/apoc/ml/aws/BedrockIT.java
+++ b/extended/src/test/java/apoc/ml/aws/BedrockIT.java
@@ -27,8 +27,10 @@ import static apoc.ml.aws.BedrockTestUtil.*;
 import static apoc.ml.aws.BedrockUtil.*;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
@@ -290,5 +292,22 @@ public class BedrockIT {
     private static void assertionsTitanEmbed(Map value) {
         assertNotNull(value.get("inputTextTokenCount"));
         assertNotNull(value.get("embedding"));
+    }
+
+    @Test
+    public void completionNull() {
+        testCall(db, "CALL apoc.ml.bedrock.completion(null, $conf)",
+                Map.of("conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        testCall(db,
+                "CALL apoc.ml.bedrock.chat(null, $conf)",
+                Map.of("conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/aws/BedrockIT.java
+++ b/extended/src/test/java/apoc/ml/aws/BedrockIT.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.ExtendedApocConfig.APOC_AWS_KEY_ID;
 import static apoc.ExtendedApocConfig.APOC_AWS_SECRET_KEY;
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.ml.aws.AWSConfig.KEY_ID;
 import static apoc.ml.aws.AWSConfig.METHOD_KEY;
 import static apoc.ml.aws.AWSConfig.SECRET_KEY;
@@ -296,18 +297,15 @@ public class BedrockIT {
 
     @Test
     public void completionNull() {
-        testCall(db, "CALL apoc.ml.bedrock.completion(null, $conf)",
-                Map.of("conf", emptyMap()),
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.completion(null)",
+                emptyMap()
         );
     }
 
     @Test
     public void chatCompletionNull() {
-        testCall(db,
-                "CALL apoc.ml.bedrock.chat(null, $conf)",
-                Map.of("conf", emptyMap()),
-                (row) -> assertNull(row.get("value"))
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.chat(null)",
+                emptyMap()
         );
     }
 }

--- a/extended/src/test/java/apoc/ml/aws/BedrockIT.java
+++ b/extended/src/test/java/apoc/ml/aws/BedrockIT.java
@@ -296,6 +296,13 @@ public class BedrockIT {
     }
 
     @Test
+    public void embeddingNull() {
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.embedding(null)",
+                emptyMap()
+        );
+    }
+
+    @Test
     public void completionNull() {
         assertNullInputFails(db, "CALL apoc.ml.bedrock.completion(null)",
                 emptyMap()
@@ -305,6 +312,13 @@ public class BedrockIT {
     @Test
     public void chatCompletionNull() {
         assertNullInputFails(db, "CALL apoc.ml.bedrock.chat(null)",
+                emptyMap()
+        );
+    }
+
+    @Test
+    public void imageNull() {
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.image(null)",
                 emptyMap()
         );
     }

--- a/extended/src/test/java/apoc/ml/sagemaker/SageMakerIT.java
+++ b/extended/src/test/java/apoc/ml/sagemaker/SageMakerIT.java
@@ -22,8 +22,11 @@ import static apoc.ExtendedApocConfig.APOC_AWS_SECRET_KEY;
 import static apoc.ml.aws.AWSConfig.HEADERS_KEY;
 import static apoc.ml.aws.AWSConfig.REGION_KEY;
 import static apoc.ml.aws.SageMakerConfig.ENDPOINT_NAME_KEY;
+import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNotNull;
 
@@ -158,6 +161,23 @@ public class SageMakerIT {
 
     private void assertEventually(Callable<Boolean> booleanCallable) {
         Assert.assertEventually(booleanCallable, val -> val, 30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void completionNull() {
+        testCall(db, "CALL apoc.ml.sagemaker.completion(null, $conf)",
+                Map.of("conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        testCall(db,
+                "CALL apoc.ml.sagemaker.chat(null, $conf)",
+                Map.of("conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
     }
 
 }


### PR DESCRIPTION
Fixes `https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3611`

- vertexai and openai embeddings return null rows with null list values
- embeddings, chat completion, completion and image procedures return null if the input parameter is null
- not implemented null check in apoc.ml.<type>.custom procedures, since we can potentially pass a null parameter (e.g. to call [this RestAPI](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GetModelInvocationLoggingConfiguration.html))


- TODO: open Trello Card for the following note?

### Additional notes


Would be great to handle errors like these, but we cannot implement it since is part of APOC Core:

`CALL apoc.ml.openai.chat([ {role:"user", content:null}], $apiKey, $conf)`

We should do something like this:

```
        @Override
        public InputStream getInputStream() throws IOException {
            if (con instanceof HttpURLConnection httpConn && httpConn.getResponseCode() >= 400) 
            {
                // return ErrorStream as a RuntimeException 
                String errMsg = new String(httpConn.getErrorStream().readAllBytes());
                throw new RuntimeException("Error during HTTP call:\n" + errMsg);
            }
            
            return toLimitedIStream(con.getInputStream(), getLength());
        }
```