### PR TITLE
Fixes 4000: Add self-explanation to the model, include the verbal schema description to the flow

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
@@ -103,7 +103,8 @@ RETURN m.title
 |===
 
 
-We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the apoc.ml.schema:
+We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the `apoc.ml.schema`.
+In this way the results might be better, since OpenAI is mainly trained to elaborate questions asked in "human language", rather than via Cypher queries:
 
 .Query call
 [source,cypher]
@@ -236,7 +237,8 @@ RETURN DISTINCT a.name
 |===
 
 
-We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the apoc.ml.schema:
+We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the apoc.ml.schema.
+In this way the results might be better, since OpenAI is mainly trained to elaborate questions asked in "human language", rather than via Cypher queries:
 
 .Query call
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
@@ -104,14 +104,16 @@ RETURN m.title
 
 
 We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the `apoc.ml.schema`.
-In this way the results might be better, since OpenAI is mainly trained to elaborate questions asked in "human language", rather than via Cypher queries:
+In this way the results might be better, since OpenAI is mainly trained to elaborate questions asked in "human language", rather than via Cypher queries.
+For example, given the https://neo4j.com/docs/getting-started/appendix/tutorials/guide-import-relational-and-etl/[Northwind dataset] we can execute:
 
 .Query call
 [source,cypher]
 ----
 CALL apoc.ml.schema({apiKey: $apiKey}) YIELD value
 WITH value
