### PR TITLE
Fixes 4337: Improvements for apoc.agg.analytics

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/load-jdbc.adoc
@@ -538,8 +538,11 @@ In addition to the configurations of the `apoc.load.jdbc` procedure, the `apoc.j
 
 [cols="1m,2,1"]
 |===
-| tableName | the temporary table name | neo4j_tmp_table
-| provider | the SQL provider, to handle data type based on it, possible values are "POSTGRES", "MYSQL" and "DEFAULT"  | "DEFAULT"
+| name | description | default 
+| tableName | The temporary table name | neo4j_tmp_table
+| provider | The SQL provider, to handle data type based on it, possible values are "POSTGRES", "MYSQL" and "DEFAULT"  | "DEFAULT"
+| batchSize | The batch size with which to insert data into the SQL table | 200000
+| writeMode | 'CREATE' | If 'CREATE' it creates a new temporary table. If 'APPEND' reuse an existing table.
 |===
 
 

--- a/extended/src/main/java/apoc/load/Analytics.java
+++ b/extended/src/main/java/apoc/load/Analytics.java
@@ -3,6 +3,7 @@ package apoc.load;
 import apoc.Extended;
 import apoc.load.util.LoadJdbcConfig;
 import apoc.result.RowResult;
+import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
@@ -13,7 +14,6 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import java.sql.Connection;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,12 +24,27 @@ import static apoc.load.Jdbc.executeQuery;
 import static apoc.load.Jdbc.executeUpdate;
 import static apoc.load.util.JdbcUtil.getConnection;
 import static apoc.load.util.JdbcUtil.getUrlOrKey;
+import static apoc.util.ExtendedUtil.batchIterator;
 
 @Extended
 public class Analytics {
+
     public static final String PROVIDER_CONF_KEY = "provider";
     public static final String TABLE_NAME_CONF_KEY = "tableName";
+    public static final String BATCH_SIZE_CONF_KEY = "batchSize";
+    public static final String WRITE_MODE_CONF_KEY = "writeMode";
+    
+    public static final int BATCH_SIZE_DEFAULT = 200000;
     public static final String TABLE_NAME_DEFAULT_CONF_KEY = "neo4j_tmp_table";
+    
+    public static final String EMPTY_SQL_QUERY_ERROR = "The SQL query is empty";
+    public static final String EMPTY_NEO4J_QUERY_ERROR = "The Neo4j query is empty";
+    public static final String WRONG_BATCH_SIZE_ERR = "The batchSize value is invalid";
+
+    public enum WriteMode {
+        APPEND, CREATE
+    }
+    
 
     enum Provider {
         DEFAULT,
@@ -57,44 +72,56 @@ public class Analytics {
         AtomicReference<String> createTable = new AtomicReference<>();
         final Provider provider = Provider.valueOf((String) config.getOrDefault(PROVIDER_CONF_KEY, Provider.DEFAULT.name()));
         final String tableName = (String) config.getOrDefault(TABLE_NAME_CONF_KEY, TABLE_NAME_DEFAULT_CONF_KEY);
+        final int batchSize = Util.toInteger(config.getOrDefault(BATCH_SIZE_CONF_KEY, BATCH_SIZE_DEFAULT));
+        String writeModeString = (String) config.getOrDefault(WRITE_MODE_CONF_KEY, WriteMode.CREATE.toString());
+        WriteMode writeMode = WriteMode.valueOf(writeModeString.toUpperCase());
 
         AtomicReference<String> columns = new AtomicReference<>();
-        AtomicReference<String> queryInsert = new AtomicReference<>();
-        
-                db.executeTransactionally(neo4jQuery,
+        AtomicReference<List<String>> queriesInsert = new AtomicReference<>();
+
+        if (StringUtils.isBlank(neo4jQuery)) {
+            throw new RuntimeException(EMPTY_NEO4J_QUERY_ERROR);
+        }
+        if (StringUtils.isBlank(sqlQuery)) {
+            throw new RuntimeException(EMPTY_SQL_QUERY_ERROR);
+        }
+        if (batchSize < 1) {
+            throw new RuntimeException(WRONG_BATCH_SIZE_ERR);
+        }
+
+        boolean isCreate = writeMode.equals(WriteMode.CREATE);
+        db.executeTransactionally(neo4jQuery,
                 Map.of(),
                 result -> {
-                    List<String> sqlValuesForQueryInsert = new ArrayList<>();
-                    result.forEachRemaining(map -> {
-                        
-                        if (createTable.get() == null) {
+                    List<String> insertClause = batchIterator(result, batchSize, map -> {
+                        if (isCreate && createTable.get() == null) {
                             String tempTableClause = getTempTableClause(map, provider, tableName);
                             createTable.set(tempTableClause);
                         }
 
-                        // convert Neo4j row result to SQL row
                         final String row = getStreamSortedByKey(map)
-                              //  .map(e -> addFieldToTempTable(e, sqlTypesForTempTable, provider))
                                 .map(Map.Entry::getValue)
                                 .map(Analytics::formatSqlValue)
                                 .collect(Collectors.joining(","));
-                        
-                        // add SQL row for query insert
-                        sqlValuesForQueryInsert.add("(" + row + ")");
-                    });
-                    
-                    // add values to `INSERT INTO ...` clause
-                    String sqlValues = StringUtils.join(sqlValuesForQueryInsert, ",");
-                    String insertClause = String.format("INSERT INTO %s VALUES %s",
-                            tableName, sqlValues
-                    );
-                    queryInsert.set(insertClause);
-                    
+                        return "(" + row + ")";
+                    })
+                    .map(i -> {
+                        String sqlValues = String.join(",", i);
+                        return String.format("INSERT INTO %s VALUES %s",
+                                tableName, sqlValues
+                        );
+                    })
+                    .toList();
+
+                    queriesInsert.set(insertClause);
+
                     // columns to handle error msg
-                    String neo4jResultColumns = result.columns().stream()
-                            .sorted()
-                            .collect(Collectors.joining(","));
-                    columns.set(neo4jResultColumns);
+                    if (columns.get() == null) {
+                        String neo4jResultColumns = result.columns().stream()
+                                .sorted()
+                                .collect(Collectors.joining(","));
+                        columns.set(neo4jResultColumns);
+                    }
                     return null;
                 });
 
@@ -110,10 +137,15 @@ public class Analytics {
         Object[] paramsArray = params.toArray(new Object[params.size()]);
 
         // Step 1. Create temporary table
-        executeUpdate(urlOrKey, createTable.get(), config, connection, log, paramsArray);
+        if (isCreate) {
+            executeUpdate(urlOrKey, createTable.get(), config, connection, log, paramsArray);
+        }
+
 
         // Step 2. Insert data in temp table
-        executeUpdate(urlOrKey, queryInsert.get(), config, connection, log, paramsArray);
+        queriesInsert.get().forEach(
+                query -> executeUpdate(urlOrKey, query, config, connection, log, paramsArray)
+        );
         
         try {
             // Step 3. Return data from temp table

--- a/extended/src/main/java/apoc/load/util/JdbcUtil.java
+++ b/extended/src/main/java/apoc/load/util/JdbcUtil.java
@@ -18,7 +18,7 @@ import java.sql.SQLException;
 
 public class JdbcUtil {
 
-    private static final String KEY_NOT_FOUND_MESSAGE = "No apoc.jdbc.%s.url url specified";
+    public static final String KEY_NOT_FOUND_MESSAGE = "No apoc.jdbc.%s.url url specified";
     private static final String LOAD_TYPE = "jdbc";
 
     private JdbcUtil() {}

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -32,10 +32,12 @@ import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAccessor;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatProperties;
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatToString;
@@ -410,4 +412,22 @@ public class ExtendedUtil
         );
     }
 
+    public static <T, V> Stream<List<V>> batchIterator(Iterator<T> iterator, int batchSize, Function<T, V> consumer) {
+        return StreamSupport.stream(new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
+            @Override
+            public boolean tryAdvance(Consumer<? super List<V>> action) {
+                List<V> batch = new ArrayList<>(batchSize);
+                while (iterator.hasNext() && batch.size() < batchSize) {
+                    T next = iterator.next();
+                    V apply = consumer.apply(next);
+                    batch.add(apply);
+                }
+                if (batch.isEmpty()) {
+                    return false; // Stop the stream when no elements remain
+                }
+                action.accept(batch);
+                return true;
+            }
+        }, false);
+    }
 }

--- a/extended/src/test/java/apoc/load/DuckDBJdbcPerformanceTest.java
+++ b/extended/src/test/java/apoc/load/DuckDBJdbcPerformanceTest.java
@@ -1,0 +1,96 @@
+package apoc.load;
+
+import apoc.periodic.Periodic;
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.neo4j.graphdb.Result;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static apoc.ApocConfig.apocConfig;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testResult;
+
+/**
+ * Query times with 4 million nodes:
+ * - table creation: 25 ms
+ * - table population: 68438 ms
+ * - return data from table: 958 ms
+ * - TOTAL: 69421 ms
+ */
+@Ignore("This test check DuckDB analytics performances, we ignore it since it's slow and just log the times spent")
+public class DuckDBJdbcPerformanceTest extends AbstractJdbcTest {
+
+    public String JDBC_DUCKDB = null;
+    
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+    private Connection conn;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() throws Exception {
+        JDBC_DUCKDB = "jdbc:duckdb:" + temporaryFolder.newFolder() + "/testDB";
+        apocConfig().setProperty("apoc.jdbc.duckdb.url", JDBC_DUCKDB);
+        apocConfig().setProperty("apoc.jdbc.test.sql","SELECT * FROM PERSON");
+        apocConfig().setProperty("apoc.jdbc.testparams.sql","SELECT * FROM PERSON WHERE NAME = ?");
+        TestUtil.registerProcedure(db, Jdbc.class, Periodic.class, Analytics.class);
+        
+        conn = DriverManager.getConnection(JDBC_DUCKDB);
+
+        IntStream.range(0, 200)
+                .forEach(__-> db.executeTransactionally("UNWIND range(0, 19999) as id WITH id CREATE (:City {country: 'country' + id, name: 'name' + id, year: id * 2, population: id})"));
+
+        Map<String, Object> stringObjectMap = db.executeTransactionally("match (n) return count(n)", Map.of(), Result::next);
+        System.out.println("stringObjectMap = " + stringObjectMap);
+    }
+
+    @After
+    public void tearDown() throws SQLException {
+        conn.close();
+    }
+
+    @Test
+    public void testLoadJdbcAnalytics() {
+        String cypher = "MATCH (n:City) RETURN n.country AS country, n.name AS name, n.year AS year, n.population AS population";
+
+        String sql = """
+            SELECT
+                country,
+                name,
+                year,
+                population,
+                RANK() OVER (PARTITION BY country ORDER BY year DESC) AS rank
+            FROM %s
+            ORDER BY rank, country, name;
+            """
+            .formatted(Analytics.TABLE_NAME_DEFAULT_CONF_KEY);
+        
+        long startTime = System.currentTimeMillis();
+        testResult(db, "CALL apoc.jdbc.analytics($queryCypher, $url, $sql) YIELD row RETURN count(*)",
+                map(
+                        "queryCypher", cypher,
+                        "sql", sql,
+                        "url", JDBC_DUCKDB
+                ),
+                Result::resultAsString);
+        
+        long totalTime = System.currentTimeMillis() - startTime;
+        System.out.println("Total time: " + totalTime);
+    }
+
+}

--- a/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
+++ b/extended/src/test/java/apoc/load/DuckDBJdbcTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -30,12 +31,20 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static apoc.ApocConfig.apocConfig;
+import static apoc.load.Analytics.BATCH_SIZE_CONF_KEY;
+import static apoc.load.Analytics.EMPTY_NEO4J_QUERY_ERROR;
+import static apoc.load.Analytics.EMPTY_SQL_QUERY_ERROR;
+import static apoc.load.Analytics.TABLE_NAME_CONF_KEY;
+import static apoc.load.Analytics.WRITE_MODE_CONF_KEY;
+import static apoc.load.Analytics.WRONG_BATCH_SIZE_ERR;
+import static apoc.load.util.JdbcUtil.KEY_NOT_FOUND_MESSAGE;
 import static apoc.util.ExtendedTestUtil.assertFails;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class DuckDBJdbcTest extends AbstractJdbcTest {
@@ -71,6 +80,89 @@ public class DuckDBJdbcTest extends AbstractJdbcTest {
     @After
     public void tearDown() throws SQLException {
         conn.close();
+    }
+    
+    @Test
+    public void testLoadJdbcAnalyticsWithPivotOnAndAppendMode() throws SQLException {
+        String customTable = "table_append";
+        
+        Statement statement = conn.createStatement();
+        String createTableSql = String.format("CREATE TABLE %s (country VARCHAR, name VARCHAR, population INTEGER, year INTEGER)", customTable);
+        statement.execute(createTableSql);
+        String insertSql = String.format("INSERT INTO %s VALUES ('FG','Zapponeta',1005,2000), ('FG','Zapponeta',1065,2010)", customTable);
+        statement.execute(insertSql);
+        
+        String cypher = "MATCH (n:City) RETURN n.country AS country, n.name AS name, n.year AS year, n.population AS population";
+
+        String analyticsSql = String.format("""
+                PIVOT %s
+                ON year
+                USING sum(population)
+                ORDER by name
+                """, 
+                customTable);
+
+        testResult(db, "CALL apoc.jdbc.analytics($queryCypher, $url, $sql, [], $config)",
+                map(
+                        "queryCypher", cypher,
+                        "sql", analyticsSql,
+                        "url", JDBC_DUCKDB,
+                        "config", map(
+                                TABLE_NAME_CONF_KEY, customTable, 
+                                WRITE_MODE_CONF_KEY, Analytics.WriteMode.APPEND.toString()
+                        )
+                ),
+                r -> {
+                    String rowKey = "row";
+                    String nameKey = "name";
+                    String countryKey = "country";
+
+                    pivotOnAssertions(r, rowKey, nameKey, countryKey);
+                    Map<String, Object> row = r.next();
+                    var result = (Map) row.get(rowKey);
+                    assertEquals("Zapponeta", result.get(nameKey));
+                    assertEquals("FG", result.get(countryKey));
+                    assertEquals("1005", result.get("2000"));
+                    assertEquals("1065", result.get("2010"));
+                    assertNull(result.get("2020"));
+                    
+                    assertFalse(r.hasNext());
+                });
+
+        String dropSql = String.format("DROP TABLE %s", customTable);
+        statement.execute(dropSql);
+    }
+    
+    @Test
+    public void testLoadJdbcAnalyticsWithWrongBatchSize() {
+        assertFails(db, "CALL apoc.jdbc.analytics('match (n) return n', $url, 'SELECT country FROM tableName', [], $conf)",
+                map("url", JDBC_DUCKDB, "conf", map(BATCH_SIZE_CONF_KEY, -7)),
+                WRONG_BATCH_SIZE_ERR
+        );
+    }
+    
+    @Test
+    public void testLoadJdbcAnalyticsWithEmptySQL() {
+        assertFails(db, "CALL apoc.jdbc.analytics('match (n) return n', $url, '')", 
+                map("url", JDBC_DUCKDB),
+                EMPTY_SQL_QUERY_ERROR
+        );
+    }
+    
+    @Test
+    public void testLoadJdbcAnalyticsWithEmptyCypher() {
+        assertFails(db, "CALL apoc.jdbc.analytics('', $url, 'SELECT country FROM tableName')",
+                map("url", JDBC_DUCKDB),
+                EMPTY_NEO4J_QUERY_ERROR
+        );
+    }
+    
+    @Test
+    public void testLoadJdbcAnalyticsWithEmptyUrl() {
+        assertFails(db, "CALL apoc.jdbc.analytics('match (n) return n', '', 'SELECT country FROM tableName')",
+                map(),
+                String.format(KEY_NOT_FOUND_MESSAGE, "")
+        );
     }
 
     @Test
@@ -243,39 +335,43 @@ public class DuckDBJdbcTest extends AbstractJdbcTest {
                         "queryCypher", cypher,
                         "sql", sql,
                         "url", JDBC_DUCKDB,
-                        "config", map(Analytics.TABLE_NAME_CONF_KEY, customTable)
+                        "config", map(TABLE_NAME_CONF_KEY, customTable)
                 ),
                 r -> {
-                    Map<String, Object> row = r.next();
+                    
                     String rowKey = "row";
                     String nameKey = "name";
                     String countryKey = "country";
-
-                    var result = (Map) row.get(rowKey);
-                    assertEquals("Amsterdam", result.get(nameKey));
-                    assertEquals("NL", result.get(countryKey));
-                    assertEquals("1005", result.get("2000"));
-                    assertEquals("1065", result.get("2010"));
-                    assertEquals("1158", result.get("2020"));
-
-                    row = r.next();
-                    result = (Map) row.get(rowKey);
-                    assertEquals("New York City", result.get(nameKey));
-                    assertEquals("US", result.get(countryKey));
-                    assertEquals("8015", result.get("2000"));
-                    assertEquals("8175", result.get("2010"));
-                    assertEquals("8772", result.get("2020"));
-
-                    row = r.next();
-                    result = (Map) row.get(rowKey);
-                    assertEquals("Seattle", result.get(nameKey));
-                    assertEquals("US", result.get(countryKey));
-                    assertEquals("564", result.get("2000"));
-                    assertEquals("608", result.get("2010"));
-                    assertEquals("738", result.get("2020"));
+                    pivotOnAssertions(r, rowKey, nameKey, countryKey);
 
                     assertFalse(r.hasNext());
                 });
+    }
+
+    private static void pivotOnAssertions(Result r, String rowKey, String nameKey, String countryKey) {
+        Map<String, Object> row = r.next();
+        var result = (Map) row.get(rowKey);
+        assertEquals("Amsterdam", result.get(nameKey));
+        assertEquals("NL", result.get(countryKey));
+        assertEquals("1005", result.get("2000"));
+        assertEquals("1065", result.get("2010"));
+        assertEquals("1158", result.get("2020"));
+
+        row = r.next();
+        result = (Map) row.get(rowKey);
+        assertEquals("New York City", result.get(nameKey));
+        assertEquals("US", result.get(countryKey));
+        assertEquals("8015", result.get("2000"));
+        assertEquals("8175", result.get("2010"));
+        assertEquals("8772", result.get("2020"));
+
+        row = r.next();
+        result = (Map) row.get(rowKey);
+        assertEquals("Seattle", result.get(nameKey));
+        assertEquals("US", result.get(countryKey));
+        assertEquals("564", result.get("2000"));
+        assertEquals("608", result.get("2010"));
+        assertEquals("738", result.get("2020"));
     }
 
     @Test


### PR DESCRIPTION
TODO - cleanup and add docs with performance result when the other one is merged

Fixes 4337

- Added performance test with 4 million nodes (I think is better than download csv/7z dump from an url, since the url could be invalid in the future and downloading it locally requires a lot of disk space)
- Added batching mechanism. Without batchSize the insert table time is 91 vs the 68 seconds with batchSize.
- writeMode CREATE
- added neo4jQuery, sqlQuery and batchSize validations