### PR TITLE
Fixes 3840: UUID handler throws warnings when deleting nodes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.19.0"
+    neo4jVersion = "5.17.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/extended/src/main/java/apoc/uuid/UuidHandler.java
+++ b/extended/src/main/java/apoc/uuid/UuidHandler.java
@@ -112,20 +112,24 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
         }
     }
 
-    private void checkAndRestoreUuidProperty(Iterable<PropertyEntry<Node>> nodeProperties, String label, String uuidProperty) {
-        checkAndRestoreUuidProperty(nodeProperties, label, uuidProperty, null);
+    private void checkAndRestoreUuidProperty(Iterable<PropertyEntry<Node>> nodeProperties, String label, String uuidProperty, TransactionData txData) {
+        checkAndRestoreUuidProperty(nodeProperties, label, uuidProperty, txData, null);
     }
 
-    private void checkAndRestoreUuidProperty(Iterable<PropertyEntry<Node>> nodeProperties, String label, String uuidProperty, Predicate<PropertyEntry<Node>> predicate) {
+    private void checkAndRestoreUuidProperty(Iterable<PropertyEntry<Node>> nodeProperties, String label, String uuidProperty, TransactionData txData, Predicate<PropertyEntry<Node>> predicate) {
         if (nodeProperties.iterator().hasNext()) {
             nodeProperties.forEach(nodePropertyEntry -> {
+                Node entity = nodePropertyEntry.entity();
+                if (txData.isDeleted(entity)) {
+                    return;
+                }
                 if (predicate == null) {
-                    if (nodePropertyEntry.entity().hasLabel(Label.label(label)) && nodePropertyEntry.key().equals(uuidProperty)) {
-                        nodePropertyEntry.entity().setProperty(uuidProperty, nodePropertyEntry.previouslyCommittedValue());
+                    if (entity.hasLabel(Label.label(label)) && nodePropertyEntry.key().equals(uuidProperty)) {
+                        entity.setProperty(uuidProperty, nodePropertyEntry.previouslyCommittedValue());
                     }
                 } else {
-                    if (nodePropertyEntry.entity().hasLabel(Label.label(label)) && nodePropertyEntry.key().equals(uuidProperty) && predicate.test(nodePropertyEntry)) {
-                        nodePropertyEntry.entity().setProperty(uuidProperty, nodePropertyEntry.previouslyCommittedValue());
+                    if (entity.hasLabel(Label.label(label)) && nodePropertyEntry.key().equals(uuidProperty) && predicate.test(nodePropertyEntry)) {
+                        entity.setProperty(uuidProperty, nodePropertyEntry.previouslyCommittedValue());
                     }
                 }
             });
@@ -151,9 +155,9 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
                         node.setProperty(propertyName, uuid);
                     }
                 });
-                checkAndRestoreUuidProperty(assignedNodeProperties, label, propertyName,
+                checkAndRestoreUuidProperty(assignedNodeProperties, label, propertyName, txData,
                         (nodePropertyEntry) -> nodePropertyEntry.value() == null || nodePropertyEntry.value().equals(""));
-                checkAndRestoreUuidProperty(removedNodeProperties, label, propertyName);
+                checkAndRestoreUuidProperty(removedNodeProperties, label, propertyName, txData);
             } catch (Exception e) {
                 log.warn("Error executing uuid " + label + " in phase before", e);
             }

--- a/extended/src/test/java/apoc/uuid/UUIDNewProceduresTest.java
+++ b/extended/src/test/java/apoc/uuid/UUIDNewProceduresTest.java
@@ -2,6 +2,7 @@ package apoc.uuid;
 
 import apoc.create.Create;
 import apoc.periodic.Periodic;
+import apoc.util.FileUtils;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.hamcrest.Matchers;
@@ -16,6 +17,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -506,5 +508,26 @@ public class UUIDNewProceduresTest {
             assertThat(e.getMessage(), Matchers.containsString(UUID_NOT_SET));
         }
         apocConfig().setProperty(APOC_UUID_REFRESH, PROCEDURE_DEFAULT_REFRESH);
+    }
+    
+    @Test
+    public void testAddAndRemoveUuidNodeDoesNotThrowError() throws Exception {
+        // given
+        db.executeTransactionally("CREATE CONSTRAINT FOR (test:Test1) REQUIRE test.foo IS UNIQUE");
+
+        // when
+        db.executeTransactionally("CALL apoc.uuid.install('Test1', {uuidProperty: 'foo'}) YIELD label RETURN label");
+        db.executeTransactionally("CREATE (p:Test1)");
+
+        db.executeTransactionally("MATCH (p:Test1) DELETE p");
+
+        // wait time greater than the refresh one, to make sure UUIDHandler.checkAndRestoreUuidProperty() has been executed
+        Thread.sleep(PROCEDURE_DEFAULT_REFRESH + 100);
+        
+        final String logFileContent = Files.readString(new File(FileUtils.getLogDirectory(), "debug.log").toPath())
+                .toLowerCase();
+
+        assertTrue("Actual debug.log content:\n" + logFileContent,
+                !logFileContent.contains("error") && !logFileContent.contains("exception"));
     }
 }

--- a/extended/src/test/java/apoc/uuid/UUIDNewProceduresTest.java
+++ b/extended/src/test/java/apoc/uuid/UUIDNewProceduresTest.java
@@ -524,10 +524,8 @@ public class UUIDNewProceduresTest {
         // wait time greater than the refresh one, to make sure UUIDHandler.checkAndRestoreUuidProperty() has been executed
         Thread.sleep(PROCEDURE_DEFAULT_REFRESH + 100);
         
-        final String logFileContent = Files.readString(new File(FileUtils.getLogDirectory(), "debug.log").toPath())
-                .toLowerCase();
+        final String logFileContent = Files.readString(new File(FileUtils.getLogDirectory(), "debug.log").toPath());
 
-        assertTrue("Actual debug.log content:\n" + logFileContent,
-                !logFileContent.contains("error") && !logFileContent.contains("exception"));
+        assertFalse("Actual debug.log content:\n" + logFileContent, logFileContent.contains("NotFoundException"));
     }
 }


### PR DESCRIPTION
Fixes `https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3840`.

Added check `txData.isDeleted(entity)` at the start of the forEach properties.

 