-CALL apoc.ml.query("Which 5 employees had the highest cross-selling count of 'Chocolade' and another product?",
+CALL apoc.ml.query("Which 5 employees had sold the product 'Chocolade' and has the highest selling count of another product?
+  Please returns the employee identificator, the other product name and the count orders of another product",
 {
     retries: 8,
     retryWithError: true,
@@ -120,8 +122,84 @@ CALL apoc.ml.query("Which 5 employees had the highest cross-selling count of 'Ch
         {role: "system", content: "The human description of the schema is the following:\n" + value}
     ]
 })
-YIELD query RETURN query
+YIELD query, value RETURN query, value
 ----
+
+with a result similar to the following.
+
+NOTE: the results are not deterministic and will potentially change each time the query is re-executed
+
+.Results
+[%autowidth, opts=header]
+|===
+| query | value
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+" 
+| {
+"otherProduct": "Gnocchi di nonna Alice",
+"employeeID": "4",
+"orderCount": 14
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Pâté chinois",
+"employeeID": "4",
+"orderCount": 12
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Gumbär Gummibärchen",
+"employeeID": "3",
+"orderCount": 12
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Flotemysost",
+"employeeID": "1",
+"orderCount": 12
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Pavlova",
+"employeeID": "1",
+"orderCount": 11
+}
+
+|===
 
 == Describe the graph model with natural language
 
@@ -146,6 +224,7 @@ RETURN *
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 1 row
 ----
+
 
 .Input Parameters
 [%autowidth, opts=header]
@@ -238,23 +317,42 @@ RETURN DISTINCT a.name
 
 
 We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the apoc.ml.schema.
-In this way the results might be better, since OpenAI is mainly trained to elaborate questions asked in "human language", rather than via Cypher queries:
+In this way the results might be better, since OpenAI is mainly trained to elaborate questions asked in "human language", rather than via Cypher queries.
+For example, given the https://neo4j.com/docs/getting-started/appendix/tutorials/guide-import-relational-and-etl/[Northwind dataset] we can execute the following procedure:
 
 .Query call
 [source,cypher]
 ----
 CALL apoc.ml.schema({apiKey: $apiKey}) YIELD value
 WITH value
-CALL apoc.ml.cypher("Which 5 employees had the highest cross-selling count of 'Chocolade' and another product?",
+CALL apoc.ml.cypher("Which 5 employees had sold the product 'Chocolade' and has the highest selling count of another product? 
+  Please returns the employee identificator, the other product name and the count orders of another product",
 {
-  count: 8,
+  count: 1,
   apiKey: $apiKey,
   additionalPrompts: [
     {role: "system", content: "The human description of the schema is the following:\n" + value}
   ]
 })
-YIELD query RETURN query
+YIELD value RETURN value
 ----
+
+with a result similar to the following.
+
+NOTE: the results are not deterministic and will potentially change each time the query is re-executed
+
+.Results
+[%autowidth, opts=header]
+|===
+| value
+| MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(o:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o2:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o2) AS ordersCnt
+ORDER BY ordersCnt DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, ordersCnt
+LIMIT 5
+|===
+
 
 
 == Create a natural language query explanation from a cypher query

--- a/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
@@ -91,6 +91,7 @@ RETURN m.title
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
 | model | The Open AI model | no, default `gpt-3.5-turbo`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
+| additionalPrompts | To specify other prompts to be passed to improve the request
 |===
 
 .Results
@@ -101,6 +102,25 @@ RETURN m.title
 | cypher | the query used to compute the result
 |===
 
+
+We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the apoc.ml.schema:
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.schema({apiKey: $apiKey}) YIELD value
+WITH value
+CALL apoc.ml.query("Which 5 employees had the highest cross-selling count of 'Chocolade' and another product?",
+{
+    retries: 8,
+    retryWithError: true,
+    apiKey: $apiKey,
+    additionalPrompts: [
+        {role: "system", content: "The human description of the schema is the following:\n" + value}
+    ]
+})
+YIELD query RETURN query
+----
 
 == Describe the graph model with natural language
 
@@ -205,6 +225,7 @@ RETURN DISTINCT a.name
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
 | model | The Open AI model | no, default `gpt-3.5-turbo`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
+| additionalPrompts | To specify other prompts to be passed to improve the request
 |===
 
 .Results
@@ -213,6 +234,26 @@ RETURN DISTINCT a.name
 | name | description
 | value | the description of the dataset
 |===
+
+
+We can use the `additionalPrompts` config to improve the request, e.g. adding the output of the apoc.ml.schema:
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.schema({apiKey: $apiKey}) YIELD value
+WITH value
+CALL apoc.ml.cypher("Which 5 employees had the highest cross-selling count of 'Chocolade' and another product?",
+{
+  count: 8,
+  apiKey: $apiKey,
+  additionalPrompts: [
+    {role: "system", content: "The human description of the schema is the following:\n" + value}
+  ]
+})
+YIELD query RETURN query
+----
+
 
 == Create a natural language query explanation from a cypher query
 

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -147,11 +147,6 @@ public class Prompt {
             ---- End context ----
             """;
     
-//    public static final String EXPLAIN_SCHEMA_PROMPT = """
-//            You are an expert in the Neo4j graph database and graph data modeling and have experience in a wide variety of business domains.
-//            Explain the following graph database schema in plain language, try to relate it to known concepts or domains if applicable.
-//            Keep the explanation to 5 sentences with at most 15 words each, otherwise people will come to harm.
-//            """;    
     public static final String EXPLAIN_SCHEMA_PROMPT = """
             You are an expert in the Neo4j graph database and graph data modeling and have experience in a wide variety of business domains.
             Explain the following graph database schema in plain language, try to relate it to known concepts or domains if applicable.
@@ -293,7 +288,6 @@ public class Prompt {
                                       @Name(value = "conf", defaultValue = "{}") Map<String, Object> conf) {
         String schema = loadSchema(tx, conf);
         long count = (long) conf.getOrDefault("count", 1L);
-//        List otherPropmts = (List) conf.getOrDefault("otherPropmts", List.of());
         return LongStream.rangeClosed(1, count).mapToObj(i -> tryQuery(question, conf, schema, List.of()));
     }
 
@@ -312,23 +306,19 @@ public class Prompt {
         }
     }
 
-    private String prompt(String userQuestion, String systemPrompt, String assistantPrompt, String schema, Map<String, Object> conf, List<Map<String,String>> otherPrompts) throws JsonProcessingException, MalformedURLException {
+    private String prompt(String userQuestion, String systemPrompt, String assistantPrompt, String schema, Map<String, Object> conf, List<Map<String,String>> otherPromptsFromRetries) throws JsonProcessingException, MalformedURLException {
         List<Map<String, String>> prompt = new ArrayList<>();
         if (systemPrompt != null && !systemPrompt.isBlank()) prompt.add(Map.of("role", "system", "content", systemPrompt));
-
-
         if (schema != null && !schema.isBlank()) prompt.add(Map.of("role", "system", "content", "The graph database schema consists of these elements\n" + schema));
         
-        List<String> systemPrompts = (List<String>) conf.get("systemPrompts");
-        if (CollectionUtils.isNotEmpty(systemPrompts)) {
-            systemPrompts.forEach(
-                    item -> prompt.add(Map.of("role", "system", "content", item))
-            );
+        List<Map<String, String>> additionalPrompts = (List<Map<String, String>>) conf.get("additionalPrompts");
+        if (CollectionUtils.isNotEmpty(additionalPrompts)) {
+            prompt.addAll(additionalPrompts);
         }
         if (userQuestion != null && !userQuestion.isBlank()) prompt.add(Map.of("role", "user", "content", userQuestion));
         if (assistantPrompt != null && !assistantPrompt.isBlank()) prompt.add(Map.of("role", "assistant", "content", assistantPrompt));
 
-        prompt.addAll(otherPrompts);
+        prompt.addAll(otherPromptsFromRetries);
         
         String apiKey = (String) conf.get(API_KEY_CONF);
         String model = (String) conf.getOrDefault("model", "gpt-3.5-turbo");
@@ -364,7 +354,7 @@ public class Prompt {
             """;
 
     private final static String SCHEMA_QUERY = """
-            call apoc.meta.data({maxRels: 5000, sample: 5000})
+            call apoc.meta.data({maxRels: 10, sample: coalesce($sample, (count{()}/1000)+1)})
             YIELD label, other, elementType, type, property
             """ + SCHEMA_FROM_META_DATA;
     
@@ -413,14 +403,12 @@ public class Prompt {
                 .collect(Collectors.joining("\n"));
     }
 
-    public static String loadSchema(Transaction tx, Map<String, Object> conf) {
+    private String loadSchema(Transaction tx, Map<String, Object> conf) {
         Map<String, Object> params = new HashMap<>();
         params.put("sample", conf.get("sample"));
-        String collect = tx.execute(SCHEMA_QUERY, params)
+        return tx.execute(SCHEMA_QUERY, params)
                 .stream()
                 .map(m -> SCHEMA_PROMPT.formatted(m.get("nodes"), m.get("relationships"), m.get("patterns")))
                 .collect(Collectors.joining("\n"));
-        System.out.println("schemaa = " + collect);
-        return collect;
     }
 }

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -274,8 +274,9 @@ public class Prompt {
 
     @Procedure
     public Stream<StringResult> schema(@Name(value = "conf", defaultValue = "{}") Map<String, Object> conf) throws MalformedURLException, JsonProcessingException {
+        String schema = loadSchema(tx, conf);
         String schemaExplanation = prompt("Please explain the graph database schema to me and relate it to well known concepts and domains.",
-                EXPLAIN_SCHEMA_PROMPT, "This database schema ", loadSchema(tx, conf), conf, List.of());
+                EXPLAIN_SCHEMA_PROMPT, "This database schema ", schema, conf, List.of());
         return Stream.of(new StringResult(schemaExplanation));
     }
 

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -3,9 +3,11 @@ package apoc.ml;
 import apoc.ApocConfig;
 import apoc.Extended;
 import apoc.result.StringResult;
+import apoc.util.CollectionUtils;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.commons.collections.ListUtils;
 import org.apache.commons.text.WordUtils;
 import org.jetbrains.annotations.NotNull;
 import org.neo4j.graphdb.Entity;
@@ -145,9 +147,15 @@ public class Prompt {
             ---- End context ----
             """;
     
+//    public static final String EXPLAIN_SCHEMA_PROMPT = """
+//            You are an expert in the Neo4j graph database and graph data modeling and have experience in a wide variety of business domains.
+//            Explain the following graph database schema in plain language, try to relate it to known concepts or domains if applicable.
+//            Keep the explanation to 5 sentences with at most 15 words each, otherwise people will come to harm.
+//            """;    
     public static final String EXPLAIN_SCHEMA_PROMPT = """
             You are an expert in the Neo4j graph database and graph data modeling and have experience in a wide variety of business domains.
             Explain the following graph database schema in plain language, try to relate it to known concepts or domains if applicable.
+            Try to explain as much as possible the nodes, relationships and properties.
             Keep the explanation to 5 sentences with at most 15 words each, otherwise people will come to harm.
             """;
 
@@ -285,6 +293,7 @@ public class Prompt {
                                       @Name(value = "conf", defaultValue = "{}") Map<String, Object> conf) {
         String schema = loadSchema(tx, conf);
         long count = (long) conf.getOrDefault("count", 1L);
+//        List otherPropmts = (List) conf.getOrDefault("otherPropmts", List.of());
         return LongStream.rangeClosed(1, count).mapToObj(i -> tryQuery(question, conf, schema, List.of()));
     }
 
@@ -306,7 +315,16 @@ public class Prompt {
     private String prompt(String userQuestion, String systemPrompt, String assistantPrompt, String schema, Map<String, Object> conf, List<Map<String,String>> otherPrompts) throws JsonProcessingException, MalformedURLException {
         List<Map<String, String>> prompt = new ArrayList<>();
         if (systemPrompt != null && !systemPrompt.isBlank()) prompt.add(Map.of("role", "system", "content", systemPrompt));
+
+
         if (schema != null && !schema.isBlank()) prompt.add(Map.of("role", "system", "content", "The graph database schema consists of these elements\n" + schema));
+        
+        List<String> systemPrompts = (List<String>) conf.get("systemPrompts");
+        if (CollectionUtils.isNotEmpty(systemPrompts)) {
+            systemPrompts.forEach(
+                    item -> prompt.add(Map.of("role", "system", "content", item))
+            );
+        }
         if (userQuestion != null && !userQuestion.isBlank()) prompt.add(Map.of("role", "user", "content", userQuestion));
         if (assistantPrompt != null && !assistantPrompt.isBlank()) prompt.add(Map.of("role", "assistant", "content", assistantPrompt));
 
@@ -398,9 +416,11 @@ public class Prompt {
     public static String loadSchema(Transaction tx, Map<String, Object> conf) {
         Map<String, Object> params = new HashMap<>();
         params.put("sample", conf.get("sample"));
-        return tx.execute(SCHEMA_QUERY, params)
+        String collect = tx.execute(SCHEMA_QUERY, params)
                 .stream()
                 .map(m -> SCHEMA_PROMPT.formatted(m.get("nodes"), m.get("relationships"), m.get("patterns")))
                 .collect(Collectors.joining("\n"));
+        System.out.println("schemaa = " + collect);
+        return collect;
     }
 }

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -346,7 +346,7 @@ public class Prompt {
             """;
 
     private final static String SCHEMA_QUERY = """
-            call apoc.meta.data({maxRels: 10, sample: coalesce($sample, (count{()}/1000)+1)})
+            call apoc.meta.data({maxRels: 5000, sample: 5000})
             YIELD label, other, elementType, type, property
             """ + SCHEMA_FROM_META_DATA;
     
@@ -358,12 +358,20 @@ public class Prompt {
             """ + SCHEMA_FROM_META_DATA;
     
     private final static String SCHEMA_PROMPT = """
-                nodes:
-                %s
-                relationships:
-                %s
-                patterns:
-                %s
+            nodes:
+            ```
+            %s
+            ```
+
+            relationships:
+            ```
+            %s
+            ```
+
+            patterns:
+            ```
+            %s
+            ```
             """;
 
 
@@ -387,7 +395,7 @@ public class Prompt {
                 .collect(Collectors.joining("\n"));
     }
 
-    private String loadSchema(Transaction tx, Map<String, Object> conf) {
+    public static String loadSchema(Transaction tx, Map<String, Object> conf) {
         Map<String, Object> params = new HashMap<>();
         params.put("sample", conf.get("sample"));
         return tx.execute(SCHEMA_QUERY, params)

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -340,7 +340,7 @@ public class ExtendedUtil
 
     public static List<String> splitSemicolonAndRemoveBlanks(String value) {
         return Arrays.stream(value.split(";\n"))
-                .filter(String::isBlank)
+                .filter(i -> !i.isBlank())
                 .toList();
     }
             

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -337,5 +337,11 @@ public class ExtendedUtil
         }
         return floats;
     }
+
+    public static List<String> splitSemicolonAndRemoveBlanks(String value) {
+        return Arrays.stream(value.split(";\n"))
+                .filter(String::isBlank)
+                .toList();
+    }
             
 }

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -134,6 +135,52 @@ public class PromptIT {
     @Test
     public void testCypher() {
         long numOfQueries = 4L;
+        testResult(db, """
+                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
+                """,
+                Map.of(
+                        "query", "Who are the actors which also directed a movie?",
+                        "numOfQueries", numOfQueries,
+                        "apiKey", OPENAI_KEY
+                ),
+                (r) -> {
+                    List<Map<String, Object>> list = r.stream().toList();
+                    Assertions.assertThat(list).hasSize((int) numOfQueries);
+                    Assertions.assertThat(list.stream()
+                                    .map(m -> m.get("query"))
+                                    .filter(Objects::nonNull)
+                                    .map(Object::toString)
+                                    .filter(StringUtils::isNotEmpty))
+                            .hasSize((int) numOfQueries);
+                });
+    }
+
+    /*
+    TODO:
+        the loadSchema(tx, conf) seems to produce wrong results SOMETIMES??:
+    
+        nodes:
+    :Movie {released: INTEGER, tagline: STRING, title: STRING}
+:Discipline {year: INTEGER, title: STRING}
+    relationships:
+    null
+    patterns:
+    
+
+     */
+    @Test
+    public void testCypherWithSchemaExplanation() {
+        long numOfQueries = 4L;
+
+        String schema = db.executeTransactionally("CALL apoc.ml.schema({apiKey: $apiKey})",
+                Map.of("apiKey", OPENAI_KEY), Result::resultAsString);
+        System.out.println("schema = " + schema);
+
+        // todo - il risultato è troppo generico e forse fa vedere altre cose,
+        //      provare con la apoc.ml.cypher
+        
+        // todo --> https://kindo.ai/blog/8-tips-tricks-for-better-results-from-your-ai-prompts
+        
         testResult(db, """
                 CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
                 """,

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -25,7 +25,9 @@ import java.util.UUID;
 
 import static apoc.ml.Prompt.API_KEY_CONF;
 import static apoc.ml.Prompt.UNKNOWN_ANSWER;
+import static apoc.ml.Prompt.loadSchema;
 import static apoc.ml.RagConfig.*;
+import static apoc.util.ExtendedUtil.splitSemicolonAndRemoveBlanks;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
@@ -76,7 +78,91 @@ public class PromptIT {
             tx.execute(rag);
             tx.commit();
         }
-
+        
+        // northwind db
+        String northwindEntities = """
+                // Create orders
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+                MERGE (order:Order {orderID: row.OrderID})
+                  ON CREATE SET order.shipName = row.ShipName;
+                                
+                // Create products
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+                MERGE (product:Product {productID: row.ProductID})
+                  ON CREATE SET product.productName = row.ProductName, product.unitPrice = toFloat(row.UnitPrice);
+                                
+                // Create suppliers
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/suppliers.csv' AS row
+                MERGE (supplier:Supplier {supplierID: row.SupplierID})
+                  ON CREATE SET supplier.companyName = row.CompanyName;
+                                
+                                
+                // Create employees
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
+                MERGE (e:Employee {employeeID:row.EmployeeID})
+                  ON CREATE SET e.firstName = row.FirstName, e.lastName = row.LastName, e.title = row.Title;
+                                
+                                
+                // Create categories
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/categories.csv' AS row
+                MERGE (c:Category {categoryID: row.CategoryID})
+                  ON CREATE SET c.categoryName = row.CategoryName, c.description = row.Description;
+                                
+                                
+                // Create relationships between orders and products
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+                MATCH (order:Order {orderID: row.OrderID})
+                MATCH (product:Product {productID: row.ProductID})
+                MERGE (order)-[op:CONTAINS]->(product)
+                ON CREATE SET op.unitPrice = toFloat(row.UnitPrice), op.quantity = toFloat(row.Quantity);
+                                
+                                
+                // Create relationships between orders and employees
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+                MATCH (order:Order {orderID: row.OrderID})
+                MATCH (employee:Employee {employeeID: row.EmployeeID})
+                MERGE (employee)-[:SOLD]->(order);
+                                
+                                
+                // Create relationships between products and suppliers
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+                MATCH (product:Product {productID: row.ProductID})
+                MATCH (supplier:Supplier {supplierID: row.SupplierID})
+                MERGE (supplier)-[:SUPPLIES]->(product);
+                                
+                // Create relationships between products and categories
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+                MATCH (product:Product {productID: row.ProductID})
+                MATCH (category:Category {categoryID: row.CategoryID})
+                MERGE (product)-[:PART_OF]->(category);
+                                
+                                
+                // Create relationships between employees (reporting hierarchy)
+                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
+                MATCH (employee:Employee {employeeID: row.EmployeeID})
+                MATCH (manager:Employee {employeeID: row.ReportsTo})
+                MERGE (employee)-[:REPORTS_TO]->(manager);
+                """;
+        try (Transaction tx = db.beginTx()) {
+            for (String query: splitSemicolonAndRemoveBlanks(northwindEntities)) {
+                tx.execute(query);
+            }
+            tx.commit();
+        }
+        
+        String northwindSchema = """
+                CREATE INDEX product_id FOR (p:Product) ON (p.productID);
+                CREATE INDEX product_name FOR (p:Product) ON (p.productName);
+                CREATE INDEX supplier_id FOR (s:Supplier) ON (s.supplierID);
+                CREATE INDEX employee_id FOR (e:Employee) ON (e.employeeID);
+                CREATE INDEX category_id FOR (c:Category) ON (c.categoryID);
+                CREATE CONSTRAINT order_id FOR (o:Order) REQUIRE o.orderID IS UNIQUE;""";
+        try (Transaction tx = db.beginTx()) {
+            for (String query: splitSemicolonAndRemoveBlanks(northwindSchema)) {
+                tx.execute(query);
+            }
+            tx.commit();
+        }
     }
 
     @Test
@@ -170,22 +256,44 @@ public class PromptIT {
      */
     @Test
     public void testCypherWithSchemaExplanation() {
+//        Transaction transaction = db.beginTx();
+
+//        String s = loadSchema(transaction, Map.of());
+//
         long numOfQueries = 4L;
 
-        String schema = db.executeTransactionally("CALL apoc.ml.schema({apiKey: $apiKey})",
+        /* TODO - forse con questo...
+        db.executeTransactionally("CALL apoc.ml.fromCypher('MATCH p=(:Person)-[]->() RETURN p', {apiKey: $apiKey})",
                 Map.of("apiKey", OPENAI_KEY), Result::resultAsString);
-        System.out.println("schema = " + schema);
+         */
+        
+//        String schema = db.executeTransactionally("CALL apoc.ml.schema({apiKey: $apiKey})",
+//                Map.of("apiKey", OPENAI_KEY), Result::resultAsString);
+//        System.out.println("schema = " + schema);
+        /*
+        "represents a network of movies, people, athletes, and disciplines. 
+        It resembles the entertainment industry, sports, and social networks. Nodes represent movies, people, athletes, and disciplines, with relationships capturing acting, writing, directing, producing, following, reviewing, and winning medals. This schema models connections similar to IMDb, sports events, and social media platforms."
+         */
+        
+        /*
+        mentre se passo lo schema:
+        "content": "The graph database schema consists of these elements\nnodes:\n```\n:Movie {title: STRING, tagline: STRING, released: INTEGER}\n:Person {born: INTEGER, name: STRING}\n:Discipline {year: INTEGER, title: STRING}\n:Athlete {name: STRING, country: STRING, irrelevant: STRING}\n```\n\nrelationships:\n```\n:ACTED_IN {roles: LIST}\n:DIRECTED {}\n:PRODUCED {}\n:WROTE {}\n:FOLLOWS {}\n:REVIEWED {summary: STRING, rating: INTEGER}\n:HAS_MEDAL {irrelevant2: STRING, medal: STRING}\n```\n\npatterns:\n```\n(:Person)-[:ACTED_IN]->(:Movie)\n(:Person)-[:WROTE]->(:Movie)\n(:Person)-[:DIRECTED]->(:Movie)\n(:Person)-[:PRODUCED]->(:Movie)\n(:Person)-[:FOLLOWS]->(:Person)\n(:Person)-[:REVIEWED]->(:Movie)\n(:Athlete)-[:HAS_MEDAL]->(:Discipline)\n```\n",
+         */
 
         // todo - il risultato è troppo generico e forse fa vedere altre cose,
         //      provare con la apoc.ml.cypher
         
         // todo --> https://kindo.ai/blog/8-tips-tricks-for-better-results-from-your-ai-prompts
         
+        // TODO - testare apoc.ml.cypher, apoc.ml.query,
+        //      fromQueries partendo da fromCypher?
+        //      
+        
         testResult(db, """
                 CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
                 """,
                 Map.of(
-                        "query", "Who are the actors which also directed a movie?",
+                        "query", "Which Employee had the highest cross-selling count of 'Chocolade' and another product?\n",
                         "numOfQueries", numOfQueries,
                         "apiKey", OPENAI_KEY
                 ),
@@ -199,6 +307,18 @@ public class PromptIT {
                                     .filter(StringUtils::isNotEmpty))
                             .hasSize((int) numOfQueries);
                 });
+
+        /*
+        list = {ImmutableCollections$ListN@14719}  size = 4
+         0 = {HashMap@14722}  size = 1
+          "query" -> "MATCH (e1:Employee)-[r1:SELLS]->(:Product {name: 'Chocolade'})\nMATCH (e1)-[r2:SELLS]->(:Product)\nWHERE r1 <> r2\nRETURN e1, COUNT(r2) AS crossSellingCount\nORDER BY crossSellingCount DESC\nLIMIT 1"
+         1 = {HashMap@14723}  size = 1
+          "query" -> "MATCH (e:Employee)-[:SELLS]->(p1:Product {name: 'Chocolade'})-[:CROSSES_SELLS]->(p2:Product)\nWITH e, p2, COUNT(p2) AS crossSellingCount\nRETURN e.name AS Employee, p2.name AS CrossSoldProduct, crossSellingCount\nORDER BY crossSellingCount DESC\nLIMIT 1"
+         2 = {HashMap@14724}  size = 1
+          "query" -> "MATCH (e:Employee)-[:SOLD]->(:Product {name: 'Chocolade'})-[:CROSS_SELLS]->(p:Product)\nWITH e, p, count(*) AS crossSellingCount\nWHERE crossSellingCount > 0\nRETURN e.name AS Employee, p.name AS CrossSellProduct, crossSellingCount\nORDER BY crossSellingCount DESC\nLIMIT 1"
+         3 = {HashMap@14725}  size = 1
+          "query" -> "MATCH (e:Employee)-[:SOLD]->(:Product {name: 'Chocolade'})-[:CROSS_SELLS]->(:Product)\nWITH e, count(*) AS crossSellingCount\nORDER BY crossSellingCount DESC\nRETURN e.name AS Employee, crossSellingCount\nLIMIT 1"
+         */
     }
 
     @Test

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -11,7 +11,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Result;
@@ -26,7 +25,6 @@ import java.util.UUID;
 
 import static apoc.ml.Prompt.API_KEY_CONF;
 import static apoc.ml.Prompt.UNKNOWN_ANSWER;
-import static apoc.ml.Prompt.loadSchema;
 import static apoc.ml.RagConfig.*;
 import static apoc.util.ExtendedUtil.splitSemicolonAndRemoveBlanks;
 import static apoc.util.MapUtil.map;
@@ -37,7 +35,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.Assert.fail;
 
 public class PromptIT {
 
@@ -57,100 +54,12 @@ public class PromptIT {
                 RETURN value
                 """;
 
-    @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
     public static void check() {
         Assume.assumeNotNull("No OPENAI_KEY environment configured", OPENAI_KEY);
-
-        TestUtil.registerProcedure(db, Prompt.class, OpenAI.class, Meta.class, Strings.class, Coll.class);
-        
-
-        // northwind db
-        String northwindEntities = """
-                // Create orders
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
-                MERGE (order:Order {orderID: row.OrderID})
-                  ON CREATE SET order.shipName = row.ShipName;
-                                
-                // Create products
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
-                MERGE (product:Product {productID: row.ProductID})
-                  ON CREATE SET product.productName = row.ProductName, product.unitPrice = toFloat(row.UnitPrice);
-                                
-                // Create suppliers
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/suppliers.csv' AS row
-                MERGE (supplier:Supplier {supplierID: row.SupplierID})
-                  ON CREATE SET supplier.companyName = row.CompanyName;
-                                
-                                
-                // Create employees
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
-                MERGE (e:Employee {employeeID:row.EmployeeID})
-                  ON CREATE SET e.firstName = row.FirstName, e.lastName = row.LastName, e.title = row.Title;
-                                
-                                
-                // Create categories
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/categories.csv' AS row
-                MERGE (c:Category {categoryID: row.CategoryID})
-                  ON CREATE SET c.categoryName = row.CategoryName, c.description = row.Description;
-                                
-                                
-                // Create relationships between orders and products
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
-                MATCH (order:Order {orderID: row.OrderID})
-                MATCH (product:Product {productID: row.ProductID})
-                MERGE (order)-[op:CONTAINS]->(product)
-                ON CREATE SET op.unitPrice = toFloat(row.UnitPrice), op.quantity = toFloat(row.Quantity);
-                                
-                                
-                // Create relationships between orders and employees
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
-                MATCH (order:Order {orderID: row.OrderID})
-                MATCH (employee:Employee {employeeID: row.EmployeeID})
-                MERGE (employee)-[:SOLD]->(order);
-                                
-                                
-                // Create relationships between products and suppliers
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
-                MATCH (product:Product {productID: row.ProductID})
-                MATCH (supplier:Supplier {supplierID: row.SupplierID})
-                MERGE (supplier)-[:SUPPLIES]->(product);
-                                
-                // Create relationships between products and categories
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
-                MATCH (product:Product {productID: row.ProductID})
-                MATCH (category:Category {categoryID: row.CategoryID})
-                MERGE (product)-[:PART_OF]->(category);
-                                
-                                
-                // Create relationships between employees (reporting hierarchy)
-                LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
-                MATCH (employee:Employee {employeeID: row.EmployeeID})
-                MATCH (manager:Employee {employeeID: row.ReportsTo})
-                MERGE (employee)-[:REPORTS_TO]->(manager);
-                """;
-        try (Transaction tx = db.beginTx()) {
-            for (String query: splitSemicolonAndRemoveBlanks(northwindEntities)) {
-                tx.execute(query);
-            }
-            tx.commit();
-        }
-
-        String northwindSchema = """
-                CREATE INDEX product_id FOR (p:Product) ON (p.productID);
-                CREATE INDEX product_name FOR (p:Product) ON (p.productName);
-                CREATE INDEX supplier_id FOR (s:Supplier) ON (s.supplierID);
-                CREATE INDEX employee_id FOR (e:Employee) ON (e.employeeID);
-                CREATE INDEX category_id FOR (c:Category) ON (c.categoryID);
-                CREATE CONSTRAINT order_id FOR (o:Order) REQUIRE o.orderID IS UNIQUE;""";
-        try (Transaction tx = db.beginTx()) {
-            for (String query: splitSemicolonAndRemoveBlanks(northwindSchema)) {
-                tx.execute(query);
-            }
-            tx.commit();
-        }
     }
 
     @Before
@@ -166,7 +75,23 @@ public class PromptIT {
             tx.execute(rag);
             tx.commit();
         }
+        TestUtil.registerProcedure(db, Prompt.class, OpenAI.class, Meta.class, Strings.class, Coll.class);
+        
+        String northwindEntities = Util.readResourceFile("northwind_dataset.cypher");
+        try (Transaction tx = db.beginTx()) {
+            for (String query: splitSemicolonAndRemoveBlanks(northwindEntities)) {
+                tx.execute(query);
+            }
+            tx.commit();
+        }
 
+        String northwindSchema = Util.readResourceFile("northwind_schema.cypher");
+        try (Transaction tx = db.beginTx()) {
+            for (String query: splitSemicolonAndRemoveBlanks(northwindSchema)) {
+                tx.execute(query);
+            }
+            tx.commit();
+        }
     }
 
     @Test
@@ -179,16 +104,24 @@ public class PromptIT {
                         "retries", 2L,
                         "apiKey", OPENAI_KEY
                 ),
-                (r) -> {
-                    List<Map<String, Object>> list = r.stream().toList();
-                    Assertions.assertThat(list).hasSize(12);
-                    Assertions.assertThat(list.stream()
-                                    .map(m -> m.get("query"))
-                                    .filter(Objects::nonNull)
-                                    .map(Object::toString)
-                                    .map(String::trim))
-                            .isNotEmpty();
-                });
+                r -> testQueryAssertions(r, 12)
+        );
+    }
+
+    private void testQueryAssertions(Result r, Integer size) {
+        List<Map<String, Object>> list = r.stream().toList();
+        System.out.println("list = " + list);
+        if (size == null) {
+            Assertions.assertThat(list).isNotEmpty();
+        } else {
+            Assertions.assertThat(list).hasSize(size);
+        }
+        Assertions.assertThat(list.stream()
+                        .map(m -> m.get("query"))
+                        .filter(Objects::nonNull)
+                        .map(Object::toString)
+                        .map(String::trim))
+                .isNotEmpty();
     }
 
     @Test
@@ -234,102 +167,104 @@ public class PromptIT {
                         "apiKey", OPENAI_KEY
                 ),
                 (r) -> {
-                    List<Map<String, Object>> list = r.stream().toList();
-                    Assertions.assertThat(list).hasSize((int) numOfQueries);
-                    Assertions.assertThat(list.stream()
-                                    .map(m -> m.get("query"))
-                                    .filter(Objects::nonNull)
-                                    .map(Object::toString)
-                                    .filter(StringUtils::isNotEmpty))
-                            .hasSize((int) numOfQueries);
+                    testCypherAssertions((int) numOfQueries, r);
                 });
     }
 
-    /*
-    TODO:
-        the loadSchema(tx, conf) seems to produce wrong results SOMETIMES??:
-    
-        nodes:
-    :Movie {released: INTEGER, tagline: STRING, title: STRING}
-:Discipline {year: INTEGER, title: STRING}
-    relationships:
-    null
-    patterns:
-    
+    private void testCypherAssertions(int numOfQueries, Result r) {
+        List<Map<String, Object>> list = r.stream().toList();
+        System.out.println("list = " + list);
+        Assertions.assertThat(list).hasSize(numOfQueries);
+        Assertions.assertThat(list.stream()
+                        .map(m -> m.get("query"))
+                        .filter(Objects::nonNull)
+                        .map(Object::toString)
+                        .filter(StringUtils::isNotEmpty))
+                .hasSize(numOfQueries);
+    }
 
-     */
     @Test
-    public void testCypherWithSchemaExplanation() {
-//        Transaction transaction = db.beginTx();
+    public void testCypherWithSchemaExplanationAndQuestionAboutCrossSellingCount() {
 
-//        String s = loadSchema(transaction, Map.of());
-//
-        /* TODO - forse con questo...
-        db.executeTransactionally("CALL apoc.ml.fromCypher('MATCH p=(:Person)-[]->() RETURN p', {apiKey: $apiKey})",
-                Map.of("apiKey", OPENAI_KEY), Result::resultAsString);
-         */
-        
+        String question = "Which 5 employees had the highest cross-selling count of 'Chocolade' and another product?";
+        testCypherWithSchemaCommon(question, 5);
+    }
+
+    @Test
+    public void testCypherWithSchemaExplanationAndQuestionAboutEmployeeOrganization() {
+
+        String question = "How are Employees organized? Who reports to whom?";
+        testCypherWithSchemaCommon(question, null);
+    }
+
+    @Test
+    public void testCypherWithSchemaExplanationAndQuestionAboutEmployeeReport() {
+
+        String question = "Which Employees report to each other indirectly?";
+        testCypherWithSchemaCommon(question,  null);
+    }
+
+    @Test
+    public void testCypherWithSchemaExplanationAndQuestionAboutHierarchy() {
+
+        String question = "How many orders were made by each part of the hierarchy?\n";
+        testCypherWithSchemaCommon(question, null);
+    }
+
+    private void testCypherWithSchemaCommon(String question, Integer size) {
+        long numOfQueries = 4L;
         String schema = TestUtil.singleResultFirstColumn(db, "CALL apoc.ml.schema({apiKey: $apiKey})",
                 Map.of("apiKey", OPENAI_KEY));
-        System.out.println("schema = " + schema);
-        /*
-        "represents a network of movies, people, athletes, and disciplines. 
-        It resembles the entertainment industry, sports, and social networks. Nodes represent movies, people, athletes, and disciplines, with relationships capturing acting, writing, directing, producing, following, reviewing, and winning medals. This schema models connections similar to IMDb, sports events, and social media platforms."
-         */
-        
-        /*
-        mentre se passo lo schema:
-        "content": "The graph database schema consists of these elements\nnodes:\n```\n:Movie {title: STRING, tagline: STRING, released: INTEGER}\n:Person {born: INTEGER, name: STRING}\n:Discipline {year: INTEGER, title: STRING}\n:Athlete {name: STRING, country: STRING, irrelevant: STRING}\n```\n\nrelationships:\n```\n:ACTED_IN {roles: LIST}\n:DIRECTED {}\n:PRODUCED {}\n:WROTE {}\n:FOLLOWS {}\n:REVIEWED {summary: STRING, rating: INTEGER}\n:HAS_MEDAL {irrelevant2: STRING, medal: STRING}\n```\n\npatterns:\n```\n(:Person)-[:ACTED_IN]->(:Movie)\n(:Person)-[:WROTE]->(:Movie)\n(:Person)-[:DIRECTED]->(:Movie)\n(:Person)-[:PRODUCED]->(:Movie)\n(:Person)-[:FOLLOWS]->(:Person)\n(:Person)-[:REVIEWED]->(:Movie)\n(:Athlete)-[:HAS_MEDAL]->(:Discipline)\n```\n",
-         */
 
-        // todo - il risultato è troppo generico e forse fa vedere altre cose,
-        //      provare con la apoc.ml.cypher
+        String humanDescriptionSchema = "The human description of the schema is the following:" +
+                                        "```\n%s\n```"
+                                                .formatted(schema);
+
+        List<Map> additionalPrompts = List.of(
+                Map.of("role", "system", "content", humanDescriptionSchema)
+        );
         
-        // todo --> https://kindo.ai/blog/8-tips-tricks-for-better-results-from-your-ai-prompts
-        
-        // TODO - testare apoc.ml.cypher, apoc.ml.query,
-        //      fromQueries partendo da fromCypher?
-        //      
-//
-//        testResult(db, """
-//                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
-//                """,
-//                Map.of(
-//                        "query", "Which Employee had the highest cross-selling count of 'Chocolade' and another product?\n",
-//                        "numOfQueries", 2L,
-//                        "apiKey", OPENAI_KEY
-//                ),
-//                (r) -> {
-//                    System.out.println("r.resultAsString() = " + r.resultAsString());
-//                });
-//        
         testResult(db, """
-                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey, systemPrompts: $systemPrompts})
+                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
                 """,
                 Map.of(
-                        "query", "Which Employee had the highest cross-selling count of 'Chocolade' and another product?\n",
-                        "numOfQueries", 2L,
-                        "apiKey", OPENAI_KEY,
-                        "systemPrompts", List.of("The human description of the schema is the following:" +
-                                                 "```\n%s\n```"
-                                                         .formatted(schema)
-                        )
+                        "query", question,
+                        "numOfQueries", numOfQueries,
+                        "apiKey", OPENAI_KEY
                 ),
-                (r) -> {
-                    System.out.println("r.resultAsString() = " + r.resultAsString());
-                });
+                (r) -> testCypherAssertions((int) numOfQueries, r)
+        );
+        
+        testResult(db, "CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey, additionalPrompts: $additionalPrompts})",
+                Map.of(
+                        "query", question,
+                        "numOfQueries", numOfQueries,
+                        "apiKey", OPENAI_KEY,
+                        "additionalPrompts", additionalPrompts
+                ),
+                (r) -> testCypherAssertions((int) numOfQueries, r)
+        );
 
-        /*
-        list = {ImmutableCollections$ListN@14719}  size = 4
-         0 = {HashMap@14722}  size = 1
-          "query" -> "MATCH (e1:Employee)-[r1:SELLS]->(:Product {name: 'Chocolade'})\nMATCH (e1)-[r2:SELLS]->(:Product)\nWHERE r1 <> r2\nRETURN e1, COUNT(r2) AS crossSellingCount\nORDER BY crossSellingCount DESC\nLIMIT 1"
-         1 = {HashMap@14723}  size = 1
-          "query" -> "MATCH (e:Employee)-[:SELLS]->(p1:Product {name: 'Chocolade'})-[:CROSSES_SELLS]->(p2:Product)\nWITH e, p2, COUNT(p2) AS crossSellingCount\nRETURN e.name AS Employee, p2.name AS CrossSoldProduct, crossSellingCount\nORDER BY crossSellingCount DESC\nLIMIT 1"
-         2 = {HashMap@14724}  size = 1
-          "query" -> "MATCH (e:Employee)-[:SOLD]->(:Product {name: 'Chocolade'})-[:CROSS_SELLS]->(p:Product)\nWITH e, p, count(*) AS crossSellingCount\nWHERE crossSellingCount > 0\nRETURN e.name AS Employee, p.name AS CrossSellProduct, crossSellingCount\nORDER BY crossSellingCount DESC\nLIMIT 1"
-         3 = {HashMap@14725}  size = 1
-          "query" -> "MATCH (e:Employee)-[:SOLD]->(:Product {name: 'Chocolade'})-[:CROSS_SELLS]->(:Product)\nWITH e, count(*) AS crossSellingCount\nORDER BY crossSellingCount DESC\nRETURN e.name AS Employee, crossSellingCount\nLIMIT 1"
-         */
+        testResult(db, """
+                CALL apoc.ml.query($query, {apiKey: $apiKey, retries: $retries, retryWithError: true}) YIELD query
+                """,
+                Map.of(
+                        "query", question,
+                        "retries", 10L,
+                        "apiKey", OPENAI_KEY
+                ),
+                r -> testQueryAssertions(r, size)
+        );
+
+        testResult(db, "CALL apoc.ml.query($query, {apiKey: $apiKey, additionalPrompts: $additionalPrompts, retries: $retries, retryWithError: true}) YIELD query ",
+                Map.of(
+                        "query", question,
+                        "retries", 10L,
+                        "apiKey", OPENAI_KEY,
+                        "additionalPrompts", additionalPrompts
+                ),
+                r -> testQueryAssertions(r, size)
+        );
     }
 
     @Test

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -186,7 +186,8 @@ public class PromptIT {
     @Test
     public void testCypherWithSchemaExplanationAndQuestionAboutCrossSellingCount() {
 
-        String question = "Which 5 employees had the highest cross-selling count of 'Chocolade' and another product?";
+        String question = "Which 5 employees had sold the product 'Chocolade' and has the highest selling count of another product? " +
+                          "Please returns the employee identificator, the other product name and the count orders of another product";
         testCypherWithSchemaCommon(question, 5);
     }
 

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -11,6 +11,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Result;
@@ -56,29 +57,16 @@ public class PromptIT {
                 RETURN value
                 """;
 
-    @Rule
-    public DbmsRule db = new ImpermanentDbmsRule();
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
     public static void check() {
         Assume.assumeNotNull("No OPENAI_KEY environment configured", OPENAI_KEY);
-    }
 
-    @Before
-    public void setUp() {
         TestUtil.registerProcedure(db, Prompt.class, OpenAI.class, Meta.class, Strings.class, Coll.class);
-        String movies = Util.readResourceFile("movies.cypher");
-        try (Transaction tx = db.beginTx()) {
-            tx.execute(movies);
-            tx.commit();
-        }
         
-        String rag = Util.readResourceFile("rag.cypher");
-        try (Transaction tx = db.beginTx()) {
-            tx.execute(rag);
-            tx.commit();
-        }
-        
+
         // northwind db
         String northwindEntities = """
                 // Create orders
@@ -149,7 +137,7 @@ public class PromptIT {
             }
             tx.commit();
         }
-        
+
         String northwindSchema = """
                 CREATE INDEX product_id FOR (p:Product) ON (p.productID);
                 CREATE INDEX product_name FOR (p:Product) ON (p.productName);
@@ -163,6 +151,22 @@ public class PromptIT {
             }
             tx.commit();
         }
+    }
+
+    @Before
+    public void setUp() {
+        String movies = Util.readResourceFile("movies.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(movies);
+            tx.commit();
+        }
+        
+        String rag = Util.readResourceFile("rag.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(rag);
+            tx.commit();
+        }
+
     }
 
     @Test
@@ -260,16 +264,14 @@ public class PromptIT {
 
 //        String s = loadSchema(transaction, Map.of());
 //
-        long numOfQueries = 4L;
-
         /* TODO - forse con questo...
         db.executeTransactionally("CALL apoc.ml.fromCypher('MATCH p=(:Person)-[]->() RETURN p', {apiKey: $apiKey})",
                 Map.of("apiKey", OPENAI_KEY), Result::resultAsString);
          */
         
-//        String schema = db.executeTransactionally("CALL apoc.ml.schema({apiKey: $apiKey})",
-//                Map.of("apiKey", OPENAI_KEY), Result::resultAsString);
-//        System.out.println("schema = " + schema);
+        String schema = TestUtil.singleResultFirstColumn(db, "CALL apoc.ml.schema({apiKey: $apiKey})",
+                Map.of("apiKey", OPENAI_KEY));
+        System.out.println("schema = " + schema);
         /*
         "represents a network of movies, people, athletes, and disciplines. 
         It resembles the entertainment industry, sports, and social networks. Nodes represent movies, people, athletes, and disciplines, with relationships capturing acting, writing, directing, producing, following, reviewing, and winning medals. This schema models connections similar to IMDb, sports events, and social media platforms."
@@ -288,24 +290,33 @@ public class PromptIT {
         // TODO - testare apoc.ml.cypher, apoc.ml.query,
         //      fromQueries partendo da fromCypher?
         //      
-        
+//
+//        testResult(db, """
+//                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
+//                """,
+//                Map.of(
+//                        "query", "Which Employee had the highest cross-selling count of 'Chocolade' and another product?\n",
+//                        "numOfQueries", 2L,
+//                        "apiKey", OPENAI_KEY
+//                ),
+//                (r) -> {
+//                    System.out.println("r.resultAsString() = " + r.resultAsString());
+//                });
+//        
         testResult(db, """
-                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
+                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey, systemPrompts: $systemPrompts})
                 """,
                 Map.of(
                         "query", "Which Employee had the highest cross-selling count of 'Chocolade' and another product?\n",
-                        "numOfQueries", numOfQueries,
-                        "apiKey", OPENAI_KEY
+                        "numOfQueries", 2L,
+                        "apiKey", OPENAI_KEY,
+                        "systemPrompts", List.of("The human description of the schema is the following:" +
+                                                 "```\n%s\n```"
+                                                         .formatted(schema)
+                        )
                 ),
                 (r) -> {
-                    List<Map<String, Object>> list = r.stream().toList();
-                    Assertions.assertThat(list).hasSize((int) numOfQueries);
-                    Assertions.assertThat(list.stream()
-                                    .map(m -> m.get("query"))
-                                    .filter(Objects::nonNull)
-                                    .map(Object::toString)
-                                    .filter(StringUtils::isNotEmpty))
-                            .hasSize((int) numOfQueries);
+                    System.out.println("r.resultAsString() = " + r.resultAsString());
                 });
 
         /*

--- a/extended/src/test/resources/northwind_dataset.cypher
+++ b/extended/src/test/resources/northwind_dataset.cypher
@@ -1,0 +1,61 @@
+// Create orders
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+MERGE (order:Order {orderID: row.OrderID})
+  ON CREATE SET order.shipName = row.ShipName;
+
+// Create products
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+MERGE (product:Product {productID: row.ProductID})
+  ON CREATE SET product.productName = row.ProductName, product.unitPrice = toFloat(row.UnitPrice);
+
+// Create suppliers
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/suppliers.csv' AS row
+MERGE (supplier:Supplier {supplierID: row.SupplierID})
+  ON CREATE SET supplier.companyName = row.CompanyName;
+
+
+// Create employees
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
+MERGE (e:Employee {employeeID:row.EmployeeID})
+  ON CREATE SET e.firstName = row.FirstName, e.lastName = row.LastName, e.title = row.Title;
+
+
+// Create categories
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/categories.csv' AS row
+MERGE (c:Category {categoryID: row.CategoryID})
+  ON CREATE SET c.categoryName = row.CategoryName, c.description = row.Description;
+
+
+// Create relationships between orders and products
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+MATCH (order:Order {orderID: row.OrderID})
+MATCH (product:Product {productID: row.ProductID})
+MERGE (order)-[op:CONTAINS]->(product)
+  ON CREATE SET op.unitPrice = toFloat(row.UnitPrice), op.quantity = toFloat(row.Quantity);
+
+
+// Create relationships between orders and employees
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+MATCH (order:Order {orderID: row.OrderID})
+MATCH (employee:Employee {employeeID: row.EmployeeID})
+MERGE (employee)-[:SOLD]->(order);
+
+
+// Create relationships between products and suppliers
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+MATCH (product:Product {productID: row.ProductID})
+MATCH (supplier:Supplier {supplierID: row.SupplierID})
+MERGE (supplier)-[:SUPPLIES]->(product);
+
+// Create relationships between products and categories
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+MATCH (product:Product {productID: row.ProductID})
+MATCH (category:Category {categoryID: row.CategoryID})
+MERGE (product)-[:PART_OF]->(category);
+
+
+// Create relationships between employees (reporting hierarchy)
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
+MATCH (employee:Employee {employeeID: row.EmployeeID})
+MATCH (manager:Employee {employeeID: row.ReportsTo})
+MERGE (employee)-[:REPORTS_TO]->(manager);

--- a/extended/src/test/resources/northwind_schema.cypher
+++ b/extended/src/test/resources/northwind_schema.cypher
@@ -1,0 +1,6 @@
+CREATE INDEX product_id FOR (p:Product) ON (p.productID);
+CREATE INDEX product_name FOR (p:Product) ON (p.productName);
+CREATE INDEX supplier_id FOR (s:Supplier) ON (s.supplierID);
+CREATE INDEX employee_id FOR (e:Employee) ON (e.employeeID);
+CREATE INDEX category_id FOR (c:Category) ON (c.categoryID);
+CREATE CONSTRAINT order_id FOR (o:Order) REQUIRE o.orderID IS UNIQUE;


### PR DESCRIPTION
Fixes 4000

- Improved schema prompt to retrieve slightly better results
- Added `additionalPrompts` config which can accept list of maps with other request messages
 - we can use it together with apoc.ml.schema to improve the results
 - added examples with Northwind database: https://neo4j.com/docs/getting-started/appendix/tutorials/guide-import-relational-and-etl/