### PR TITLE
[DRAFT] Issue #614: automatic substructure dense nodes

### DIFF
--- a/extended/src/main/java/apoc/graph/GraphsExtended.java
+++ b/extended/src/main/java/apoc/graph/GraphsExtended.java
@@ -2,30 +2,94 @@ package apoc.graph;
 
 import apoc.Extended;
 import apoc.result.GraphResult;
+import apoc.result.NodeResult;
 import apoc.result.VirtualNode;
 import apoc.result.VirtualRelationship;
+import apoc.util.Util;
 import apoc.util.collection.Iterables;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.procedure.Description;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.Procedure;
-import org.neo4j.procedure.UserAggregationFunction;
-import org.neo4j.procedure.UserAggregationResult;
-import org.neo4j.procedure.UserAggregationUpdate;
+import org.neo4j.graphdb.*;
+import org.neo4j.procedure.*;
+import org.neo4j.storageengine.api.RelationshipDirection;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 @Extended
 public class GraphsExtended {
+
+    public static class HierarchicalRelationshipProcessor {
+        public static final int LEVEL_COUNTER = 10;
+        private final Iterator<Relationship> iterator;
+        private final Node node;
+        private final RelationshipType originalType;
+        private final Direction direction;
+        private final GraphDatabaseService db;
+        private int relationshipCounter = 0; // Counts total relationships processed
+
+        public HierarchicalRelationshipProcessor(Node node, RelationshipType type, Direction direction, GraphDatabaseService db) {
+            this.iterator = node.getRelationships(direction, type).iterator();
+            this.node = node;
+            this.originalType = type;
+            this.direction = direction;
+            this.db = db;
+        }
+
+        public void processAll() {
+            iterator.forEachRemaining(rel -> {
+                try (Transaction tx = db.beginTx()) {
+                    Node sourceNode = Util.rebind(tx, node);
+                    Node targetNode = rel.getOtherNode(sourceNode);
+                    relationshipCounter++;
+
+                    // Determine the level label dynamically
+                    String levelLabel = getLevelLabel(relationshipCounter);
+
+                    // Create an intermediate level node
+                    Node levelNode = tx.createNode(Label.label(levelLabel));
+                    levelNode.setProperty("createdAt", System.currentTimeMillis());
+
+                    // Copy properties from the old relationship
+                    for (String key : rel.getPropertyKeys()) {
+                        levelNode.setProperty(key, rel.getProperty(key)); // Store properties in LevelX node
+                    }
+
+                    // Create new relationships
+                    Relationship relAtoL = sourceNode.createRelationshipTo(levelNode, originalType);
+                    Relationship relLtoB = levelNode.createRelationshipTo(targetNode, RelationshipType.withName("INTERMEDIATE")); // (LevelX) --[:INTERMEDIATE]--> (B)
+
+                    // Remove old relationship
+                    rel.delete();
+
+                    tx.commit();
+                }
+            });
+        }
+
+        // Dynamically generate level labels based on relationship count
+        private static String getLevelLabel(int count) {
+            if (count <= LEVEL_COUNTER) return "Level1";
+            int level = (count - 1) / LEVEL_COUNTER + 1;
+            return "Level" + level;// + subIndex;
+        }
+    }
+
+    @Context
+    public GraphDatabaseService db;
+    
+    @Procedure(name = "apoc.graph.substructure", mode = Mode.WRITE)
+    @Description("TODO")
+    public Stream<NodeResult> substructure(@Name("node") Node node) {
+        // TODO - change this values, put in configs
+        RelationshipType type = RelationshipType.withName("test");
+        Direction direction = Direction.OUTGOING;
+        // -- change the above values
+
+        new HierarchicalRelationshipProcessor(node, type, direction, db).processAll();
+        
+        return Stream.of(new NodeResult(node));
+    }
 
     @Procedure("apoc.graph.filterProperties")
     @Description(

--- a/extended/src/main/java/apoc/graph/GraphsExtended.java
+++ b/extended/src/main/java/apoc/graph/GraphsExtended.java
@@ -9,12 +9,9 @@ import apoc.util.Util;
 import apoc.util.collection.Iterables;
 import org.neo4j.graphdb.*;
 import org.neo4j.procedure.*;
-import org.neo4j.storageengine.api.RelationshipDirection;
 
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 @Extended
 public class GraphsExtended {
@@ -23,15 +20,15 @@ public class GraphsExtended {
         public static final int LEVEL_COUNTER = 10;
         private final Iterator<Relationship> iterator;
         private final Node node;
-        private final RelationshipType originalType;
         private final Direction direction;
         private final GraphDatabaseService db;
         private int relationshipCounter = 0; // Counts total relationships processed
+        private Node levelNode = null; // Stores the current LevelX node
 
-        public HierarchicalRelationshipProcessor(Node node, RelationshipType type, Direction direction, GraphDatabaseService db) {
-            this.iterator = node.getRelationships(direction, type).iterator();
+        // TODO - customize RelationshipType type, if present getRelationships only for that specific one
+        public HierarchicalRelationshipProcessor(Node node, /*RelationshipType type, */Direction direction, GraphDatabaseService db) {
+            this.iterator = node.getRelationships(direction/*, type*/).iterator();
             this.node = node;
-            this.originalType = type;
             this.direction = direction;
             this.db = db;
         }
@@ -46,32 +43,38 @@ public class GraphsExtended {
                     // Determine the level label dynamically
                     String levelLabel = getLevelLabel(relationshipCounter);
 
-                    // Create an intermediate level node
-                    Node levelNode = tx.createNode(Label.label(levelLabel));
-                    levelNode.setProperty("createdAt", System.currentTimeMillis());
-
-                    // Copy properties from the old relationship
-                    for (String key : rel.getPropertyKeys()) {
-                        levelNode.setProperty(key, rel.getProperty(key)); // Store properties in LevelX node
+                    // If it's the first relationship in a batch of 10, create a new (source)-[:INTERMEDIATE]->(:LevelX) path
+                    if (relationshipCounter % 10 == 1) {
+                        levelNode = tx.createNode(Label.label(levelLabel));
+                        
+                        sourceNode.createRelationshipTo(levelNode, RelationshipType.withName("INTERMEDIATE"));
+                    } else {
+                        levelNode = Util.rebind(tx, levelNode);
                     }
 
-                    // Create new relationships
-                    Relationship relAtoL = sourceNode.createRelationshipTo(levelNode, originalType);
-                    Relationship relLtoB = levelNode.createRelationshipTo(targetNode, RelationshipType.withName("INTERMEDIATE")); // (LevelX) --[:INTERMEDIATE]--> (B)
+                    if (levelNode != null) {
+                        // Create new relationships from the original one
+                        Relationship relLtoB = levelNode.createRelationshipTo(targetNode, rel.getType());
 
-                    // Remove old relationship
-                    rel.delete();
-
+                        // Copy properties from the old relationship
+                        for (String key : rel.getPropertyKeys()) {
+                            relLtoB.setProperty(key, rel.getProperty(key));
+                        }
+                        
+                        // Remove old relationship
+                        rel.delete();
+                    }
                     tx.commit();
                 }
             });
         }
 
         // Dynamically generate level labels based on relationship count
+        // i.e. "Level1", "Level2", "Level3", ...
         private static String getLevelLabel(int count) {
             if (count <= LEVEL_COUNTER) return "Level1";
             int level = (count - 1) / LEVEL_COUNTER + 1;
-            return "Level" + level;// + subIndex;
+            return "Level" + level;
         }
     }
 
@@ -82,11 +85,11 @@ public class GraphsExtended {
     @Description("TODO")
     public Stream<NodeResult> substructure(@Name("node") Node node) {
         // TODO - change this values, put in configs
-        RelationshipType type = RelationshipType.withName("test");
+        RelationshipType type = RelationshipType.withName("TEST");
         Direction direction = Direction.OUTGOING;
         // -- change the above values
 
-        new HierarchicalRelationshipProcessor(node, type, direction, db).processAll();
+        new HierarchicalRelationshipProcessor(node, /*type, */direction, db).processAll();
         
         return Stream.of(new NodeResult(node));
     }

--- a/extended/src/test/java/apoc/graph/GraphsExtendedTest.java
+++ b/extended/src/test/java/apoc/graph/GraphsExtendedTest.java
@@ -245,7 +245,7 @@ public class GraphsExtendedTest {
             IntStream.range(0, 100).boxed()
                     .forEach(i -> {
                         Node bar = tx.createNode(Label.label("Bar"));
-                        foo.createRelationshipTo(bar, RelationshipType.withName("test"));
+                        foo.createRelationshipTo(bar, RelationshipType.withName("TEST"));
                     });
             
             tx.commit();
@@ -256,10 +256,33 @@ public class GraphsExtendedTest {
                     Node node = (Node) r.get("node");
                     String collect = node.getRelationships(Direction.OUTGOING).stream().map(i -> {
                         Node endNode = i.getEndNode();
-                        return endNode.getLabels() + ", " + Iterables.single(endNode.getRelationships(Direction.OUTGOING)).getEndNode().getLabels();
+                        String collected = Iterables.stream(endNode.getRelationships(Direction.OUTGOING)).map(rel -> rel.getEndNode().toString()).collect(Collectors.joining(", "));
+                        return "intermediate label: " + endNode.getLabels() + "\n with nodes: " + collected;
                     }).collect(Collectors.joining("\n"));
 
-                    System.out.println("nodes: \n" + collect);
+                    System.out.println(collect);
+                    /* The print result is:
+                        intermediate label: [Level1]
+                         with nodes: Node[55], Node[49], Node[64], Node[73], Node[54], Node[82], Node[87], Node[88], Node[109], Node[89]
+                        intermediate label: [Level10]
+                         with nodes: Node[111], Node[48], Node[51], Node[85], Node[43], Node[103], Node[63], Node[46], Node[53], Node[92]
+                        intermediate label: [Level9]
+                         with nodes: Node[67], Node[45], Node[59], Node[75], Node[52], Node[96], Node[99], Node[91], Node[90], Node[80]
+                        intermediate label: [Level8]
+                         with nodes: Node[50], Node[60], Node[42], Node[44], Node[86], Node[100], Node[47], Node[83], Node[95], Node[35]
+                        intermediate label: [Level7]
+                         with nodes: Node[34], Node[33], Node[32], Node[31], Node[30], Node[29], Node[28], Node[27], Node[26], Node[25]
+                        intermediate label: [Level6]
+                         with nodes: Node[24], Node[23], Node[22], Node[21], Node[20], Node[19], Node[18], Node[17], Node[16], Node[15]
+                        intermediate label: [Level5]
+                         with nodes: Node[79], Node[70], Node[40], Node[65], Node[36], Node[71], Node[57], Node[81], Node[113], Node[37]
+                        intermediate label: [Level4]
+                         with nodes: Node[76], Node[84], Node[101], Node[66], Node[93], Node[110], Node[106], Node[112], Node[68], Node[72]
+                        intermediate label: [Level3]
+                         with nodes: Node[78], Node[74], Node[61], Node[39], Node[107], Node[58], Node[97], Node[94], Node[108], Node[114]
+                        intermediate label: [Level2]
+                         with nodes: Node[41], Node[98], Node[38], Node[62], Node[104], Node[102], Node[105], Node[56], Node[69], Node[77]
+                     */
                 });
     }
 

--- a/extended/src/test/java/apoc/graph/GraphsExtendedTest.java
+++ b/extended/src/test/java/apoc/graph/GraphsExtendedTest.java
@@ -3,14 +3,11 @@ package apoc.graph;
 import apoc.create.Create;
 import apoc.map.Maps;
 import apoc.util.TestUtil;
+import apoc.util.collection.Iterables;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.*;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -20,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static apoc.util.TestUtil.*;
 import static apoc.util.Util.map;
@@ -237,6 +235,32 @@ public class GraphsExtendedTest {
                 WITH apoc.graph.filterProperties(path) as graph
                 RETURN graph.nodes AS nodes, graph.relationships AS relationships""",
                 this::assertEmptyFilter);
+    }
+
+    @Test
+    public void testSubstructure() {
+        try (Transaction tx = db.beginTx()) {
+            Node foo = tx.createNode(Label.label("SubstructureNode"));
+
+            IntStream.range(0, 100).boxed()
+                    .forEach(i -> {
+                        Node bar = tx.createNode(Label.label("Bar"));
+                        foo.createRelationshipTo(bar, RelationshipType.withName("test"));
+                    });
+            
+            tx.commit();
+        }
+        
+        testCall(db, "MATCH (n:SubstructureNode) WITH n CALL apoc.graph.substructure(n) YIELD node RETURN node",
+                r -> {
+                    Node node = (Node) r.get("node");
+                    String collect = node.getRelationships(Direction.OUTGOING).stream().map(i -> {
+                        Node endNode = i.getEndNode();
+                        return endNode.getLabels() + ", " + Iterables.single(endNode.getRelationships(Direction.OUTGOING)).getEndNode().getLabels();
+                    }).collect(Collectors.joining("\n"));
+
+                    System.out.println("nodes: \n" + collect);
+                });
     }
 
     private void assertEmptyFilter(Map<String, Object> r) {


### PR DESCRIPTION
IDEA FOR #614:

- create something similar to apoc.trigger which check if there are nodes with millions of rels
  - we could filter for relationship types, minimum number of rels, ...
- in case are present, doing something like `HierarchicalRelationshipProcessor`
  - we could customize the `LEVEL_COUNTER`, which is 10
  - rel type name `INTERMEDIATE` configurable
  - direction outgoing/incoming/both configurable


The `HierarchicalRelationshipProcessor` transforms a super node from this:
<img width="1601" alt="Screenshot 2025-03-17 at 14 53 59" src="https://github.com/user-attachments/assets/fddcf7ce-3fc7-4025-b18a-55162acb8697" />


to this:
<img width="1601" alt="Screenshot 2025-03-17 at 14 53 33" src="https://github.com/user-attachments/assets/384aa50f-dbb1-4f4e-8f78-f671d2878447" />

